### PR TITLE
NMSW-10 Add GDS Footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import Footer from './layout/Footer';
 import Header from './layout/Header';
 
 const App = () => {
@@ -15,6 +16,7 @@ const App = () => {
           <span>and a span where we forget to add the class, but should default to GDS font</span>
         </main>
       </div>
+      <Footer />
     </>
   );
 };

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -5,6 +5,11 @@ body {
   font-family: "GDS Transport",arial,sans-serif;
   font-weight: 400;
   margin: 0px; // reset margin to 0 as it was setting to the browser user-agent px size
+  background-color: govuk-colour("light-grey"); // set body to footer colour (light grey) so that if a page is very short we don't get white background under the footer
+}
+
+#root {
+  background: govuk-colour("white"); // set root div to content colour (white) as a default
 }
 
 /* Add small space between crown and text in logo in header */

--- a/src/layout/Footer.jsx
+++ b/src/layout/Footer.jsx
@@ -1,0 +1,36 @@
+const Footer = () => {
+  return (
+    <footer className="govuk-footer " role="contentinfo">
+      <div className="govuk-width-container ">
+        <div className="govuk-footer__meta">
+          <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            {/* HTML structure for when we add in the links
+            <h2 className="govuk-visually-hidden">Support links</h2>
+            <ul className="govuk-footer__inline-list">
+              <li className="govuk-footer__inline-list-item">
+                <a className="govuk-footer__link" href="#1">
+                  Item 1
+                </a>
+              </li>
+              <li className="govuk-footer__inline-list-item">
+                <a className="govuk-footer__link" href="#2">
+                  Item 2
+                </a>
+              </li>
+              <li className="govuk-footer__inline-list-item">
+                <a className="govuk-footer__link" href="#3">
+                  Item 3
+                </a>
+              </li>
+            </ul> */}
+          </div>
+          <div className="govuk-footer__meta-item">
+            <a className="govuk-footer__link govuk-footer__copyright-logo" href="/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/layout/__tests__/Footer.test.jsx
+++ b/src/layout/__tests__/Footer.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Footer from '../Footer';
+
+describe('Footer tests', () => {
+
+  it('should render the footer with Crown Copyright text', async () => {
+    await waitFor(() => { render(<Footer />); });
+    expect(screen.getByText('© Crown copyright')).toBeInTheDocument();
+  });
+
+  it('should render the Crown Copyright element with the class that contains the image', async () => {
+    await waitFor(() => { render(<Footer />); });
+    const checkCrownCopyrightLogo = screen.getByText('© Crown copyright');
+    expect(checkCrownCopyrightLogo).toBeInTheDocument();
+    expect(checkCrownCopyrightLogo.outerHTML).toEqual('<a class="govuk-footer__link govuk-footer__copyright-logo" href="/">© Crown copyright</a>');
+  });
+
+});


### PR DESCRIPTION
# Ticket

NMSW-10

----

## AC

GIVEN The product site is up
WHEN I go to /
THEN I am shown the landing page for the product 
AND I can see the GDS styled footer

----

## To test

- run app locally
- go to localhost:3000
- > you should see the GDS footer with the Crown copyright logo
_the Crown copyright logo will not link to anywhere_

----

## Notes

The logo element will fail axe checks for colour contrast. It's a known situation https://github.com/alphagov/govuk-frontend/issues/2134

- add GDS footer
- comment out code for footer links as we don't need them now but will need them soon
- add background colour to body that matches footer background colour so if a page is shorter than the window it fills with the footer colour and not the content colour
- add background colour to root element (main div ID within body) that matches content background colour so that any page level components without a background colour specified will have that background, and anything specified (e.g header, footer) will use their specified colour
- added test for the text
- added test for the logo class name which will display the logo
