### PR TITLE
NMSW-22 Create cookie banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
+import CookieBanner from './layout/CookieBanner';
 import Header from './layout/Header';
 
 const App = () => {
   return (
     <>
+      <CookieBanner />
       <Header />
       <div className="govuk-width-container">
         <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="content" role="main">

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -1,0 +1,24 @@
+import { SERVICE_NAME } from '../constants/AppConstants';
+
+const CookieBanner = () => {
+
+  return (
+    <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label={`Cookies on ${SERVICE_NAME}`}>
+      <div className="govuk-cookie-banner__message govuk-width-container">
+
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h2 className="govuk-cookie-banner__heading govuk-heading-m">{`Cookies on ${SERVICE_NAME}`}</h2>
+
+            <div className="govuk-cookie-banner__content">
+              <p className="govuk-body">We use some essential cookies to make this service work.</p>
+              <p className="govuk-body">We&apos;d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/layout/__tests__/CookieBanner.test.jsx
+++ b/src/layout/__tests__/CookieBanner.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import CookieBanner from '../CookieBanner';
+
+describe('CookieBanner tests', () => {
+
+  it('should render the CookieBanner with cookie text', async () => {
+    await waitFor(() => { render(<CookieBanner />); });
+    expect(screen.getByText('Cookies on National Maritime Single Window')).toBeInTheDocument();
+    expect(screen.getByText('We use some essential cookies to make this service work.')).toBeInTheDocument();
+    expect(screen.getByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Ticket

NMSW-22

----

## AC

GIVEN I am visiting the site
WHEN I have no stored cookie consent information
THEN I am shown the GDS cookie banner 

----

## To test
- run app locally
- go to localhost:3000
- > you should see a banner at the top of the page with a h2 of 'Cookies on National Maritime Single Window'
- >and a paragraph of'We use some essential cookies to make this service work.'
 
- and a second paragraph of
- >'We'd like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.'
- there will be no buttons or links on this version
- there is no way to turn off the banner yet


----

## Notes
