### PR TITLE
NMSW-9 Add GDS Phase Banner component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import CookieBanner from './layout/CookieBanner';
 import Footer from './layout/Footer';
 import Header from './layout/Header';
+import PhaseBanner from './layout/PhaseBanner';
 
 const App = () => {
   return (
@@ -8,6 +9,7 @@ const App = () => {
       <CookieBanner />
       <Header />
       <div className="govuk-width-container">
+        <PhaseBanner />
         <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="content" role="main">
           <h1 className="govuk-heading-l">Basic setup</h1>
           <p className="govuk-body">With a test paragraph so we can prove GovUK frontend style are working</p>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,16 +1,24 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { SERVICE_NAME } from './constants/AppConstants.js';
 import App from './App.jsx';
-import Header from './layout/Header';
 
 describe('App tests', () => {
 
   // adding this test here on the assumption we form the page container in App, 
-  // if we move that to another file then should move this render heading test too
+  // if we move that to another file then should move this render heading, phase banner and footer tests too
   it('should render the heading on the page', async () => {
-    await waitFor(() => { render(<Header />); });
+    await waitFor(() => { render(<App />); });
     expect(screen.getByText('GOV.UK')).toBeInTheDocument();
     expect(screen.getByText(SERVICE_NAME)).toBeInTheDocument();
+  });
+
+  it('should render the phase banner on the page', async () => {
+    await waitFor(() => { render(<App />); });
+    const checkPhaseBannerText = screen.getByTestId('phaseBannerText');
+    const checkPhaseBannerLink = screen.getByText('feedback');
+    expect(checkPhaseBannerText).toHaveTextContent('This is a new service - your ');
+    expect(checkPhaseBannerLink).toBeInTheDocument();
+    expect(checkPhaseBannerText).toHaveTextContent(' will help us to improve it.');
   });
 
   it('should render the page with a h1', async () => {
@@ -18,5 +26,12 @@ describe('App tests', () => {
     const checkHeading = screen.getByText('Basic setup');
     expect(checkHeading).toBeInTheDocument();
     expect(checkHeading.outerHTML).toEqual('<h1 class="govuk-heading-l">Basic setup</h1>');
+  });
+
+  it('should render the footer on the page', async () => {
+    await waitFor(() => { render(<App />); });
+    const checkCrownCopyrightLogo = screen.getByText('© Crown copyright');
+    expect(checkCrownCopyrightLogo).toBeInTheDocument();
+    expect(checkCrownCopyrightLogo.outerHTML).toEqual('<a class="govuk-footer__link govuk-footer__copyright-logo" href="/">© Crown copyright</a>');
   });
 });

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -1,2 +1,3 @@
 // Site
+export const FEEDBACK_URL = '/';
 export const SERVICE_NAME = 'National Maritime Single Window';

--- a/src/layout/PhaseBanner.jsx
+++ b/src/layout/PhaseBanner.jsx
@@ -1,0 +1,18 @@
+import { FEEDBACK_URL } from '../constants/AppConstants';
+
+const PhaseBanner = () => {
+  return (
+    <div role="region" className="govuk-phase-banner">
+      <p className="govuk-phase-banner__content">
+        <strong className="govuk-tag govuk-phase-banner__content__tag">
+          beta
+        </strong>
+        <span className="govuk-phase-banner__text" data-testid="phaseBannerText">
+          This is a new service - your <a className="govuk-link" href={FEEDBACK_URL}>feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+  );
+};
+
+export default PhaseBanner;

--- a/src/layout/__tests__/PhaseBanner.test.jsx
+++ b/src/layout/__tests__/PhaseBanner.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { FEEDBACK_URL } from '../../constants/AppConstants';
+import PhaseBanner from '../PhaseBanner';
+
+describe('Phase Banner tests', () => {
+
+  it('should render the PhaseBanner with the feedback sentence', async () => {
+    await waitFor(() => { render(<PhaseBanner />); });
+    const checkPhaseBannerText = screen.getByTestId('phaseBannerText');
+    const checkPhaseBannerLink = screen.getByText('feedback');
+    expect(checkPhaseBannerText).toHaveTextContent('This is a new service - your ');
+    expect(checkPhaseBannerLink).toBeInTheDocument();
+    expect(checkPhaseBannerText).toHaveTextContent(' will help us to improve it.');
+  });
+
+  it('should create the feedback url based on the constant', async () => {
+    await waitFor(() => { render(<PhaseBanner />); });
+    const checkPhaseBannerLink = screen.getByText('feedback');
+    expect(checkPhaseBannerLink.outerHTML).toEqual(`<a class="govuk-link" href="${FEEDBACK_URL}">feedback</a>`);
+  });
+
+  it('should contain this feedback url', async () => {
+    await waitFor(() => { render(<PhaseBanner />); });
+    const checkPhaseBannerLink = screen.getByText('feedback');
+    expect(checkPhaseBannerLink.outerHTML).toEqual('<a class="govuk-link" href="/">feedback</a>');
+  });
+});


### PR DESCRIPTION
# Ticket

NMSW-9

----

## AC

GIVEN The product site is up
WHEN I go to /
THEN I can see the GDS Beta phase banner

----

## To test

- run app locally
- go to localhost:3000
- > you should see the beta phase banner

----

## Notes

We don't have a link for the feedback banner yet - see ticket NMSW-46

- added GDS Phase Banner component
- added a role so that it was contained within a landmark for accessibility
- updated App.jsx test to test for header, footer, phase banner
- added unit tests for PhaseBanner