### PR TITLE
NMSW-11 Add Landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,10 @@
+// Page Layout Components
 import CookieBanner from './layout/CookieBanner';
 import Footer from './layout/Footer';
 import Header from './layout/Header';
 import PhaseBanner from './layout/PhaseBanner';
+// Pages
+import Landing from './pages/LandingPage/Landing';
 
 const App = () => {
   return (
@@ -10,14 +13,12 @@ const App = () => {
       <Header />
       <div className="govuk-width-container">
         <PhaseBanner />
+        {/* Back links will go in here and be visible on every page by default
+        If we don't want that we will add logic on the back link component as to when 
+        it should not show; */}
         <main className="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="content" role="main">
-          <h1 className="govuk-heading-l">Basic setup</h1>
-          <p className="govuk-body">With a test paragraph so we can prove GovUK frontend style are working</p>
-          <button className="govuk-button" data-module="govuk-button">
-            And a test button
-          </button>
-          <br />
-          <span>and a span where we forget to add the class, but should default to GDS font</span>
+          {/* routing goes here, once in place replace Landing with route to landing */}
+          <Landing />
         </main>
       </div>
       <Footer />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -9,7 +9,7 @@ describe('App tests', () => {
   it('should render the heading on the page', async () => {
     await waitFor(() => { render(<App />); });
     expect(screen.getByText('GOV.UK')).toBeInTheDocument();
-    expect(screen.getByText(SERVICE_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId('serviceName').textContent).toEqual(SERVICE_NAME);
   });
 
   it('should render the phase banner on the page', async () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -21,13 +21,6 @@ describe('App tests', () => {
     expect(checkPhaseBannerText).toHaveTextContent(' will help us to improve it.');
   });
 
-  it('should render the page with a h1', async () => {
-    await waitFor(() => { render(<App />); });
-    const checkHeading = screen.getByText('Basic setup');
-    expect(checkHeading).toBeInTheDocument();
-    expect(checkHeading.outerHTML).toEqual('<h1 class="govuk-heading-l">Basic setup</h1>');
-  });
-
   it('should render the footer on the page', async () => {
     await waitFor(() => { render(<App />); });
     const checkCrownCopyrightLogo = screen.getByText('© Crown copyright');

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -18,7 +18,7 @@ const Header = () => {
           </a>
         </div>
         <div className="govuk-header__content">
-          <a href="/" className="govuk-header__link govuk-header__service-name">
+          <a href="/" className="govuk-header__link govuk-header__service-name" data-testid="serviceName">
             {SERVICE_NAME}
           </a>
         </div>

--- a/src/pages/LandingPage/Landing.jsx
+++ b/src/pages/LandingPage/Landing.jsx
@@ -1,0 +1,12 @@
+import { SERVICE_NAME } from '../../constants/AppConstants';
+
+const Landing = () => {
+  return (
+    <>
+      <h1 className="govuk-heading-l">{SERVICE_NAME}</h1>
+      <p className="govuk-body">Use this service to:</p>
+    </>
+  );
+};
+
+export default Landing;

--- a/src/pages/LandingPage/LandingPage.test.jsx
+++ b/src/pages/LandingPage/LandingPage.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SERVICE_NAME } from '../../constants/AppConstants';
+import Landing from './Landing';
+
+describe('Landing page tests', () => {
+
+  it('should render the page with the service name as a H1', async () => {
+    await waitFor(() => { render(<Landing />); });
+    expect(screen.getByText('National Maritime Single Window')).toBeInTheDocument();
+  });
+
+  it('should render the service name text from the constants file', async () => {
+    await waitFor(() => { render(<Landing />); });
+    expect(screen.getByText(SERVICE_NAME)).toBeInTheDocument();
+  });
+
+  it('should tell the user what the service is used for', async () => {
+    await waitFor(() => {render(<Landing />); });
+    expect(screen.getByText('Use this service to:')).toBeInTheDocument();
+  });
+
+});


### PR DESCRIPTION
# Ticket

NMSW-11

----

## AC

GIVEN The product site is up
WHEN I go to /
THEN I am shown the landing page for the product 
AND I can see a page with a h1

----

## To test

- run app locally
- go to localhost:3000
  - you should see a page header with the GOVUK logo & a product title of National Maritime Single Window
  - neither of these will have links
  - you should see the GDS beta phase banner
  - you should see the GDS footer with the crown copyright logo
  - there will be no links in the footer
  - you should see a H1 saying National Maritime Single Window
  - you should see paragraph text saying Use this service to:

----

## Notes

- NMSW-47 created for when we have content for this page
- added a data-testid to the service name in the header so we can target that in tests to ensure it's rendering correctly when the service name is also shown on the page in other text
- added Landing page page component
- removed most of the test content from App.jsx
- as we don't have routing, rendering Landing directly in App.jsx for now
