### PR TITLE
NMSW-13 Remove rogue comma

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
       "quotes": [ "error",  "single"],
       "semi": ["error", "always"],
       "no-console": ["warn"],
-      "comma-dangle": ["error", "always-multiline"],
       "eol-last": ["error", "always"]
   },
   "overrides": [

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,6 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
-    </BrowserRouter>,
-  </React.StrictMode>,
+    </BrowserRouter>
+  </React.StrictMode>
 );


### PR DESCRIPTION
# Ticket

NMSW-13

----

## FIX

Noticed an odd `,` on the page in the root element that shouldn't be there - removed it
Also identified it was resulting in aXe tools reporting that content on the page wasn't contained in a landmark

----

## To test

- run app locally
- go to localhost:3000
- scroll to the footer
- > there should be no white background below the footer
- > there should be no comma below the footer
- run aXe devtools
- > there should be no landmark issues

----

## Notes
