### PR TITLE
NMSW-23 Add accept/reject buttons to cookie banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,8 +3,26 @@ import CookieBanner from './layout/CookieBanner';
 import Footer from './layout/Footer';
 import Header from './layout/Header';
 import PhaseBanner from './layout/PhaseBanner';
+// utils
+import findCookiePreference from './utils/findCookiePreference';
 
 const App = () => {
+
+  const cookiePreference = findCookiePreference('cookiePreference');
+
+  // Pull this logic out into own function and call in useEffect here
+
+  useEffect(() => {
+    if (cookiePreference !== null && cookiePreference !== undefined) {
+      // setShowCookieBanner(false)
+      if (cookiePreference === true) {
+        console.log('APP', 'GA ON');
+      } else {
+        console.log('APP','GA OFF');
+      }
+    }
+  }, [cookiePreference]);
+
   return (
     <>
       <CookieBanner />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import AppRouter from './AppRouter';
 import CookieBanner from './layout/CookieBanner';
 import Footer from './layout/Footer';
@@ -10,7 +11,7 @@ import setAnalyticCookie from './utils/setAnalyticCookie';
 const App = () => {
 
   const cookiePreference = findCookiePreference('cookiePreference');
-  
+
   useEffect(() => {
     setAnalyticCookie(cookiePreference);
   }, []);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,23 +5,15 @@ import Header from './layout/Header';
 import PhaseBanner from './layout/PhaseBanner';
 // utils
 import findCookiePreference from './utils/findCookiePreference';
+import setAnalyticCookie from './utils/setAnalyticCookie';
 
 const App = () => {
 
   const cookiePreference = findCookiePreference('cookiePreference');
-
-  // Pull this logic out into own function and call in useEffect here
-
+  
   useEffect(() => {
-    if (cookiePreference !== null && cookiePreference !== undefined) {
-      // setShowCookieBanner(false)
-      if (cookiePreference === true) {
-        console.log('APP', 'GA ON');
-      } else {
-        console.log('APP','GA OFF');
-      }
-    }
-  }, [cookiePreference]);
+    setAnalyticCookie(cookiePreference);
+  }, []);
 
   return (
     <>

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -5,10 +5,10 @@ const CookieBanner = () => {
   const setAnalyticCookie = (type) => {
     if (type === 'accept') {
       document.cookie = 'cookiePreference=true';
-      //set GA cookie
+      console.log('GA ON');
     } else {
       document.cookie = 'cookiePreference=false';
-      // set GA cookie
+      console.log('GA OFF');
     }
   };
 

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -2,6 +2,16 @@ import { SERVICE_NAME } from '../constants/AppConstants';
 
 const CookieBanner = () => {
 
+  const setAnalyticCookie = (type) => {
+    if (type === 'accept') {
+      document.cookie = 'cookiePreference=true';
+      //set GA cookie
+    } else {
+      document.cookie = 'cookiePreference=false';
+      // set GA cookie
+    }
+  };
+
   return (
     <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label={`Cookies on ${SERVICE_NAME}`}>
       <div className="govuk-cookie-banner__message govuk-width-container">
@@ -15,6 +25,16 @@ const CookieBanner = () => {
               <p className="govuk-body">We&apos;d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
             </div>
           </div>
+        </div>
+
+        <div className="govuk-button-group">
+          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie('accept')}>
+            Accept analytics cookies
+          </button>
+          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie('reject')}>
+            Reject analytics cookies
+          </button>
+          {/* <a className="govuk-link" href="#">View cookies</a> */}
         </div>
       </div>
     </div>

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -1,16 +1,7 @@
 import { SERVICE_NAME } from '../constants/AppConstants';
+import setAnalyticCookie from '../utils/setAnalyticCookie';
 
 const CookieBanner = () => {
-
-  const setAnalyticCookie = (type) => {
-    if (type === 'accept') {
-      document.cookie = 'cookiePreference=true';
-      console.log('GA ON');
-    } else {
-      document.cookie = 'cookiePreference=false';
-      console.log('GA OFF');
-    }
-  };
 
   return (
     <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label={`Cookies on ${SERVICE_NAME}`}>
@@ -28,10 +19,10 @@ const CookieBanner = () => {
         </div>
 
         <div className="govuk-button-group">
-          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie('accept')}>
+          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie(undefined, 'accept')}>
             Accept analytics cookies
           </button>
-          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie('reject')}>
+          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie(undefined, 'reject')}>
             Reject analytics cookies
           </button>
           {/* <a className="govuk-link" href="#">View cookies</a> */}

--- a/src/layout/__tests__/CookieBanner.test.jsx
+++ b/src/layout/__tests__/CookieBanner.test.jsx
@@ -1,5 +1,19 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import CookieBanner from '../CookieBanner';
+
+// For when more than just the cookiePreference cookie exists 
+const extractPreferenceCookie = (cookieName) => {
+  const cookieArray = document.cookie.split(';');
+
+  for (let i = 0; i < cookieArray.length; i++) {
+    let cookiePair = cookieArray[i].split('=');
+    if (cookieName == cookiePair[0].trim()) {
+      return cookieArray[i];
+    }
+  }
+};
 
 describe('CookieBanner tests', () => {
 
@@ -8,5 +22,32 @@ describe('CookieBanner tests', () => {
     expect(screen.getByText('Cookies on National Maritime Single Window')).toBeInTheDocument();
     expect(screen.getByText('We use some essential cookies to make this service work.')).toBeInTheDocument();
     expect(screen.getByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).toBeInTheDocument();
+  });
+
+  it('should render an accept and a reject button', async () => {
+    await waitFor(() => { render(<CookieBanner />); });
+    const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
+    const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
+
+    expect(acceptButton).toBeInTheDocument();
+    expect(rejectButton).toBeInTheDocument();
+  });
+
+  it('should set cookiePreference to true when Accept analytics cookies is clicked', async () => {
+    const user = userEvent.setup();
+    await waitFor(() => { render(<CookieBanner />); });
+
+    const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
+    user.click(acceptButton);
+    await waitFor(() => { expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=true'); });
+  });
+
+  it('should set cookiePreference to false when Reject analytics cookies is clicked', async () => {
+    const user = userEvent.setup();
+    await waitFor(() => { render(<CookieBanner />); });
+
+    const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
+    user.click(rejectButton);
+    await waitFor(() => { expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=false'); });
   });
 });

--- a/src/utils/__tests__/findCookiePreference.test.jsx
+++ b/src/utils/__tests__/findCookiePreference.test.jsx
@@ -1,0 +1,23 @@
+import findCookiePreference from '../findCookiePreference';
+
+describe('find cookie preference', () => {
+  it('should return null if cookiePreference does not exist', () => {
+    const result = findCookiePreference('cookiePreference');
+
+    expect(result).toBe(null);
+  });
+
+  it('should return true if cookiePreference equals true', () => {
+    document.cookie = 'cookiePreference=true';
+
+    const result = findCookiePreference('cookiePreference');
+    expect(result).toBe(true);
+  });
+
+  it('should return false if cookiePreference equals false', () => {
+    document.cookie = 'cookiePreference=false';
+
+    const result = findCookiePreference('cookiePreference');
+    expect(result).toBe(false);
+  });
+});

--- a/src/utils/findCookiePreference.js
+++ b/src/utils/findCookiePreference.js
@@ -1,7 +1,6 @@
 const findCookiePreference = (cookieName) => {
   const cookieArray = document.cookie.split(';');
 
-
   for (let i = 0; i < cookieArray.length; i++) {
     let cookiePair = cookieArray[i].split('=');
     if (cookieName == cookiePair[0].trim()) {

--- a/src/utils/findCookiePreference.js
+++ b/src/utils/findCookiePreference.js
@@ -1,0 +1,18 @@
+const findCookiePreference = (cookieName) => {
+  const cookieArray = document.cookie.split(';');
+
+
+  for (let i = 0; i < cookieArray.length; i++) {
+    let cookiePair = cookieArray[i].split('=');
+    if (cookieName == cookiePair[0].trim()) {
+      if (cookiePair[1] === 'true') {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+  return null;
+};
+
+export default findCookiePreference;

--- a/src/utils/setAnalyticCookie.js
+++ b/src/utils/setAnalyticCookie.js
@@ -1,0 +1,13 @@
+const setAnalyticCookie = (cookiePreference, type) => {
+  if (cookiePreference === true || type === 'accept') {
+    document.cookie = 'cookiePreference=true';
+    console.log('GA ON');
+  } else if (cookiePreference === false || type === 'reject') {
+    document.cookie = 'cookiePreference=false';
+    console.log('GA OFF');
+  } else {
+    return;
+  }
+};
+
+export default setAnalyticCookie;


### PR DESCRIPTION
# Ticket

NMSW-23

----

## AC

GIVEN I can see the cookie banner
WHEN I click 'do not accept'
THEN an essential cookie is set to store my preference to 'do not track'

GIVEN I can see the cookie banner
WHEN I click 'Accept'
THEN an essential cookie is set to store my preference to 'track'

----

## To test

- run app locally
- go to localhost:3000
- you should see the cookie banner at the top of the page
- it should have an accept button
- open dev tools
- you should not see a cookie for cookie preference
- > NOTE: if you have clicked a button in the cookie panel there will be a cookie, delete it before continuing
- click the accept button
- open dev tools
- view the cookie section
- > you should see a cookie for cookie preferences set to true
- refresh the page
- > you should see a cookie with preference set to true
- click the decline button
- open dev tools
- view the cookie section
- > you should see a cookie for cookie preferences set to false

----

## Notes

- You may have to manually click the refresh button (above the cookiePreference cookie) on the cookie section to see the preference update in dev tools