### PR TITLE
NMSW-62 Add auto scroll to top on page change

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,7 +1,8 @@
-import { Routes, Route} from 'react-router-dom';
-import ProtectedRoutes from './utils/ProtectedRoutes';
-
+import { Routes, Route } from 'react-router-dom';
 import useUserIsPermitted from './hooks/useUserIsPermitted';
+import ProtectedRoutes from './utils/ProtectedRoutes';
+import ScrollToTop from './utils/scrollToTop';
+
 // URLs
 import {
   ACCESSIBILITY_URL,
@@ -22,22 +23,25 @@ import PrivacyNotice from './pages/Regulatory/PrivacyNotice';
 import SignIn from './pages/SignIn/SignIn';
 import SecondPage from './pages/TempPages/SecondPage';
 
+
 const AppRouter = () => {
   const isPermittedToView = useUserIsPermitted();
 
   return (
-    <Routes>
-      <Route path='/' element={<Landing />} />
-      <Route path={LANDING_URL} element={<Landing />} />
-      <Route path={SIGN_IN_URL} element={<SignIn />} />
-      <Route path={ACCESSIBILITY_URL} element={<AccessibilityStatement />} />
-      <Route path={COOKIE_URL} element={<CookiePolicy />} />
-      <Route path={PRIVACY_URL} element={<PrivacyNotice />} />
-      <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>
-        <Route path={DASHBOARD_URL} element={<Dashboard />} />
-        <Route path={SECOND_PAGE_URL} element={<SecondPage />} />
-      </Route> 
-    </Routes>
+    <ScrollToTop>
+      <Routes>
+        <Route path='/' element={<Landing />} />
+        <Route path={LANDING_URL} element={<Landing />} />
+        <Route path={SIGN_IN_URL} element={<SignIn />} />
+        <Route path={ACCESSIBILITY_URL} element={<AccessibilityStatement />} />
+        <Route path={COOKIE_URL} element={<CookiePolicy />} />
+        <Route path={PRIVACY_URL} element={<PrivacyNotice />} />
+        <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>
+          <Route path={DASHBOARD_URL} element={<Dashboard />} />
+          <Route path={SECOND_PAGE_URL} element={<SecondPage />} />
+        </Route>
+      </Routes>
+    </ScrollToTop>
   );
 };
 

--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import PropTypes from 'prop-types';
+
+const ScrollToTop = ({ children }) => {
+  const location = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    document.activeElement.blur(); // deselect the link so it doesn't remain in the focus state when page loads
+  }, [location.pathname]);
+
+  return <>{children}</>;
+};
+
+export default ScrollToTop;
+
+ScrollToTop.propTypes = {
+  children: PropTypes.node, // allows any renderable object
+};


### PR DESCRIPTION
# Ticket

NMSW-62

----

## AC

GIVEN I have clicked on an internal link
WHEN the new page component loads
THEN I should be able to see the top of the page

----

## To test

- go to any page
- shrink your browser so you have to scroll to get to the footer and cannot see the H1 when you do
- scroll to the footer
- click the 'cookies' link
- > the cookie page should load and scroll to the top of the page where you can see the H1

----

## Notes
