### PR TITLE
NMSW-25 Add a confirmation of cookie preference set banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ const App = () => {
 
   return (
     <>
-      <CookieBanner />
+      {cookiePreference === null && <CookieBanner />}
       <Header />
       <div className="govuk-width-container">
         <PhaseBanner />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -12,9 +12,7 @@ describe('App tests', () => {
 
   it('should render the phase banner on the page', async () => {
     render(<BrowserRouter><App /></BrowserRouter>);
-    expect(screen.getByTestId('phaseBannerText')).toHaveTextContent('This is a new service - your ');
-    expect(screen.getByText('feedback')).toBeInTheDocument();
-    expect(screen.getByTestId('phaseBannerText')).toHaveTextContent(' will help us to improve it.');
+    expect(screen.getByTestId('phaseBannerText')).toHaveTextContent('This is a new service - your feedback will help us to improve it.');
   });
 
   it('should render the footer on the page', async () => {
@@ -25,5 +23,34 @@ describe('App tests', () => {
     expect(screen.getByText('Cookies').outerHTML).toEqual('<a class="govuk-footer__link" href="/cookies">Cookies</a>');
     expect(screen.getByText('Accessibility')).toBeInTheDocument();
     expect(screen.getByText('Accessibility').outerHTML).toEqual('<a class="govuk-footer__link" href="/accessibility-statement">Accessibility</a>');
+    expect(screen.getByText('Privacy')).toBeInTheDocument();
+    expect(screen.getByText('Privacy').outerHTML).toEqual('<a class="govuk-footer__link" href="/privacy-notice">Privacy</a>');
+  });
+
+  it('should render cookie banner when there is no cookiePreference cookie', async () => {
+    render(<BrowserRouter><App /></BrowserRouter>);
+    const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
+    const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
+
+    expect(screen.getByText('We use some essential cookies to make this service work.')).toBeInTheDocument();
+    expect(screen.getByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).toBeInTheDocument();
+    expect(acceptButton).toBeInTheDocument();
+    expect(rejectButton).toBeInTheDocument();
+  });
+
+  it('should not render cookie banner when cookiePreference is true', async () => {
+    document.cookie = 'cookiePreference=true';
+    render(<BrowserRouter><App /></BrowserRouter>);
+
+    expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
+    expect(screen.queryByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).not.toBeInTheDocument();
+  });
+
+  it('should not render cookie banner when cookiePreference is false', async () => {
+    document.cookie = 'cookiePreference=false';
+    render(<BrowserRouter><App /></BrowserRouter>);
+
+    expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
+    expect(screen.queryByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).not.toBeInTheDocument();
   });
 });

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -48,7 +48,7 @@ const CookieBanner = () => {
             <div className="govuk-grid-column-two-thirds">
 
               <div className="govuk-cookie-banner__content">
-                <p className="govuk-body" data-testid="cookieMessage">{`You've ${isAnalyticsAcceptedOrRejected} additional cookies. You can `}
+                <p className="govuk-body" data-testid="cookieMessage">{`You've ${isAnalyticsAcceptedOrRejected} analytics cookies. You can `}
                   {/* No option to change cookies currently, this will be built later*/}
                   <Link className="govuk-link" to={COOKIE_URL}>change your cookie settings </Link>
                   at any time.

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -1,34 +1,70 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
 import { SERVICE_NAME } from '../constants/AppConstants';
+import { COOKIE_URL } from '../constants/AppUrlConstants';
 import setAnalyticCookie from '../utils/setAnalyticCookie';
 
 const CookieBanner = () => {
 
+  const [isAnalyticsButtonClicked, setIsAnalyticsButtonClicked] = useState(false);
+  const [hideCookieBanner, setHideCookieBanner] = useState(false);
+  const [isAnalyticsAcceptedOrRejected, setIsAnalyticsAcceptedOrRejected] = useState('');
+
+  if (hideCookieBanner) { return null; }
+
   return (
-    <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label={`Cookies on ${SERVICE_NAME}`}>
-      <div className="govuk-cookie-banner__message govuk-width-container">
+    <>
+      {!isAnalyticsButtonClicked && <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label={`Cookies on ${SERVICE_NAME}`}>
+        <div className="govuk-cookie-banner__message govuk-width-container">
 
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <h2 className="govuk-cookie-banner__heading govuk-heading-m">{`Cookies on ${SERVICE_NAME}`}</h2>
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              <h2 className="govuk-cookie-banner__heading govuk-heading-m">{`Cookies on ${SERVICE_NAME}`}</h2>
 
-            <div className="govuk-cookie-banner__content">
-              <p className="govuk-body">We use some essential cookies to make this service work.</p>
-              <p className="govuk-body">We&apos;d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+              <div className="govuk-cookie-banner__content">
+                <p className="govuk-body">We use some essential cookies to make this service work.</p>
+                <p className="govuk-body">We&apos;d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="govuk-button-group">
-          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie(true)}>
-            Accept analytics cookies
-          </button>
-          <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => setAnalyticCookie(false)}>
-            Reject analytics cookies
-          </button>
-          {/* <a className="govuk-link" href="#">View cookies</a> */}
+          <div className="govuk-button-group">
+            <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => { setAnalyticCookie(true); setIsAnalyticsButtonClicked(true); setIsAnalyticsAcceptedOrRejected('accepted'); }}>
+              Accept analytics cookies
+            </button>
+            <button type="button" className="govuk-button" data-module="govuk-button" onClick={() => { setAnalyticCookie(false); setIsAnalyticsButtonClicked(true); setIsAnalyticsAcceptedOrRejected('rejected'); }}>
+              Reject analytics cookies
+            </button>
+            {/* <a className="govuk-link" href="#">View cookies</a> */}
+          </div>
         </div>
-      </div>
-    </div>
+      </div>}
+
+      {isAnalyticsButtonClicked && <div className="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on [name of service]">
+        <div className="govuk-cookie-banner__message govuk-width-container">
+
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+
+              <div className="govuk-cookie-banner__content">
+                <p className="govuk-body" data-testid="cookieMessage">{`You've ${isAnalyticsAcceptedOrRejected} additional cookies. You can `}
+                  {/* No option to change cookies currently, this will be built later*/}
+                  <Link className="govuk-link" to={COOKIE_URL}>change your cookie settings </Link>
+                  at any time.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="govuk-button-group">
+            <button className="govuk-button" data-module="govuk-button" type="button" onClick={() => { setHideCookieBanner(true); }}>
+              Hide cookie message
+            </button>
+          </div>
+        </div>
+      </div>}
+    </>
   );
 };
 

--- a/src/layout/__tests__/CookieBanner.test.jsx
+++ b/src/layout/__tests__/CookieBanner.test.jsx
@@ -59,7 +59,7 @@ describe('CookieBanner tests', () => {
     const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
     await user.click(acceptButton);
 
-    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve accepted additional cookies. You can change your cookie settings at any time.');
+    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve accepted analytics cookies. You can change your cookie settings at any time.');
     expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
     expect(acceptButton).not.toBeInTheDocument();
   });
@@ -71,7 +71,7 @@ describe('CookieBanner tests', () => {
     const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
     await user.click(rejectButton);
 
-    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve rejected additional cookies. You can change your cookie settings at any time.');
+    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve rejected analytics cookies. You can change your cookie settings at any time.');
     expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
     expect(rejectButton).not.toBeInTheDocument();
   });

--- a/src/layout/__tests__/CookieBanner.test.jsx
+++ b/src/layout/__tests__/CookieBanner.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 
 import CookieBanner from '../CookieBanner';
 
@@ -35,7 +36,7 @@ describe('CookieBanner tests', () => {
 
   it('should set cookiePreference to true when Accept analytics cookies is clicked', async () => {
     const user = userEvent.setup();
-    render(<CookieBanner />);
+    render(<MemoryRouter><CookieBanner /></MemoryRouter>);
 
     const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
     await user.click(acceptButton);
@@ -44,10 +45,51 @@ describe('CookieBanner tests', () => {
 
   it('should set cookiePreference to false when Reject analytics cookies is clicked', async () => {
     const user = userEvent.setup();
-    render(<CookieBanner />);
+    render(<MemoryRouter><CookieBanner /></MemoryRouter>);
 
     const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
     await user.click(rejectButton);
     expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=false');
   });
+  
+  it('should show the confirmation banner when accept is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><CookieBanner /></MemoryRouter>);
+
+    const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
+    await user.click(acceptButton);
+
+    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve accepted additional cookies. You can change your cookie settings at any time.');
+    expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
+    expect(acceptButton).not.toBeInTheDocument();
+  });
+
+  it('should show the confirmation banner when reject is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><CookieBanner /></MemoryRouter>);
+
+    const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
+    await user.click(rejectButton);
+
+    expect(screen.getByTestId('cookieMessage')).toHaveTextContent('You\'ve rejected additional cookies. You can change your cookie settings at any time.');
+    expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
+    expect(rejectButton).not.toBeInTheDocument();
+  });
+
+  it('should hide the confirmation banner once hide cookie message is clicked after user accepts or rejects cookies', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><CookieBanner /></MemoryRouter>);
+
+    const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
+    await user.click(acceptButton);
+
+    const hideButton = screen.getByRole('button', { name: 'Hide cookie message'});
+    await user.click(hideButton);
+
+    expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Accept analytics cookies' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cookieMessage')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hide cookie message'})).not.toBeInTheDocument();
+  });
 });
+


### PR DESCRIPTION
# Ticket

NMSW-25

----

## AC

GIVEN I can see the cookie banner
WHEN I click 'reject'
THEN the banners are hidden 
AND the confirmation banner is shown

GIVEN I can see the cookie banner
WHEN I click 'accept'
AND the banners are hidden 
AND the confirmation banner is shown

----

## To test

- run app locally
- go to localhost:3000
- > you should see the cookie banner at the top of the page
- it should have an accept button
- click the accept button
- > you should see a confirmation page that you have accepted cookies
- > and a hide cookie message button
- click the hide cookie message button 
- > the cookie banner should be hidden
- refresh the page
- the cookie banner should remain hidden
- go to dev tools > cookies and remove the cookie preference cookie
- refresh the page
- > you should see the cookie banner again
- click the reject button
- > you should see the confirmation page again


----

## Notes
