### PR TITLE
NMSW-26 Add link to CookieBanner

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -2,7 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import useUserIsPermitted from './hooks/useUserIsPermitted';
 import ProtectedRoutes from './utils/ProtectedRoutes';
-import ScrollToTop from './utils/scrollToTop';
+import ScrollToTop from './utils/ScrollToTop';
 
 // URLs
 import {

--- a/src/layout/CookieBanner.jsx
+++ b/src/layout/CookieBanner.jsx
@@ -42,7 +42,7 @@ const CookieBanner = ({ setIsCookieBannerShown }) => {
             }}>
               Reject analytics cookies
             </button>
-            {/* <a className="govuk-link" href="#">View cookies</a> */}
+            <Link className="govuk-link" to={COOKIE_URL}>View cookies</Link>
           </div>
         </div>
       </div>}

--- a/src/layout/__tests__/CookieBanner.test.jsx
+++ b/src/layout/__tests__/CookieBanner.test.jsx
@@ -31,9 +31,11 @@ describe('CookieBanner tests', () => {
     render(<MemoryRouter><CookieBanner setIsCookieBannerShown={setIsCookieBannerShown} /></MemoryRouter>);
     const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
     const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
+    const viewCookieLink = screen.getByRole('link', { name: 'View cookies'});
 
     expect(acceptButton).toBeInTheDocument();
     expect(rejectButton).toBeInTheDocument();
+    expect(viewCookieLink).toBeInTheDocument();
   });
 
   it('should set cookiePreference to true when Accept analytics cookies is clicked', async () => {

--- a/src/pages/Regulatory/__tests__/CookiePolicy.test.jsx
+++ b/src/pages/Regulatory/__tests__/CookiePolicy.test.jsx
@@ -23,12 +23,12 @@ describe('Cookie policy tests', () => {
   });
 
   it('should render a title of Cookies', async () => {
-    render(<MemoryRouter><CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown}/></MemoryRouter>);
+    render(<MemoryRouter><CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown} /></MemoryRouter>);
     expect(screen.getByText('Cookies')).toBeInTheDocument();
   });
 
   it('should render form to change cookie settings', async () => {
-    render(<MemoryRouter><CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown}/></MemoryRouter>);
+    render(<MemoryRouter><CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown} /></MemoryRouter>);
     expect(screen.getByText('Change your cookie settings')).toBeInTheDocument();
     expect(screen.getByText('Do you want to accept analytics cookies?')).toBeInTheDocument();
     expect(screen.getByText('Yes')).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe('Cookie policy tests', () => {
   });
 
   it('should prefill the no radio button if no cookiePreference', async () => {
-    render(<MemoryRouter><CookiePolicy /></MemoryRouter>);
+    render(<MemoryRouter><CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown} /></MemoryRouter>);
     expect(screen.getByRole('radio', { name: 'No' })).toBeChecked();
   });
 
@@ -54,7 +54,7 @@ describe('Cookie policy tests', () => {
     const saveCookies = screen.getByRole('button', { name: 'Save cookie settings' });
 
     expect(extractPreferenceCookie('cookiePreference')).toEqual(undefined);
-    
+
     await user.click(yesRadio);
     await user.click(saveCookies);
     expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=true');
@@ -68,7 +68,7 @@ describe('Cookie policy tests', () => {
     const saveCookies = screen.getByRole('button', { name: 'Save cookie settings' });
 
     expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=true');
-    
+
     await user.click(noRadio);
     await user.click(saveCookies);
     expect(extractPreferenceCookie('cookiePreference')).toEqual('cookiePreference=false');


### PR DESCRIPTION
# Ticket

NMSW-26

----

## AC

Given I am viewing the cookie banner
When I click on the view cookies link
Then I am shown the cookie page

Given I have selected accept or reject on the cookie banner
And am viewing the confirmation page
When I click on the 'change your cookie settings' link
Then I am shown the cookie page

----

## To test

- To Test
- run app locally
- go to localhost:3000
- If present, delete cookiePreference cookie
- > you should see the cookie banner at the top of the page
- it should have a view cookies link
- click the view cookies link
- > you should be taken to the cookie page
- there will be no content on this page at this time
- go back to the cookie banner
- select accept or reject
- > you should see the confirmation of cookie selected panel
- click on 'change your cookie settings'
- > you should be taken to the cookie page

----

## Notes
