### PR TITLE
NMSW-120 Extend test coverage

### DIFF
--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -1,5 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import DisplayForm from '../DisplayForm';
+import {
+  FIELD_EMAIL,
+  FIELD_PASSWORD,
+  FIELD_RADIO,
+  FIELD_TEXT,
+} from '../../constants/AppConstants';
 
 /*
  * These tests check that we can pass a variety of
@@ -42,34 +48,67 @@ describe('Display Form', () => {
   };
   const formTextInput = [
     {
-      type: 'text',
+      type: FIELD_TEXT,
       label: 'Text input',
       hint: 'This is a hint for a text input',
       fieldName: 'testField',
     }
   ];
+  const formRadioInput = [
+    {
+      type: FIELD_RADIO,
+      label: 'This is a radio button set',
+      fieldName: 'radioButtonSet',
+      className: 'govuk-radios',
+      grouped: true,
+      hint: 'radio hint',
+      radioOptions: [
+        {
+          label: 'Radio one',
+          name: 'radioButtonSet',
+          id: 'radioOne',
+          value: 'radioOne',
+          checked: true
+        },
+        {
+          label: 'Radio two',
+          name: 'radioButtonSet',
+          id: 'radioTwo',
+          value: 'radioTwo',
+          checked: false
+        },
+        {
+          label: 'Radio three',
+          name: 'radioButtonSet',
+          id: 'radioThree',
+          value: 'radioThree',
+          checked: false
+        },
+      ]
+    },
+  ];
   const formSpecialInputs = [
     {
-      type: 'text',
+      type: FIELD_TEXT,
       label: 'Text input',
       hint: 'This is a hint for a text input',
       fieldName: 'testField',
     },
     {
-      type: 'email',
+      type: FIELD_EMAIL,
       label: 'Email input',
       hint: 'This is a hint for an email input',
       fieldName: 'email',
     },
     {
-      type: 'password',
+      type: FIELD_PASSWORD,
       label: 'Password input',
       hint: 'This is a hint for a password input',
       fieldName: 'password',
     }
   ];
 
-  it('should render a submit and cancel button if both exist', async () => {
+  it('should render a submit and cancel button if both exist', () => {
     render(
       <DisplayForm
         formId="testForm"
@@ -82,7 +121,7 @@ describe('Display Form', () => {
     expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
   });
 
-  it('should render only a submit button if there is no cancel button', async () => {
+  it('should render only a submit button if there is no cancel button', () => {
     render(
       <DisplayForm
         formId="testForm"
@@ -95,7 +134,7 @@ describe('Display Form', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
-  it('should render a text input', async () => {
+  it('should render a text input', () => {
     render(
       <DisplayForm
         formId="testForm"
@@ -106,10 +145,29 @@ describe('Display Form', () => {
     );
     expect(screen.getByLabelText('Text input')).toBeInTheDocument();
     expect(screen.getByText('This is a hint for a text input').outerHTML).toEqual('<div id="testField-hint" class="govuk-hint">This is a hint for a text input</div>');
-    expect(screen.getByRole('textbox', {name: 'Text input'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Text input' })).toBeInTheDocument();
   });
 
-  it('should render the special input types', async () => {
+  it('should render a radio button input', () => {
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formRadioInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByText('This is a radio button set')).toBeInTheDocument();
+    expect(screen.getByText('radio hint').outerHTML).toEqual('<div id="radioButtonSet-hint" class="govuk-hint">radio hint</div>');
+    expect(screen.getByLabelText('Radio one')).toBeInTheDocument();
+    expect(screen.getByLabelText('Radio two')).toBeInTheDocument();
+    expect(screen.getByLabelText('Radio three')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio three' })).toBeInTheDocument();
+  });
+
+  it('should render the special input types', () => {
     render(
       <DisplayForm
         formId="testForm"
@@ -121,11 +179,11 @@ describe('Display Form', () => {
     /* standard text field */
     expect(screen.getByLabelText('Text input')).toBeInTheDocument();
     expect(screen.getByText('This is a hint for a text input').outerHTML).toEqual('<div id="testField-hint" class="govuk-hint">This is a hint for a text input</div>');
-    expect(screen.getByRole('textbox', {name: 'Text input'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Text input' })).toBeInTheDocument();
     /* email field */
     expect(screen.getByLabelText('Email input')).toBeInTheDocument();
     expect(screen.getByText('This is a hint for an email input').outerHTML).toEqual('<div id="email-hint" class="govuk-hint">This is a hint for an email input</div>');
-    expect(screen.getByRole('textbox', {name: 'Email input'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Email input' })).toBeInTheDocument();
     /* password field: password inputs do not have a true textbox role so must be found via test id */
     expect(screen.getByLabelText('Password input')).toBeInTheDocument();
     expect(screen.getByText('This is a hint for a password input').outerHTML).toEqual('<div id="password-hint" class="govuk-hint">This is a hint for a password input</div>');

--- a/src/components/formFields/InputRadio.jsx
+++ b/src/components/formFields/InputRadio.jsx
@@ -31,11 +31,9 @@ const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
 
 InputRadio.propTypes = {
   autoComplete: PropTypes.string,
-  dataTestid: PropTypes.string,
   fieldDetails: PropTypes.shape({
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
-    value: PropTypes.string,
     className: PropTypes.string,
     radioOptions: PropTypes.arrayOf(
       PropTypes.shape({
@@ -44,7 +42,7 @@ InputRadio.propTypes = {
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
         checked: PropTypes.bool
-      }))
+      })).isRequired,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
   type: PropTypes.string.isRequired,

--- a/src/components/formFields/__tests__/InputRadio.test.jsx
+++ b/src/components/formFields/__tests__/InputRadio.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import InputRadio from '../InputRadio';
+
+/*
+ * These tests check that we can pass in the minimum parameters and it will generate the correct input field HTML
+ * And we can pass in the maximum parameters and it will generate the correct input field HTML
+ * It does NOT test that the full form field component with labels etc is generated
+ */
+
+describe('Radio input field generation', () => {
+  const parentHandleChange = jest.fn();
+  const fieldDetailsBasic = {
+    fieldName: 'simpleFieldName', // gets rendered in DisplayForm component
+    radioOptions: [
+      {
+        id: 'radio1',
+        name: 'radioOne',
+        label: 'Radio one',
+        value: 'radioOne',
+      }
+    ]
+  };
+  const fieldDetailsAllProps = {
+    fieldName: 'fullFieldName', // gets rendered in DisplayForm component
+    hint: 'The hint text', // gets rendered in DisplayForm component
+    value: 'radioOne', // gets rendered in DisplayForm component
+    className: 'govuk-radios govuk-radios--inline', // gets rendered in DisplayForm component
+    radioOptions: [
+      {
+        id: 'radio1',
+        name: 'radioOne',
+        label: 'Radio one',
+        value: 'radioOne',
+        checked: false,
+      },
+      {
+        id: 'radio2',
+        name: 'radioTwo',
+        label: 'Radio two',
+        value: 'radioTwo',
+        checked: true,
+      }
+    ]
+  };
+
+  it('should render the radio input field with only the required props', () => {
+    render(
+      <InputRadio
+        fieldDetails={fieldDetailsBasic}
+        handleChange={parentHandleChange}
+        type='radio'
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio one' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio1-input" name="radioOne" type="radio" value="radioOne">');
+  });
+
+  it('should render the radio input field with all props passed', () => {
+    render(
+      <InputRadio
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type='radio'
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Radio one' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio1-input" name="radioOne" type="radio" value="radioOne">');
+    expect(screen.getByRole('radio', { name: 'Radio two' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio2-input" name="radioTwo" type="radio" value="radioTwo" checked="">');
+    expect(screen.getByRole('radio', { name: 'Radio one' })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+  });
+
+});

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -61,6 +61,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
       <h1 className="govuk-heading-l">Cookies</h1>
       <h2 className="govuk-heading-l">Change your cookie settings</h2>
       <DisplayForm
+        formId='changeYourCookieSettings'
         fields={formFields}
         formActions={formActions}
         handleSubmit={handleSubmit}


### PR DESCRIPTION
# Ticket

Prep for NMSW-120

----

## AC

n/a

----

## To test

Run RTL tests

----

## Notes

Extending tests within form creator so we can use them as additional documentation on how to build forms with the creator

- removed some unneeded propTypes 
- made radioOptions required propTypes as we can't create radios without it
- added a formId for Cookie form as formId is now required (wasn't previously)
- added unit tests for InputRadio
- added integration tests for DisplayForm
