### PR TITLE
NMSW-31 Form creator adapt InputRadio to take 3+ items, add form confirmation of submission page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -9,6 +9,7 @@ import {
   ACCESSIBILITY_URL,
   COOKIE_URL,
   DASHBOARD_URL,
+  FORM_CONFIRMATION_URL,
   LANDING_URL,
   PRIVACY_URL,
   SIGN_IN_URL,
@@ -19,6 +20,7 @@ import {
 import AccessibilityStatement from './pages/Regulatory/AccessibilityStatement';
 import CookiePolicy from './pages/Regulatory/CookiePolicy';
 import Dashboard from './pages/Dashboard/Dashboard';
+import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
 import Landing from './pages/Landing/Landing';
 import PrivacyNotice from './pages/Regulatory/PrivacyNotice';
 import SignIn from './pages/SignIn/SignIn';
@@ -32,11 +34,12 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
     <ScrollToTop>
       <Routes>
         <Route path='/' element={<Landing />} />
-        <Route path={LANDING_URL} element={<Landing />} />
-        <Route path={SIGN_IN_URL} element={<SignIn />} />
         <Route path={ACCESSIBILITY_URL} element={<AccessibilityStatement />} />
         <Route path={COOKIE_URL} element={<CookiePolicy  setIsCookieBannerShown={setIsCookieBannerShown} />} />
+        <Route path={FORM_CONFIRMATION_URL} element={<FormConfirmationPage />} />
+        <Route path={LANDING_URL} element={<Landing />} />
         <Route path={PRIVACY_URL} element={<PrivacyNotice />} />
+        <Route path={SIGN_IN_URL} element={<SignIn />} />
         <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>
           <Route path={DASHBOARD_URL} element={<Dashboard />} />
           <Route path={SECOND_PAGE_URL} element={<SecondPage />} />

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -23,6 +23,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
     const fieldLabelNode = fieldMap.get(error.name);
     fieldLabelNode.scrollIntoView();
     // /* TODO: replace with useRef/forwardRef */
+    // radio buttons and checkbox lists add their index key to their id so we can find and focus on them
     document.getElementById(`${error.name}-input`) ? document.getElementById(`${error.name}-input`).focus() : document.getElementById(`${error.name}-input[0]`).focus();
   };
 

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -23,7 +23,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
     const fieldLabelNode = fieldMap.get(error.name);
     fieldLabelNode.scrollIntoView();
     // /* TODO: replace with useRef/forwardRef */
-    document.getElementById(`${error.name}-input`).focus();
+    document.getElementById(`${error.name}-input`) ? document.getElementById(`${error.name}-input`).focus() : document.getElementById(`${error.name}-input[0]`).focus();
   };
 
   /* 

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -115,6 +115,12 @@ describe('Display Form', () => {
       message: 'testField is erroring'
     }
   ];
+  const formRadioInputWithErrors = [
+    {
+      name: 'radioButtonSet',
+      message: 'radioButtonSet is erroring'
+    }
+  ];
 
   it('should render a submit and cancel button if both exist', () => {
     render(
@@ -217,7 +223,7 @@ describe('Display Form', () => {
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint">');
   });
 
-  it('should scroll to erroring field if user clicks an error summary link', async () => {
+  it('should scroll to erroring field if user clicks an error summary link for a single input field', async () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
@@ -232,5 +238,22 @@ describe('Display Form', () => {
     await user.click(screen.getByRole('button', { name: 'testField is erroring'}));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getByRole('textbox', {name: /Text input/i})).toHaveFocus();
+  });
+
+  it('should scroll to erroring field if user clicks an error summary link for a radio button set', async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayForm
+        errors={formRadioInputWithErrors}
+        formId="testForm"
+        fields={formRadioInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'radioButtonSet is erroring'}));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getByRole('radio', {name: /Radio one/i})).toHaveFocus();
   });
 });

--- a/src/components/formFields/InputRadio.jsx
+++ b/src/components/formFields/InputRadio.jsx
@@ -4,12 +4,12 @@ const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
 
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">
-      {(fieldDetails.radioOptions).map((option) => {
+      {(fieldDetails.radioOptions).map((option, index) => {
         return (
           <div className="govuk-radios__item" key={option.id}>
             <input
               className="govuk-radios__input"
-              id={`${option.id}-input`}
+              id={`${fieldDetails.fieldName}-input[${index}]`} // we set the index onto the ID here so we can set focus to it if there is an error
               autoComplete={autoComplete}
               name={option.name}
               value={option.value}

--- a/src/components/formFields/InputRadio.jsx
+++ b/src/components/formFields/InputRadio.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 
 const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
-
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">
       {(fieldDetails.radioOptions).map((option, index) => {
@@ -9,16 +8,16 @@ const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
           <div className="govuk-radios__item" key={option.id}>
             <input
               className="govuk-radios__input"
-              id={`${fieldDetails.fieldName}-input[${index}]`} // we set the index onto the ID here so we can set focus to it if there is an error
+              id={`${option.name}-input[${index}]`}
               autoComplete={autoComplete}
               name={option.name}
               value={option.value}
               type={type}
               onChange={handleChange}
               defaultChecked={option.checked}
-              aria-describedby={option.hint ? `${fieldDetails.fieldName}${option.id}-hint` : null}
+              aria-describedby={option.hint ? `${fieldDetails.fieldName}${option.name}-hint` : null}
             />
-            <label className="govuk-label govuk-radios__label" htmlFor={`${option.id}-input`}>
+            <label className="govuk-label govuk-radios__label" htmlFor={`${option.name}-input[${index}]`}>
               {option.label}
             </label>
           </div>

--- a/src/components/formFields/__tests__/InputRadio.test.jsx
+++ b/src/components/formFields/__tests__/InputRadio.test.jsx
@@ -10,37 +10,43 @@ import InputRadio from '../InputRadio';
 describe('Radio input field generation', () => {
   const parentHandleChange = jest.fn();
   const fieldDetailsBasic = {
-    fieldName: 'simpleFieldName', // gets rendered in DisplayForm component
+    fieldName: 'simpleFieldName',
+    grouped: true,
+    label: 'Basic props field radio label',
     radioOptions: [
       {
-        id: 'radio1',
-        name: 'radioOne',
-        label: 'Radio one',
-        value: 'radioOne',
+        label: 'Radio option one label',
+        name: 'simpleFieldName',
+        id: 'radioOptionOneLabel',
+        value: 'radioOptionOneLabel'
       }
-    ]
+    ],
+    type: 'radio'
   };
   const fieldDetailsAllProps = {
-    fieldName: 'fullFieldName', // gets rendered in DisplayForm component
-    hint: 'The hint text', // gets rendered in DisplayForm component
-    value: 'radioOne', // gets rendered in DisplayForm component
-    className: 'govuk-radios govuk-radios--inline', // gets rendered in DisplayForm component
+    className: 'govuk-radios govuk-radios--inline',
+    fieldName: 'fullFieldName',
+    grouped: true,
+    label: 'Full props field radio label',
+    hint: 'The hint text',
+    value: 'radioOne',
     radioOptions: [
       {
-        id: 'radio1',
-        name: 'radioOne',
-        label: 'Radio one',
-        value: 'radioOne',
-        checked: false,
+        label: 'Radio option one label',
+        name: 'fullFieldName',
+        id: 'radioOptionOneLabel',
+        value: 'radioOptionOneLabel',
+        checked: false
       },
       {
-        id: 'radio2',
-        name: 'radioTwo',
-        label: 'Radio two',
-        value: 'radioTwo',
-        checked: true,
+        label: 'Radio option two label',
+        name: 'fullFieldName',
+        id: 'radioOptionTwoLabel',
+        value: 'radioOptionTwoLabel',
+        checked: true
       }
-    ]
+    ],
+    type: 'radio'
   };
 
   it('should render the radio input field with only the required props', () => {
@@ -51,8 +57,8 @@ describe('Radio input field generation', () => {
         type='radio'
       />
     );
-    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Radio one' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio1-input" name="radioOne" type="radio" value="radioOne">');
+    expect(screen.getByRole('radio', { name: 'Radio option one label' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio option one label' }).outerHTML).toEqual('<input class="govuk-radios__input" id="simpleFieldName-input[0]" name="simpleFieldName" type="radio" value="radioOptionOneLabel">');
   });
 
   it('should render the radio input field with all props passed', () => {
@@ -63,10 +69,9 @@ describe('Radio input field generation', () => {
         type='radio'
       />
     );
-    expect(screen.getByRole('radio', { name: 'Radio one' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio1-input" name="radioOne" type="radio" value="radioOne">');
-    expect(screen.getByRole('radio', { name: 'Radio two' }).outerHTML).toEqual('<input class="govuk-radios__input" id="radio2-input" name="radioTwo" type="radio" value="radioTwo" checked="">');
-    expect(screen.getByRole('radio', { name: 'Radio one' })).not.toBeChecked();
-    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Radio option one label' }).outerHTML).toEqual('<input class="govuk-radios__input" id="fullFieldName-input[0]" name="fullFieldName" type="radio" value="radioOptionOneLabel">');
+    expect(screen.getByRole('radio', { name: 'Radio option two label' }).outerHTML).toEqual('<input class="govuk-radios__input" id="fullFieldName-input[1]" name="fullFieldName" type="radio" value="radioOptionTwoLabel" checked="">');
+    expect(screen.getByRole('radio', { name: 'Radio option one label' })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Radio option two label' })).toBeChecked();
   });
-
 });

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -7,8 +7,8 @@ export const FIELD_PASSWORD = 'password';
 export const FIELD_TEXT = 'text';
 export const FIELD_RADIO = 'radio';
 // Forms: states
-export const RADIO_TRUE = 'true';
-export const RADIO_FALSE = 'false';
+export const CHECKED_TRUE = true;
+export const CHECKED_FALSE = false;
 // Forms: validation types
 export const VALIDATE_REQUIRED = 'required';
 export const VALIDATE_MIN_LENGTH = 'minLength';

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -6,6 +6,7 @@ export const FEEDBACK_URL = '/';
 export const ACCESSIBILITY_URL = '/accessibility-statement';
 export const COOKIE_URL = '/cookies';
 export const DASHBOARD_URL = '/dashboard';
+export const FORM_CONFIRMATION_URL = '/confirmation';
 export const LANDING_URL = '/';
 export const PRIVACY_URL = '/privacy-notice';
 export const SIGN_IN_URL = '/sign-in';

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -5,6 +5,7 @@ export const FEEDBACK_URL = '/';
 // Pages
 export const ACCESSIBILITY_URL = '/accessibility-statement';
 export const COOKIE_URL = '/cookies';
+export const DASHBOARD_PAGE_NAME = 'Dashboard';
 export const DASHBOARD_URL = '/dashboard';
 export const FORM_CONFIRMATION_URL = '/confirmation';
 export const LANDING_URL = '/';
@@ -12,4 +13,5 @@ export const PRIVACY_URL = '/privacy-notice';
 export const SIGN_IN_URL = '/sign-in';
 
 // Test pages
+export const SECOND_PAGE_NAME = 'Second page';
 export const SECOND_PAGE_URL = '/second-page';

--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { SERVICE_NAME } from '../constants/AppConstants';
 import {
+  DASHBOARD_PAGE_NAME,
   DASHBOARD_URL,
   LANDING_URL,
+  SECOND_PAGE_NAME,
   SECOND_PAGE_URL,
 } from '../constants/AppUrlConstants';
 import useUserIsPermitted from '../hooks/useUserIsPermitted';
@@ -14,13 +16,13 @@ const Nav = () => {
     {
       id: 'Dashboard',
       urlStem: DASHBOARD_URL,
-      text: 'Dashboard',
+      text: DASHBOARD_PAGE_NAME,
       active: true, // Dashboard is the logged in landing therefore defaults to active true
     },
     {
       id: 'SecondPage',
       urlStem: SECOND_PAGE_URL,
-      text: 'Second page',
+      text: SECOND_PAGE_NAME,
       active: false,
     }
   ];

--- a/src/pages/Confirmation/FormConfirmationPage.jsx
+++ b/src/pages/Confirmation/FormConfirmationPage.jsx
@@ -4,7 +4,7 @@ const ConfirmFormSubmission = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
 
-  if (!state) {
+  if (!state || Object.entries(state).length < 1) {
     return (
       <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
         <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -44,7 +44,7 @@ const ConfirmFormSubmission = () => {
           type="button"
           onClick={() => { navigate(state.nextPageLink); }}
         >
-          Continue to home page
+          Continue to {state.nextPageName}
         </button>
       </div>
     </div>

--- a/src/pages/Confirmation/FormConfirmationPage.jsx
+++ b/src/pages/Confirmation/FormConfirmationPage.jsx
@@ -4,10 +4,19 @@ const ConfirmFormSubmission = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
 
-  if (!state) { 
-    console.log('Confirmation page tried to load without any state');
-    return (<p>Something went wrong, check your form submissions and try again</p>);
+  if (!state) {
+    return (
+      <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+        <h2 className="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+        <div className="govuk-error-summary__body">
+          <p>Something went wrong, check your form submissions and try again</p>
+        </div>
+      </div>
+    );
   }
+
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">

--- a/src/pages/Confirmation/FormConfirmationPage.jsx
+++ b/src/pages/Confirmation/FormConfirmationPage.jsx
@@ -1,0 +1,45 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const ConfirmFormSubmission = () => {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  if (!state) { 
+    console.log('Confirmation page tried to load without any state');
+    return (<p>Something went wrong, check your form submissions and try again</p>);
+  }
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <div className="govuk-panel govuk-panel--confirmation">
+          <h1 className="govuk-panel__title">
+            {`${state.formName} submitted`}
+          </h1>
+          {state.referenceNumber &&
+            <div className="govuk-panel__body">
+              Your reference number<br /><strong>{state.referenceNumber}</strong>
+            </div>
+          }
+        </div>
+        <p className="govuk-body">We have sent you a confirmation email.</p>
+
+        <h2 className="govuk-heading-m">What happens next</h2>
+
+        <p className="govuk-body">
+          We&apos;ve sent your voyage plan to Border Force. They will contact you if they need more information.
+        </p>
+
+        <button
+          className="govuk-button govuk-button--secondary"
+          data-module="govuk-button"
+          type="button"
+          onClick={() => { navigate(state.nextPageLink); }}
+        >
+          Continue to home page
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmFormSubmission;

--- a/src/pages/Confirmation/FormConfirmationPage.test.jsx
+++ b/src/pages/Confirmation/FormConfirmationPage.test.jsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import FormConfirmationPage from './FormConfirmationPage';
+
+const mockUseLocationState = { state: {} };
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUsedNavigate,
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
+describe('Form confirmation page', () => {
+  it('should render the confirmation page if state exists', () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+      referenceNumber: '123'
+    };
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByText('Your form name submitted')).toBeInTheDocument();
+  });
+
+  it('should show an error message if the page loads without form submitted details', () => {
+    mockUseLocationState.state = '';
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong, check your form submissions and try again')).toBeInTheDocument();
+    expect((screen.getByText('There is a problem')).outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
+  });
+
+  it('should show an error message if the page loads with an empty object of form submitted details', () => {
+    mockUseLocationState.state = {};
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong, check your form submissions and try again')).toBeInTheDocument();
+    expect((screen.getByText('There is a problem')).outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
+  });
+
+  it('should show a reference number if one is provided', () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+      referenceNumber: '123'
+    };
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByText('Your reference number')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
+  });
+
+  it('should NOT show reference number text if NO reference number is provided', () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+    };
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.queryByText('Your reference number')).not.toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument();
+  });
+
+  it('should state the form name that was submitted', () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+      referenceNumber: '123'
+    };
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByRole('heading', { name: 'Your form name submitted' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Your form name submitted' }).outerHTML).toEqual('<h1 class="govuk-panel__title">Your form name submitted</h1>');
+  });
+
+  it('should have a what happens next section', () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+      referenceNumber: '123'
+    };
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByRole('heading', { name: 'What happens next' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'What happens next' }).outerHTML).toEqual('<h2 class="govuk-heading-m">What happens next</h2>');
+  });
+
+  it('should have a secondary button to take you to the page specified', async () => {
+    mockUseLocationState.state = {
+      formName: 'Your form name',
+      nextPageLink: '/next-page',
+      nextPageName: 'next page',
+      referenceNumber: '123'
+    };
+    const user = userEvent.setup();
+
+    render(<MemoryRouter><FormConfirmationPage /></MemoryRouter>);
+    expect(screen.getByRole('button', { name: 'Continue to next page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue to next page' }).outerHTML).toEqual('<button class="govuk-button govuk-button--secondary" data-module="govuk-button" type="button">Continue to next page</button>');
+    await user.click(screen.getByRole('button', { name: 'Continue to next page' }));
+    expect(mockedUsedNavigate).toHaveBeenCalled();
+    expect(mockedUsedNavigate).toHaveBeenCalledWith('/next-page');
+  });
+});

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -50,7 +50,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
 
   const handleSubmit = (e, formData) => {
     e.preventDefault();
-    if (formData.formData.cookieSettings === CHECKED_TRUE) {
+    if (formData.formData.cookieSettings === CHECKED_TRUE.toString()) {
       setAnalyticCookie(true);
     } else {
       setAnalyticCookie(false);

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import DisplayForm from '../../components/DisplayForm';
-import { FIELD_RADIO, RADIO_TRUE, RADIO_FALSE } from '../../constants/AppConstants';
+import { FIELD_RADIO, CHECKED_TRUE, CHECKED_FALSE } from '../../constants/AppConstants';
 import cookieToFind from '../../utils/cookieToFind';
 import { scrollToElementId } from '../../utils/ScrollToElementId';
 import setAnalyticCookie from '../../utils/setAnalyticCookie';
@@ -11,7 +11,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
   const [isCookieConfirmationShown, setIsCookieConfirmationShown] = useState(false);
   const cookiePreference = cookieToFind('cookiePreference');
 
-  let selected = cookiePreference === true ? RADIO_TRUE : RADIO_FALSE;
+  let selected = cookiePreference === true ? CHECKED_TRUE : CHECKED_FALSE;
 
   const formActions = {
     submit: {
@@ -34,15 +34,15 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
           label: 'Yes',
           name: 'cookieSettings',
           id: 'yes',
-          value: RADIO_TRUE,
-          checked: selected === RADIO_TRUE
+          value: 'true',
+          checked: selected === CHECKED_TRUE
         },
         {
           label: 'No',
           name: 'cookieSettings',
           id: 'no',
-          value: RADIO_FALSE,
-          checked: selected === RADIO_FALSE
+          value: 'false',
+          checked: selected === CHECKED_FALSE
         },
       ]
     },
@@ -50,7 +50,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
 
   const handleSubmit = (e, formData) => {
     e.preventDefault();
-    if (formData.formData.cookieSettings === RADIO_TRUE) {
+    if (formData.formData.cookieSettings === CHECKED_TRUE) {
       setAnalyticCookie(true);
     } else {
       setAnalyticCookie(false);

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,17 +1,18 @@
 import { useState } from 'react';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   FIELD_TEXT,
   FIELD_RADIO,
   CHECKED_FALSE,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
+import { DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import { scrollToElementId } from '../../utils/ScrollToElementId';
 import Validator from '../../utils/Validator';
 
 const SecondPage = () => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const [errors, setErrors] = useState();
 
   const formActions = {
@@ -87,8 +88,16 @@ const SecondPage = () => {
     setErrors(formErrors);
 
     if (formErrors.length < 1) {
-      console.log('formSubmitted');
-      // navigate(CONFIRMATION_PAGE);
+      navigate(
+        FORM_CONFIRMATION_URL,
+        {
+          state: {
+            formName: 'Second page',
+            nextPageLink: DASHBOARD_URL,
+            referenceNumber: '123'
+          }
+        }
+      );
     } else {
       scrollToElementId('formSecondPage');
     }

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,8 +1,111 @@
+import { useState } from 'react';
+// import { useNavigate } from 'react-router-dom';
+import {
+  FIELD_TEXT,
+  FIELD_RADIO,
+  CHECKED_FALSE,
+  VALIDATE_REQUIRED,
+} from '../../constants/AppConstants';
+import DisplayForm from '../../components/DisplayForm';
+import { scrollToElementId } from '../../utils/ScrollToElementId';
+import Validator from '../../utils/Validator';
+
 const SecondPage = () => {
+  // const navigate = useNavigate();
+  const [errors, setErrors] = useState();
+
+  const formActions = {
+    submit: {
+      className: 'govuk-button',
+      dataModule: 'govuk-button',
+      dataTestid: 'submit-button',
+      label: 'Save',
+      type: 'button',
+    }
+  };
+  const formFields = [
+    {
+      type: FIELD_TEXT,
+      label: 'First name',
+      hint: 'Enter your first name',
+      fieldName: 'firstName',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your first name',
+        },
+      ],
+    },
+    {
+      type: FIELD_RADIO,
+      label: 'What is your favourite colour',
+      fieldName: 'favouriteColour',
+      className: 'govuk-radios',
+      grouped: true,
+      radioOptions: [
+        {
+          label: 'Red',
+          name: 'favouriteColour',
+          id: 'red',
+          value: 'red',
+          checked: CHECKED_FALSE
+        },
+        {
+          label: 'Blue',
+          name: 'favouriteColour',
+          id: 'blue',
+          value: 'blue',
+          checked: CHECKED_FALSE
+        },
+        {
+          label: 'Green',
+          name: 'favouriteColour',
+          id: 'green',
+          value: 'green',
+          checked: CHECKED_FALSE
+        },
+        {
+          label: 'Other',
+          name: 'favouriteColour',
+          id: 'other',
+          value: 'other',
+          checked: CHECKED_FALSE
+        },
+      ],
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select your favourite colour',
+        },
+      ],
+    },
+  ];
+
+  const handleSubmit = async (e, formData) => {
+    e.preventDefault();
+    const formErrors = await Validator({ formData: formData.formData, formFields: formFields });
+    setErrors(formErrors);
+
+    if (formErrors.length < 1) {
+      console.log('formSubmitted');
+      // navigate(CONFIRMATION_PAGE);
+    } else {
+      scrollToElementId('formSecondPage');
+    }
+  };
+
   return (
-    <>
-      <h1 className="govuk-heading-l">Second page</h1>
-    </>
+    <div className="govuk-grid-row">
+      <h1>Second page</h1>
+      <DisplayForm
+        formId='formSecondPage'
+        errors={errors}
+        fields={formFields}
+        formActions={formActions}
+        handleSubmit={handleSubmit}
+        setErrors={setErrors}
+      />
+    </div >
   );
 };
 

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -6,7 +6,7 @@ import {
   CHECKED_FALSE,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
-import { DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
+import { DASHBOARD_PAGE_NAME, DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import { scrollToElementId } from '../../utils/ScrollToElementId';
 import Validator from '../../utils/Validator';
@@ -94,6 +94,7 @@ const SecondPage = () => {
           state: {
             formName: 'Second page',
             nextPageLink: DASHBOARD_URL,
+            nextPageName: DASHBOARD_PAGE_NAME,
             referenceNumber: '123'
           }
         }


### PR DESCRIPTION
# Ticket

NMSW-31

----

## AC

Given I am on the second page form
When I submit a valid form (all mandatory fields have a value)
Then I am taken to a confirmation page
And I can see a link to return to the dashboard

Given I am on the confirmation page
When I click the link to return to the dashboard
Then I am taken back to the dashboard

----

## To test

- run app locally
- go to localhost:3000
- click start now
- click sign in
- click second page in nav
- fill out the form on the second page
- click submit
- > you should see a confirmation of successful submission
- > you should see a reference number
- > you should see a what happens next section
- > you should see a button to continue to the next suggested page (for this form it will be dashboard)
- click the link
- > you should be returned to the dashboard
- go to another page
- in the address bar type `http://localhost:3000/confirmation` and go to that url
- > you should see a 'something went wrong' error

----

## Notes

Nav is not changing active page to dashboard when you click return to homepage button and it loads /dashboard
investigating this and will fix in next PR

The second page form is a temporary form for testing.
The confirmation page is being created as generically as possible for now as part of the form builder with sample content.