### PR TITLE
NMSW-94 Persist most form data on page refresh (not passwords, not cookie preference)

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { FIELD_PASSWORD } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
 import determineFieldType from './formFields/DetermineFieldType';
 
@@ -7,6 +8,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
   const [formData, setFormData] = useState({});
+  const [sessionData, setSessionData] = useState({});
 
   const handleChange = (e) => {
     if (errors) {
@@ -14,6 +16,12 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
       const filteredErrors = errors?.filter(errorField => errorField.name !== e.target.name);
       setErrors(filteredErrors);
     }
+    // we do not store passwords in session data
+    if (e.target.name !== FIELD_PASSWORD) {
+      setSessionData({ ...sessionData, [e.target.name]: e.target.value });
+      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value }));
+    }
+    // we do store all values into form data
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -64,22 +64,19 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
    * It also checks session storage for stored values and applies them
    */
 
-  // set fields with values from session storage
-
   useEffect(() => {
-    const sessionDataArray = Object.entries(sessionData).map(item => { return {name: item[0], value: item[1]}; });
-    
+    let sessionDataArray;
+    if (sessionData) {
+      sessionDataArray = Object.entries(sessionData).map(item => { return {name: item[0], value: item[1]}; });
+    }
+
     const mappedFormFields = fields.map((field) => {
       const sessionDataValue = sessionDataArray?.find(sessionDataField => sessionDataField.name === field.fieldName);
       return ({ ...field, value: sessionDataValue?.value });
     });
 
-    console.log({mappedFormFields})
     setFieldsWithValues(mappedFormFields);
   }, [fields]);
-  // map fields to form data
-
-  // map fields to page
 
   useEffect(() => {
     const mappedFields = fields.map((field) => {
@@ -90,7 +87,6 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
     setFormData(objectOfMappedFields);
   }, [user, setFormData]);
 
-  console.log({formData})
 
   if (!formActions || !fieldsWithValues) { return null; }
   return (

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -7,8 +7,9 @@ import determineFieldType from './formFields/DetermineFieldType';
 const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErrors }) => {
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
+  const [fieldsWithValues, setFieldsWithValues] = useState();
   const [formData, setFormData] = useState({});
-  const [sessionData, setSessionData] = useState({});
+  const [sessionData, setSessionData] = useState(JSON.parse(sessionStorage.getItem('formData')));
 
   const handleChange = (e) => {
     if (errors) {
@@ -60,7 +61,26 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
    * to the form render
    * 
    * For now as we have no RBAC it just returns all fields as fields to include
+   * It also checks session storage for stored values and applies them
    */
+
+  // set fields with values from session storage
+
+  useEffect(() => {
+    const sessionDataArray = Object.entries(sessionData).map(item => { return {name: item[0], value: item[1]}; });
+    
+    const mappedFormFields = fields.map((field) => {
+      const sessionDataValue = sessionDataArray?.find(sessionDataField => sessionDataField.name === field.fieldName);
+      return ({ ...field, value: sessionDataValue?.value });
+    });
+
+    console.log({mappedFormFields})
+    setFieldsWithValues(mappedFormFields);
+  }, [fields]);
+  // map fields to form data
+
+  // map fields to page
+
   useEffect(() => {
     const mappedFields = fields.map((field) => {
       return { fieldName: field.fieldName, value: field.value };
@@ -70,7 +90,9 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
     setFormData(objectOfMappedFields);
   }, [user, setFormData]);
 
-  if (!formActions || !fields) { return null; }
+  console.log({formData})
+
+  if (!formActions || !fieldsWithValues) { return null; }
   return (
     <form id={formId} autoComplete="off">
       {errors?.length > 0 && (
@@ -96,7 +118,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
         </div>
       )}
       {
-        fields.map((field) => {
+        fieldsWithValues.map((field) => {
           const error = errors?.find(errorField => errorField.name === field.fieldName);
           return (
             <div

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -64,6 +64,9 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
    * It also checks session storage for stored values and applies them
    */
 
+  // TODO: write tests
+  // TODO: refactor this to be clearer
+
   useEffect(() => {
     let sessionDataArray;
     if (sessionData) {
@@ -74,19 +77,15 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
       const sessionDataValue = sessionDataArray?.find(sessionDataField => sessionDataField.name === field.fieldName);
       return ({ ...field, value: sessionDataValue?.value });
     });
-
     setFieldsWithValues(mappedFormFields);
-  }, [fields]);
 
-  useEffect(() => {
-    const mappedFields = fields.map((field) => {
-      return { fieldName: field.fieldName, value: field.value };
+    const mappedFormData = fields.map((field) => {
+      const sessionDataValue = sessionDataArray?.find(sessionDataField => sessionDataField.name === field.fieldName);
+      return ({ fieldName: field.fieldName, value: sessionDataValue?.value });
     });
-    // convert the array of objects into a single object
-    const objectOfMappedFields = Object.assign({}, ...mappedFields.map(field => ({ [field.fieldName]: field.value })));
+    const objectOfMappedFields = Object.assign({}, ...mappedFormData.map(field => ({ [field.fieldName]: field.value })));
     setFormData(objectOfMappedFields);
-  }, [user, setFormData]);
-
+  }, [user, setFieldsWithValues, setFormData]);
 
   if (!formActions || !fieldsWithValues) { return null; }
   return (

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -259,7 +259,7 @@ describe('Display Form', () => {
     expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
     expect(screen.getAllByText('testField is erroring')).toHaveLength(2);
     // Error summary has the error message as a button and correct class
-    expect(screen.getByRole('button', { name: 'testField is erroring'}).outerHTML).toEqual('<button class="govuk-button--text">testField is erroring</button>');
+    expect(screen.getByRole('button', { name: 'testField is erroring' }).outerHTML).toEqual('<button class="govuk-button--text">testField is erroring</button>');
     // Input field has the error class attached
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
   });
@@ -276,9 +276,9 @@ describe('Display Form', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'testField is erroring'}));
+    await user.click(screen.getByRole('button', { name: 'testField is erroring' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
-    expect(screen.getByRole('textbox', {name: /Text input/i})).toHaveFocus();
+    expect(screen.getByRole('textbox', { name: /Text input/i })).toHaveFocus();
   });
 
   it('should scroll to erroring field if user clicks an error summary link for a radio button set', async () => {
@@ -293,9 +293,9 @@ describe('Display Form', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'radioButtonSet is erroring'}));
+    await user.click(screen.getByRole('button', { name: 'radioButtonSet is erroring' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
-    expect(screen.getByRole('radio', {name: /Radio one/i})).toHaveFocus();
+    expect(screen.getByRole('radio', { name: /Radio one/i })).toHaveFocus();
   });
 
   it('should store form data in the session for use on refresh', async () => {
@@ -331,6 +331,23 @@ describe('Display Form', () => {
     expect(screen.getByLabelText('Password')).toHaveValue('MyPassword');
     await user.click(screen.getByRole('radio', { name: 'Radio two' }));
     expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
+
+
+  it('should prefill form with data from session if it exists', async () => {
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 });

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -190,6 +190,22 @@ describe('Display Form', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
+  it('should call handleSubmit function if submit button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formTextInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+
   it('should render a text input', () => {
     render(
       <DisplayForm
@@ -313,7 +329,6 @@ describe('Display Form', () => {
         setErrors={setErrors}
       />
     );
-
     // Input field has the error class attached as component rendered with errors > 0
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
     // user starts to type

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -21,6 +21,7 @@ import {
 
 describe('Display Form', () => {
   const handleSubmit = jest.fn();
+  const setErrors = jest.fn();
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
   const formActions = {
@@ -298,6 +299,29 @@ describe('Display Form', () => {
     expect(screen.getByRole('radio', { name: /Radio one/i })).toHaveFocus();
   });
 
+  it('should call the setErrors function when user interacts with the field', async () => {
+    // the setErrors function should clear the error message from the field when it is called from this scenario
+    // we will test that it does clear in Cypress tests
+    const user = userEvent.setup();
+    render(
+      <DisplayForm
+        errors={formTextInputWithErrors}
+        formId="testForm"
+        fields={formTextInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+        setErrors={setErrors}
+      />
+    );
+
+    // Input field has the error class attached as component rendered with errors > 0
+    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
+    // user starts to type
+    await user.type(screen.getByRole('textbox', { name: 'Text input' }), 'Hello');
+    // setErrors function is called to clear the error class and message
+    expect(setErrors).toHaveBeenCalled();
+  });
+
   it('should store form data in the session for use on refresh', async () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo"}';
@@ -333,7 +357,6 @@ describe('Display Form', () => {
     expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
-
 
   it('should prefill form with data from session if it exists', async () => {
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -121,6 +121,43 @@ describe('Display Form', () => {
       message: 'radioButtonSet is erroring'
     }
   ];
+  const formWithMultipleFields = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      hint: 'This is a hint for a text input',
+      fieldName: 'testField',
+    },
+    {
+      type: FIELD_PASSWORD,
+      label: 'Password',
+      fieldName: FIELD_PASSWORD,
+    },
+    {
+      type: FIELD_RADIO,
+      label: 'This is a radio button set',
+      fieldName: 'radioButtonSet',
+      className: 'govuk-radios',
+      grouped: true,
+      hint: 'radio hint',
+      radioOptions: [
+        {
+          label: 'Radio one',
+          name: 'radioButtonSet',
+          id: 'radioOne',
+          value: 'radioOne',
+          checked: false
+        },
+        {
+          label: 'Radio two',
+          name: 'radioButtonSet',
+          id: 'radioTwo',
+          value: 'radioTwo',
+          checked: false
+        },
+      ]
+    },
+  ];
 
   beforeEach(() => {
     window.sessionStorage.clear();
@@ -259,5 +296,41 @@ describe('Display Form', () => {
     await user.click(screen.getByRole('button', { name: 'radioButtonSet is erroring'}));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getByRole('radio', {name: /Radio one/i})).toHaveFocus();
+  });
+
+  it('should store form data in the session for use on refresh', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo"}';
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.type(screen.getByLabelText('Text input'), 'Hello');
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
+    await user.click(screen.getByRole('radio', { name: 'Radio two' }));
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
+
+  it('should NOT store form data for a password field in the session for use on refresh', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"radioButtonSet":"radioTwo"}';
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.type(screen.getByLabelText('Password'), 'MyPassword');
+    expect(screen.getByLabelText('Password')).toHaveValue('MyPassword');
+    await user.click(screen.getByRole('radio', { name: 'Radio two' }));
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 });

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -122,6 +122,10 @@ describe('Display Form', () => {
     }
   ];
 
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('should render a submit and cancel button if both exist', () => {
     render(
       <DisplayForm
@@ -220,7 +224,7 @@ describe('Display Form', () => {
     // Error summary has the error message as a button and correct class
     expect(screen.getByRole('button', { name: 'testField is erroring'}).outerHTML).toEqual('<button class="govuk-button--text">testField is erroring</button>');
     // Input field has the error class attached
-    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint">');
+    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
   });
 
   it('should scroll to erroring field if user clicks an error summary link for a single input field', async () => {

--- a/src/components/formFields/InputRadio.jsx
+++ b/src/components/formFields/InputRadio.jsx
@@ -4,6 +4,7 @@ const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">
       {(fieldDetails.radioOptions).map((option, index) => {
+        const checkedState = fieldDetails.value === option.value ? true : option.checked;
         return (
           <div className="govuk-radios__item" key={option.id}>
             <input
@@ -14,7 +15,7 @@ const InputRadio = ({ autoComplete, fieldDetails, handleChange, type }) => {
               value={option.value}
               type={type}
               onChange={handleChange}
-              defaultChecked={option.checked}
+              defaultChecked={checkedState}
               aria-describedby={option.hint ? `${fieldDetails.fieldName}${option.name}-hint` : null}
             />
             <label className="govuk-label govuk-radios__label" htmlFor={`${option.name}-input[${index}]`}>
@@ -42,6 +43,7 @@ InputRadio.propTypes = {
         value: PropTypes.string.isRequired,
         checked: PropTypes.bool
       })).isRequired,
+    value: PropTypes.string,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
   type: PropTypes.string.isRequired,

--- a/src/components/formFields/InputText.jsx
+++ b/src/components/formFields/InputText.jsx
@@ -12,6 +12,7 @@ const InputText = ({ autoComplete, dataTestid, error, fieldDetails, handleChange
       autoComplete={autoComplete}
       onChange={handleChange}
       aria-describedby={fieldDetails.hint ? `${fieldDetails.fieldName}-hint` : null}
+      defaultValue={fieldDetails.value}
     />
   );
 };

--- a/src/components/formFields/__tests__/InputRadio.test.jsx
+++ b/src/components/formFields/__tests__/InputRadio.test.jsx
@@ -48,6 +48,27 @@ describe('Radio input field generation', () => {
     ],
     type: 'radio'
   };
+  const fieldDetailsWithValueSelected = {
+    fieldName: 'simpleFieldName',
+    grouped: true,
+    label: 'Basic props field radio label',
+    radioOptions: [
+      {
+        label: 'Radio option one label',
+        name: 'simpleFieldName',
+        id: 'radioOptionOneLabel',
+        value: 'radioOptionOneLabel'
+      },
+      {
+        label: 'Radio option two label',
+        name: 'simpleFieldName',
+        id: 'radioOptionTwoLabel',
+        value: 'radioOptionTwoLabel'
+      }
+    ],
+    type: 'radio',
+    value: 'radioOptionOneLabel'
+  };
 
   it('should render the radio input field with only the required props', () => {
     render(
@@ -74,4 +95,17 @@ describe('Radio input field generation', () => {
     expect(screen.getByRole('radio', { name: 'Radio option one label' })).not.toBeChecked();
     expect(screen.getByRole('radio', { name: 'Radio option two label' })).toBeChecked();
   });
+
+  it('should check the field if the value is passed in', () => {
+    render(
+      <InputRadio
+        fieldDetails={fieldDetailsWithValueSelected}
+        handleChange={parentHandleChange}
+        type='radio'
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Radio option one label' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Radio option two label' })).not.toBeChecked();
+  });
+
 });

--- a/src/components/formFields/__tests__/InputText.test.jsx
+++ b/src/components/formFields/__tests__/InputText.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { FIELD_EMAIL, FIELD_PASSWORD, FIELD_TEXT } from '../../../constants/AppConstants';
 import InputText from '../InputText';
 
 /*
@@ -44,4 +45,79 @@ describe('Text input field generation', () => {
     expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="fullFieldName-input" data-testid="test-id" name="fullFieldName" type="text" autocomplete="email" aria-describedby="fullFieldName-hint" value="The full field value">');
   });
+
+  it('should render the input with type of text if text passed', () => {
+    render(
+      <InputText
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type={FIELD_TEXT}
+      />
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' })).toHaveAttribute('type', 'text');
+  });
+
+  it('should render the input with type of email if email passed', () => {
+    render(
+      <InputText
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type={FIELD_EMAIL}
+      />
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' })).toHaveAttribute('type', 'email');
+  });
+
+  it('should render the input with type of password if password passed', () => {
+    render(
+      <InputText
+        dataTestid='passwordField'
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type={FIELD_PASSWORD}
+      />
+    );
+
+    expect(screen.getByTestId('passwordField')).toHaveAttribute('type', 'password');
+  });
+
+  it('should render the default value in the input text field when one is provided', () => {
+    render(
+      <InputText
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type='text'
+      />
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' })).toHaveValue('The full field value');
+  });
+
+  it('should render the class as the error class if an error is passed', () => {
+    render(
+      <InputText
+        error='This field has an error'
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type='text'
+      />
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="fullFieldName-input" name="fullFieldName" type="text" aria-describedby="fullFieldName-hint" value="The full field value">');
+  });
+
+  it('should NOT render the class as the error class if NO error is passed', () => {
+    render(
+      <InputText
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type='text'
+      />
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input" id="fullFieldName-input" name="fullFieldName" type="text" aria-describedby="fullFieldName-hint" value="The full field value">');
+  });
+
 });

--- a/src/components/formFields/__tests__/InputText.test.jsx
+++ b/src/components/formFields/__tests__/InputText.test.jsx
@@ -27,7 +27,7 @@ describe('Text input field generation', () => {
       />
     );
     expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input" id="simpleFieldName-input" name="simpleFieldName" type="text">');
+    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input" id="simpleFieldName-input" name="simpleFieldName" type="text" value="">');
   });
 
   it('should render a text input field with all props passed', () => {
@@ -42,6 +42,6 @@ describe('Text input field generation', () => {
       />
     );
     expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="fullFieldName-input" data-testid="test-id" name="fullFieldName" type="text" autocomplete="email" aria-describedby="fullFieldName-hint">');
+    expect(screen.getByRole('textbox', { name: '' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="fullFieldName-input" data-testid="test-id" name="fullFieldName" type="text" autocomplete="email" aria-describedby="fullFieldName-hint" value="The full field value">');
   });
 });

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -12,6 +12,8 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
   const cookiePreference = cookieToFind('cookiePreference');
   
   let selected = cookiePreference === true ? CHECKED_TRUE : CHECKED_FALSE;
+  // we do not want to persist form selection for this specific form due to the UX
+  sessionStorage.removeItem('formData');
 
   const formActions = {
     submit: {

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -34,14 +34,14 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
           label: 'Yes',
           name: 'cookieSettings',
           id: 'yes',
-          value: 'true',
+          value: 'yes',
           checked: selected === CHECKED_TRUE
         },
         {
           label: 'No',
           name: 'cookieSettings',
           id: 'no',
-          value: 'false',
+          value: 'no',
           checked: selected === CHECKED_FALSE
         },
       ]

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -7,10 +7,10 @@ import { scrollToElementId } from '../../utils/ScrollToElementId';
 import setAnalyticCookie from '../../utils/setAnalyticCookie';
 
 const CookiePolicy = ({ setIsCookieBannerShown }) => {
-
+  const COOKIE_PREFERENCE_YES = 'yes';
   const [isCookieConfirmationShown, setIsCookieConfirmationShown] = useState(false);
   const cookiePreference = cookieToFind('cookiePreference');
-
+  
   let selected = cookiePreference === true ? CHECKED_TRUE : CHECKED_FALSE;
 
   const formActions = {
@@ -34,7 +34,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
           label: 'Yes',
           name: 'cookieSettings',
           id: 'yes',
-          value: 'yes',
+          value: COOKIE_PREFERENCE_YES,
           checked: selected === CHECKED_TRUE
         },
         {
@@ -50,7 +50,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
 
   const handleSubmit = (e, formData) => {
     e.preventDefault();
-    if (formData.formData.cookieSettings === CHECKED_TRUE.toString()) {
+    if (formData.formData.cookieSettings === COOKIE_PREFERENCE_YES) {
       setAnalyticCookie(true);
     } else {
       setAnalyticCookie(false);

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -92,25 +92,6 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
           </div>
         </div>}
       <h1 className="govuk-heading-l">Cookies</h1>
-      {/* Temporary <br /> tags so that you can see a scroll */}
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
       <h2 className="govuk-heading-l">Change your cookie settings</h2>
       <DisplayForm
         formId='changeYourCookieSettings'
@@ -118,24 +99,6 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
         formActions={formActions}
         handleSubmit={handleSubmit}
       />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
     </>
   );
 };

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -49,7 +49,7 @@ const SignIn = (userDetails) => {
     {
       type: FIELD_PASSWORD,
       label: 'Password',
-      fieldName: 'password',
+      fieldName: FIELD_PASSWORD, // fieldname must be password as when fieldname is password we do not store value to session storage
       validation: [
         {
           type: VALIDATE_REQUIRED,

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -10,6 +10,10 @@ describe('Sign in tests', () => {
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   function renderWithUserContext(userDetails) {
     return render(
       <UserContext.Provider value={{ 
@@ -32,14 +36,14 @@ describe('Sign in tests', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     expect(screen.getByLabelText('Email address')).toBeInTheDocument();
     expect(screen.getByText('Enter the email address you used when you created your account').outerHTML).toEqual('<div id="email-hint" class="govuk-hint">Enter the email address you used when you created your account</div>');
-    expect(screen.getByRole('textbox', {name: /email/i}).outerHTML).toEqual('<input class="govuk-input" id="email-input" name="email" type="email" autocomplete="email" aria-describedby="email-hint">');
+    expect(screen.getByRole('textbox', {name: /email/i}).outerHTML).toEqual('<input class="govuk-input" id="email-input" name="email" type="email" autocomplete="email" aria-describedby="email-hint" value="">');
   });
 
   it('should display an input field for password', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByTestId('password-passwordField')).toHaveAttribute('type', 'password');
-    expect(screen.getByTestId('password-passwordField').outerHTML).toEqual('<input class="govuk-input" id="password-input" data-testid="password-passwordField" name="password" type="password">');
+    expect(screen.getByTestId('password-passwordField').outerHTML).toEqual('<input class="govuk-input" id="password-input" data-testid="password-passwordField" name="password" type="password" value="">');
   });
 
   it('should display a primary styled sign in button', () => {


### PR DESCRIPTION
# Ticket

NMSW-94

----

## AC

Given I am on a form
When I have entered anything into the form fields
And I refresh the page
Then the answers I have entered persist (they are not cleared)

Given I have refreshed the page and answers have persisted
When I submit the form
Then the fields that were persisted should be accepted and not error

Given I am on a form with a password field
When I have entered something in that field
And I refresh the page
Then the password field should become blank (we do not persist passwords)


----

## To test

- run app locally
- click sign in
- enter something in every field
- click refresh
- > email should remain
- > password should be cleared (not persisted)
- > sample field should remain
- click sign in button
- > password field should error
- enter password
- click sign in button
- > you should be taken to the dashboard
- go to second page form
- >  second page form form should be empty
- enter something in second page form form fields
- refresh page
- > values you entered should remain

----

## Notes
- currently nothing clears form fields, so anytime you go back to the form it will have values prefilled
- NMSW-160 starts the feature work to clear fields on submit, and other tickets will come for other scenarios