### PR TITLE
NMSW-160 Move validation to inside DisplayForm component and clear sessionStorage when form ready for submit

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { FIELD_PASSWORD } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
 import determineFieldType from './formFields/DetermineFieldType';
+import { scrollToElementId } from '../utils/ScrollToElementId';
+import Validator from '../utils/Validator';
 
 const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErrors }) => {
   const { user } = useContext(UserContext);
@@ -24,6 +26,18 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
     }
     // we do store all values into form data
     setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleValidation = async (e, formData) => {
+    e.preventDefault();
+    const formErrors = await Validator({ formData: formData.formData, formFields: fields });
+    setErrors(formErrors);
+    
+    if (formErrors.length < 1) {
+      handleSubmit();
+    } else {
+      scrollToElementId(formId);
+    }
   };
 
   const scrollToErrorField = (e, error) => {
@@ -64,9 +78,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
    * It also checks session storage for stored values and applies them
    */
 
-  // TODO: write tests
   // TODO: refactor this to be clearer
-
   useEffect(() => {
     let sessionDataArray;
     if (sessionData) {
@@ -145,7 +157,7 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
           className={formActions.submit.className}
           data-module={formActions.submit.dataModule}
           data-testid={formActions.submit.dataTestid}
-          onClick={(e) => handleSubmit(e, { formData })}
+          onClick={(e) => handleValidation(e, { formData })}
         >
           {formActions.submit.label}
         </button>

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -6,9 +6,10 @@ import determineFieldType from './formFields/DetermineFieldType';
 import { scrollToElementId } from '../utils/ScrollToElementId';
 import Validator from '../utils/Validator';
 
-const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErrors }) => {
+const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
+  const [errors, setErrors] = useState();
   const [fieldsWithValues, setFieldsWithValues] = useState();
   const [formData, setFormData] = useState({});
   const [sessionData, setSessionData] = useState(JSON.parse(sessionStorage.getItem('formData')));
@@ -179,11 +180,6 @@ const DisplayForm = ({ errors, fields, formId, formActions, handleSubmit, setErr
 export default DisplayForm;
 
 DisplayForm.propTypes = {
-  errors: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string.isRequired,
-    }),
-  ),
   fields: PropTypes.arrayOf(
     PropTypes.shape({
       fieldName: PropTypes.string.isRequired,
@@ -204,5 +200,4 @@ DisplayForm.propTypes = {
     })
   ),
   handleSubmit: PropTypes.func.isRequired,
-  setErrors: PropTypes.func
 };

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -35,7 +35,13 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
     setErrors(formErrors);
     
     if (formErrors.length < 1) {
-      handleSubmit();
+      /*
+       * Returning formData
+       * some forms perform special actions on the formData post validation
+       * e.g. CookiePolicy form will set cookie states
+       * so we always pass formData back
+       */
+      handleSubmit(formData);
     } else {
       scrollToElementId(formId);
     }

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -42,6 +42,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
        * so we always pass formData back
        */
       handleSubmit(formData);
+      sessionStorage.removeItem('formData');
     } else {
       scrollToElementId(formId);
     }

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -6,7 +6,10 @@ import {
   FIELD_PASSWORD,
   FIELD_RADIO,
   FIELD_TEXT,
-} from '../../constants/AppConstants';
+  VALIDATE_EMAIL_ADDRESS,
+  VALIDATE_MIN_LENGTH,
+  VALIDATE_REQUIRED,
+  } from '../../constants/AppConstants';
 
 /*
  * These tests check that we can pass a variety of
@@ -21,7 +24,6 @@ import {
 
 describe('Display Form', () => {
   const handleSubmit = jest.fn();
-  const setErrors = jest.fn();
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
   const formActions = {
@@ -49,15 +51,53 @@ describe('Display Form', () => {
       type: 'button',
     },
   };
-  const formTextInput = [
+  const formMandatoryTextInput = [
     {
       type: FIELD_TEXT,
       label: 'Text input',
       hint: 'This is a hint for a text input',
       fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+      ],
     }
   ];
-  const formRadioInput = [
+  const formMinimumLengthTextInput = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_MIN_LENGTH,
+          message: 'Field must be a minimum of 8 characters',
+          condition: 8,
+        },
+      ],
+    }
+  ];
+  const formMultipleValidationRules = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+        {
+          type: VALIDATE_MIN_LENGTH,
+          message: 'Field must be a minimum of 8 characters',
+          condition: 8,
+        },
+      ],
+    }
+  ];
+  const formRequiredRadioInput = [
     {
       type: FIELD_RADIO,
       label: 'This is a radio button set',
@@ -87,7 +127,13 @@ describe('Display Form', () => {
           value: 'radioThree',
           checked: false
         },
-      ]
+      ],
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select your radio option',
+        },
+      ],
     },
   ];
   const formSpecialInputs = [
@@ -102,24 +148,22 @@ describe('Display Form', () => {
       label: 'Email input',
       hint: 'This is a hint for an email input',
       fieldName: 'email',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your email address',
+        },
+        {
+          type: VALIDATE_EMAIL_ADDRESS,
+          message: 'Enter your email address in the correct format, like name@example.com',
+        },
+      ],
     },
     {
       type: FIELD_PASSWORD,
       label: 'Password input',
       hint: 'This is a hint for a password input',
       fieldName: 'password',
-    }
-  ];
-  const formTextInputWithErrors = [
-    {
-      name: 'testField',
-      message: 'testField is erroring'
-    }
-  ];
-  const formRadioInputWithErrors = [
-    {
-      name: 'radioButtonSet',
-      message: 'radioButtonSet is erroring'
     }
   ];
   const formWithMultipleFields = [
@@ -168,7 +212,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActions}
         handleSubmit={handleSubmit}
       />
@@ -181,7 +225,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -190,16 +234,18 @@ describe('Display Form', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
-  it('should call handleSubmit function if submit button is clicked', async () => {
+  it('should call handleSubmit function if submit button is clicked and there are no errors', async () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
     );
+
+    await user.type(screen.getByLabelText('Text input'), 'Hello');
     expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
     expect(screen.getAllByRole('button')).toHaveLength(1);
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
@@ -210,7 +256,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -224,7 +270,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formRadioInput}
+        fields={formRequiredRadioInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -263,37 +309,78 @@ describe('Display Form', () => {
   });
 
   it('should render error summary & field error if there are field errors', async () => {
+    const user = userEvent.setup();
     render(
       <DisplayForm
-        errors={formTextInputWithErrors}
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
     );
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
 
     expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
-    expect(screen.getAllByText('testField is erroring')).toHaveLength(2);
+    expect(screen.getAllByText('Enter your text input value')).toHaveLength(2);
     // Error summary has the error message as a button and correct class
-    expect(screen.getByRole('button', { name: 'testField is erroring' }).outerHTML).toEqual('<button class="govuk-button--text">testField is erroring</button>');
+    expect(screen.getByRole('button', { name: 'Enter your text input value' }).outerHTML).toEqual('<button class="govuk-button--text">Enter your text input value</button>');
     // Input field has the error class attached
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
+  });
+
+  it('should return an error if a minimum character count is not met', async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formMinimumLengthTextInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.type(screen.getByLabelText('Text input'), 'Ab');
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+
+    expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
+    expect(screen.getAllByText('Field must be a minimum of 8 characters')).toHaveLength(2);
+    // Error summary has the error message as a button and correct class
+    expect(screen.getByRole('button', { name: 'Field must be a minimum of 8 characters' }).outerHTML).toEqual('<button class="govuk-button--text">Field must be a minimum of 8 characters</button>');
+    // Input field has the error class attached
+    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" value="">');
+  });
+
+  it('should return the error for the first failing validation rule if there are multiple rules', async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formMultipleValidationRules}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+
+    expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
+    expect(screen.getAllByText('Enter your text input value')).toHaveLength(2);
+    // Error summary has the error message as a button and correct class
+    expect(screen.getByRole('button', { name: 'Enter your text input value' }).outerHTML).toEqual('<button class="govuk-button--text">Enter your text input value</button>');
+    // Input field has the error class attached
+    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" value="">');
   });
 
   it('should scroll to erroring field if user clicks an error summary link for a single input field', async () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
-        errors={formTextInputWithErrors}
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
     );
-
-    await user.click(screen.getByRole('button', { name: 'testField is erroring' }));
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    await user.click(screen.getByRole('button', { name: 'Enter your text input value' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getByRole('textbox', { name: /Text input/i })).toHaveFocus();
   });
@@ -302,39 +389,39 @@ describe('Display Form', () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
-        errors={formRadioInputWithErrors}
         formId="testForm"
-        fields={formRadioInput}
+        fields={formRequiredRadioInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
     );
-
-    await user.click(screen.getByRole('button', { name: 'radioButtonSet is erroring' }));
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    await user.click(screen.getByRole('button', { name: 'Select your radio option' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getByRole('radio', { name: /Radio one/i })).toHaveFocus();
   });
 
-  it('should call the setErrors function when user interacts with the field', async () => {
+  it('should clear the error message when user interacts with the field', async () => {
     // the setErrors function should clear the error message from the field when it is called from this scenario
     // we will test that it does clear in Cypress tests
     const user = userEvent.setup();
     render(
       <DisplayForm
-        errors={formTextInputWithErrors}
         formId="testForm"
-        fields={formTextInput}
+        fields={formMandatoryTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
-        setErrors={setErrors}
       />
     );
+
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
     // Input field has the error class attached as component rendered with errors > 0
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input govuk-input--error" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
     // user starts to type
     await user.type(screen.getByRole('textbox', { name: 'Text input' }), 'Hello');
-    // setErrors function is called to clear the error class and message
-    expect(setErrors).toHaveBeenCalled();
+    // error class and message is cleared
+    expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
+    
   });
 
   it('should store form data in the session for use on refresh', async () => {

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -475,4 +475,25 @@ describe('Display Form', () => {
     expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
+
+  it('should clear session data when form is ready to submit', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    expect(handleSubmit).toHaveBeenCalled();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+  });
 });

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -50,8 +50,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
     },
   ];
 
-  const handleSubmit = (e, formData) => {
-    e.preventDefault();
+  const handleSubmit = (formData) => {
     if (formData.formData.cookieSettings === COOKIE_PREFERENCE_YES) {
       setAnalyticCookie(true);
     } else {

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -10,8 +10,8 @@ import {
   } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
-import { scrollToElementId } from '../../utils/ScrollToElementId';
-import Validator from '../../utils/Validator';
+// import { scrollToElementId } from '../../utils/ScrollToElementId';
+// import Validator from '../../utils/Validator';
 
 const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };
@@ -76,17 +76,9 @@ const SignIn = (userDetails) => {
     }
   ];
 
-  const handleSubmit = async (e, formData) => {
-    e.preventDefault();
-    const formErrors = await Validator({ formData: formData.formData, formFields: formFields });
-    setErrors(formErrors);
-    
-    if (formErrors.length < 1) {
-      signIn({ ...tempHardCodedUser });
-      navigate(DASHBOARD_URL);
-    } else {
-      scrollToElementId('formSignIn');
-    }
+  const handleSubmit = () => {
+    signIn({ ...tempHardCodedUser });
+    navigate(DASHBOARD_URL);
   };
 
   return (

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../../context/userContext';
 import {
@@ -10,14 +10,11 @@ import {
   } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
-// import { scrollToElementId } from '../../utils/ScrollToElementId';
-// import Validator from '../../utils/Validator';
 
 const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };
   const { signIn } = useContext(UserContext);
   const navigate = useNavigate();
-  const [errors, setErrors] = useState();
 
   // Form fields
   const formActions = {
@@ -87,11 +84,9 @@ const SignIn = (userDetails) => {
         <h1 className="govuk-heading-l" data-testid="signin-h1">Sign in</h1>
         <DisplayForm
           formId='formSignIn'
-          errors={errors}
           fields={formFields}
           formActions={formActions}
           handleSubmit={handleSubmit}
-          setErrors={setErrors}
         />
       </div>
     </div>

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   FIELD_TEXT,
@@ -8,12 +7,9 @@ import {
 } from '../../constants/AppConstants';
 import { DASHBOARD_PAGE_NAME, DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
-import { scrollToElementId } from '../../utils/ScrollToElementId';
-import Validator from '../../utils/Validator';
 
 const SecondPage = () => {
   const navigate = useNavigate();
-  const [errors, setErrors] = useState();
 
   const formActions = {
     submit: {
@@ -82,26 +78,18 @@ const SecondPage = () => {
     },
   ];
 
-  const handleSubmit = async (e, formData) => {
-    e.preventDefault();
-    const formErrors = await Validator({ formData: formData.formData, formFields: formFields });
-    setErrors(formErrors);
-
-    if (formErrors.length < 1) {
-      navigate(
-        FORM_CONFIRMATION_URL,
-        {
-          state: {
-            formName: 'Second page',
-            nextPageLink: DASHBOARD_URL,
-            nextPageName: DASHBOARD_PAGE_NAME,
-            referenceNumber: '123'
-          }
+  const handleSubmit = () => {
+    navigate(
+      FORM_CONFIRMATION_URL,
+      {
+        state: {
+          formName: 'Second page',
+          nextPageLink: DASHBOARD_URL,
+          nextPageName: DASHBOARD_PAGE_NAME,
+          referenceNumber: '123'
         }
-      );
-    } else {
-      scrollToElementId('formSecondPage');
-    }
+      }
+    );
   };
 
   return (
@@ -109,11 +97,9 @@ const SecondPage = () => {
       <h1>Second page</h1>
       <DisplayForm
         formId='formSecondPage'
-        errors={errors}
         fields={formFields}
         formActions={formActions}
         handleSubmit={handleSubmit}
-        setErrors={setErrors}
       />
     </div >
   );

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -78,7 +78,7 @@ const SecondPage = () => {
     },
   ];
 
-  const handleSubmit = () => {
+  const handleSubmit = ({ formData }) => {
     navigate(
       FORM_CONFIRMATION_URL,
       {
@@ -86,7 +86,7 @@ const SecondPage = () => {
           formName: 'Second page',
           nextPageLink: DASHBOARD_URL,
           nextPageName: DASHBOARD_PAGE_NAME,
-          referenceNumber: '123'
+          referenceNumber: `${formData.favouriteColour}-123`
         }
       }
     );


### PR DESCRIPTION
# Ticket

NMSW-160

----

## AC

Given I have entered valid answers in a form
When I click submit
And I then return back to the form
Then the form is clear (answers do not persist after submit)

----

## To test

- run app locally
- sign in
- go to second page form
- >  second page form form should be empty
- enter something in second page form form fields
- refresh page
- > values you entered should remain
- click submit
- > you should be taken to the confirmation page
- click to go to dashboard
- go back to  second page form
- > form should be empty


----

## Notes

Decided in the interest of not replicating code unnecessarily, and in the interest of reducing room for error, to move the validation call and error handling within the DisplayForm component
