### PR TITLE
NMSW-116 Start now should take user to dashboard if signed in

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,23 +2,22 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { SERVICE_NAME } from './constants/AppConstants.js';
-import { UserProvider } from './context/userContext';
 import App from './App.jsx';
 
 describe('App tests', () => {
-  it('should render the heading on the page', async () => {
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+  it('should render the heading on the page', () => {
+    render(<BrowserRouter><App /></BrowserRouter>);
     expect(screen.getByText('GOV.UK')).toBeInTheDocument();
     expect(screen.getByTestId('serviceName').textContent).toEqual(SERVICE_NAME);
   });
 
-  it('should render the phase banner on the page', async () => {
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+  it('should render the phase banner on the page', () => {
+    render(<BrowserRouter><App /></BrowserRouter>);
     expect(screen.getByTestId('phaseBannerText')).toHaveTextContent('This is a new service - your feedback will help us to improve it.');
   });
 
-  it('should render the footer on the page', async () => {
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+  it('should render the footer on the page', () => {
+    render(<BrowserRouter><App /></BrowserRouter>);
     expect(screen.getByText('© Crown copyright')).toBeInTheDocument();
     expect(screen.getByText('© Crown copyright').outerHTML).toEqual('<a class="govuk-footer__link govuk-footer__copyright-logo" target="_blank" rel="noreferrer noopener" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>');
     expect(screen.getByText('Cookies')).toBeInTheDocument();
@@ -29,8 +28,8 @@ describe('App tests', () => {
     expect(screen.getByText('Privacy').outerHTML).toEqual('<a class="govuk-footer__link" href="/privacy-notice">Privacy</a>');
   });
 
-  it('should render cookie banner when there is no cookiePreference cookie', async () => {
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+  it('should render cookie banner when there is no cookiePreference cookie', () => {
+    render(<BrowserRouter><App /></BrowserRouter>);
     const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
     const rejectButton = screen.getByRole('button', { name: 'Reject analytics cookies' });
 
@@ -42,7 +41,7 @@ describe('App tests', () => {
 
   it('should hide the cookie confirmation banner once hide cookie message is clicked after user accepts or rejects cookies', async () => {
       const user = userEvent.setup();
-      render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+      render(<BrowserRouter><App /></BrowserRouter>);
   
       const acceptButton = screen.getByRole('button', { name: 'Accept analytics cookies' });
       await user.click(acceptButton);
@@ -56,9 +55,9 @@ describe('App tests', () => {
       expect(screen.queryByRole('button', { name: 'Hide cookie message'})).not.toBeInTheDocument();
     });
 
-  it('should not render cookie banner when cookiePreference is true', async () => {
+  it('should not render cookie banner when cookiePreference is true', () => {
     document.cookie = 'cookiePreference=true';
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+    render(<BrowserRouter><App /></BrowserRouter>);
     const acceptButton = screen.queryByRole('button', { name: 'Accept analytics cookies' });
     const rejectButton = screen.queryByRole('button', { name: 'Reject analytics cookies' });
 
@@ -68,9 +67,9 @@ describe('App tests', () => {
     expect(screen.queryByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).not.toBeInTheDocument();
   });
 
-  it('should not render cookie banner when cookiePreference is false', async () => {
+  it('should not render cookie banner when cookiePreference is false', () => {
     document.cookie = 'cookiePreference=false';
-    render(<UserProvider><BrowserRouter><App /></BrowserRouter></UserProvider>);
+    render(<BrowserRouter><App /></BrowserRouter>);
     const acceptButton = screen.queryByRole('button', { name: 'Accept analytics cookies' });
     const rejectButton = screen.queryByRole('button', { name: 'Reject analytics cookies' });
 

--- a/src/layout/__tests__/Nav.test.jsx
+++ b/src/layout/__tests__/Nav.test.jsx
@@ -79,7 +79,7 @@ describe('Navigation within header tests', () => {
     expect(screen.getByTestId('listitem-SecondPage').outerHTML).toEqual('<li class="govuk-header__navigation-item" data-testid="listitem-SecondPage"><a class="govuk-header__link" href="/second-page">Second page</a></li>');
   });
 
-  it('should set highlight NO nav items if a new url is rendered and it does not relate to any of them', async () => {
+  it('should set highlight NO nav items if a new url is rendered and it does not relate to any of them', () => {
     mockedUserIsPermitted = true;
     render(<MemoryRouter><App /></MemoryRouter>);
     expect(screen.getByTestId('listitem-Dashboard').outerHTML).toEqual('<li class="govuk-header__navigation-item" data-testid="listitem-Dashboard"><a class="govuk-header__link" href="/dashboard">Dashboard</a></li>');

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -1,14 +1,18 @@
 import { Link } from 'react-router-dom';
 import { SERVICE_NAME } from '../../constants/AppConstants';
-import { SIGN_IN_URL } from '../../constants/AppUrlConstants';
+import { DASHBOARD_URL, SIGN_IN_URL } from '../../constants/AppUrlConstants';
+import useUserIsPermitted from '../../hooks/useUserIsPermitted';
 
 const Landing = () => {
+
+  const isAuthenticated = useUserIsPermitted();
+  
   return (
     <>
       <h1 className="govuk-heading-l" data-testid="landing-h1">{SERVICE_NAME}</h1>
       <p className="govuk-body">Use this service to:</p>
       <Link 
-        to={SIGN_IN_URL}
+        to={isAuthenticated ? DASHBOARD_URL : SIGN_IN_URL}
         role="button"
         draggable="false"
         className="govuk-button govuk-button--start"


### PR DESCRIPTION
# Ticket

NMSW-116

----

## AC

Given I am logged in
When I click on the service name
Then I should be taken to the landing page
When I click on the start now button on the landing page
Then I should be taken directly to the dashboard (not via the sign in page)

Given I am logged in
When I click on the GovUK logo
Then I should be taken to the landing page
When I click on the start now button on the landing page
Then I should be taken directly to the dashboard (not via the sign in page)

----

## To test

- run app locally
- go to localhost:3000
- click on start now
- > you should be taken to the sign in page (as you are not logged in)
- click on sign in
- you should see the dashboard
- click on the service name
- click on start now
- > you should be taken to the dashboard (as you are logged in)
- click on the govuk logo
- click on start now
- > you should be taken to the dashboard (as you are logged in)

----

## Notes
