### PR TITLE
Update cypress tests for cookie page radio

### DIFF
--- a/cypress/e2e/pages/cookie.page.js
+++ b/cypress/e2e/pages/cookie.page.js
@@ -1,11 +1,11 @@
 class CookiePage {
 
   get btnRadioYes() {
-    return cy.get('input[type="radio"][value="true"]');
+    return cy.get('input[type="radio"][value="yes"]');
   }
 
   get btnRadioNo() {
-    return cy.get('input[type="radio"][value="false"]');
+    return cy.get('input[type="radio"][value="no"]');
   }
 
   get formManageCookie() {
@@ -39,7 +39,7 @@ class CookiePage {
   }
 
   clickBtnRadioYes() {
-    this.btnRadioYes.check('true');
+    this.btnRadioYes.check('yes');
   }
 
   checkBtnRadioNo() {
@@ -48,7 +48,7 @@ class CookiePage {
   }
 
   clickBtnRadioNo() {
-    this.btnRadioNo.check('false');
+    this.btnRadioNo.check('no');
   }
 
   clickBtnSaveCookie() {


### PR DESCRIPTION
# Ticket

n/a

----

## AC

Update Cypress tests to use the new values for the yes/no radio buttons on the cookie page

----

## To test

Run Cypress tests, they should pass

----

## Notes

We changed the values from true/false to yes/no in a previous PR as they were causing problems elsewhere using strings for true and false
