### PR TITLE
WIP: Conditional fields attached to radio buttons

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -12,9 +12,32 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   const [errors, setErrors] = useState();
   const [fieldsWithValues, setFieldsWithValues] = useState();
   const [formData, setFormData] = useState({});
+  const [checkedOption, setCheckedOption] = useState();
   const [sessionData, setSessionData] = useState(JSON.parse(sessionStorage.getItem('formData')));
 
   const handleChange = (e) => {
+
+    // Couldn't find a good way to use multiple methods together to get the same result as this
+    const radioTemp = fieldsWithValues;
+    const selectedRadio = e.target.name;
+    const selectedRadioValue = e.target.value;
+    const foundSelected = radioTemp.find(object => object.fieldName === selectedRadio);
+    const radioValue = foundSelected.radioOptions.find(object => object.value === selectedRadioValue);
+    const checkedOption = {...radioValue, checked: true};
+
+    // console.log('selectedRadio', selectedRadio)
+    // console.log('foundSelected', foundSelected)
+    // console.log('radioValue', radioValue)
+    console.log('checkedValue', checkedOption);
+
+    // Tried setting classes here but they are not present on page load or reload - reads undefined as no change is made initially (caused issues on render)
+    // Probably a better way to do this? 🤔
+    if (checkedOption.checked && checkedOption.conditional) {
+      setCheckedOption(checkedOption);
+    } else {
+      setCheckedOption(false);
+    }
+
     if (errors) {
       // on change any error shown for that field should be cleared so find if field has an error & remove from error list
       const filteredErrors = errors?.filter(errorField => errorField.name !== e.target.name);
@@ -25,6 +48,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
       setSessionData({ ...sessionData, [e.target.name]: e.target.value });
       sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value }));
     }
+    // if conditional clicked - render conditional logic 
     // we do store all values into form data
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
@@ -33,7 +57,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
     e.preventDefault();
     const formErrors = await Validator({ formData: formData.formData, formFields: fields });
     setErrors(formErrors);
-    
+
     if (formErrors.length < 1) {
       /*
        * Returning formData
@@ -90,7 +114,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   useEffect(() => {
     let sessionDataArray;
     if (sessionData) {
-      sessionDataArray = Object.entries(sessionData).map(item => { return {name: item[0], value: item[1]}; });
+      sessionDataArray = Object.entries(sessionData).map(item => { return { name: item[0], value: item[1] }; });
     }
 
     const mappedFormFields = fields.map((field) => {
@@ -150,6 +174,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
             >
               {
                 determineFieldType({
+                  checkedOption: checkedOption,
                   error: error?.message,
                   fieldDetails: field,
                   parentHandleChange: handleChange,

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -3,10 +3,12 @@ import {
   FIELD_EMAIL,
   FIELD_PASSWORD,
   FIELD_TEXT,
-  FIELD_RADIO
+  FIELD_RADIO,
+  FIELD_CONDITIONAL
 } from '../../constants/AppConstants';
 import InputRadio from './InputRadio';
 import InputText from './InputText';
+import InputConditional from './InputConditional';
 
 const GroupedInputs = ({ error, fieldName, fieldToReturn, hint, label }) => {
   return (
@@ -44,7 +46,7 @@ const SingleInput = ({ error, fieldName, fieldToReturn, hint, label }) => {
   );
 };
 
-const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
+const determineFieldType = ({ checkedOption, error, fieldDetails, parentHandleChange }) => {
   let fieldToReturn;
   switch (fieldDetails.type) {
 
@@ -79,9 +81,19 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
 
     case FIELD_RADIO: fieldToReturn =
       <InputRadio
-         // there is no input level error styling on a radio button so we do not pass error down here
+        // there is no input level error styling on a radio button so we do not pass error down here
         fieldDetails={fieldDetails}
         handleChange={parentHandleChange}
+        type='radio'
+      />;
+      break;
+
+    case FIELD_CONDITIONAL: fieldToReturn =
+      <InputConditional
+        error={error}
+        fieldDetails={fieldDetails}
+        handleChange={parentHandleChange}
+        checkedOption={checkedOption}
         type='radio'
       />;
       break;

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -1,0 +1,86 @@
+import { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+const InputConditional = ({ autoComplete, error, fieldDetails, handleChange, type, checkedOption }) => {
+
+  const classToApplyGroup = error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group';
+  const classToApplyInput = error ? 'govuk-input govuk-!-width-one-half govuk-input--error' : 'govuk-input govuk-!-width-one-';
+  console.log(checkedOption);
+  return (
+    <div className={fieldDetails.className} data-module="govuk-radios">
+      {(fieldDetails.radioOptions).map((option, index) => {
+        const checkedState = fieldDetails.value === option.value ? true : option.checked;
+        // Sets class depending on checked state
+        const conditionalClass = checkedOption?.checked ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden';
+        // Makes sure the conditonal inputs open and close separately when clicked on
+        const showConditionalInput = checkedOption?.value === option.value ? true : false;
+        return (
+          <Fragment key={option.id}>
+            <div className="govuk-radios__item">
+              <input
+                className="govuk-radios__input"
+                id={`${option.name}-input[${index}]`}
+                autoComplete={autoComplete}
+                name={option.name}
+                value={option.value}
+                type={type}
+                onChange={handleChange}
+                defaultChecked={checkedState}
+                aria-describedby={option.hint ? `${fieldDetails.fieldName}${option.name}-hint` : null}
+              />
+              <label className="govuk-label govuk-radios__label" htmlFor={`${option.name}-input[${index}]`}>
+                {option.label}
+              </label>
+            </div>
+            {/* 
+            - If option with conditional is preseleted then it is not showing the input on refresh or page load
+            - checkedState does not change unless page is refreshed so if we select 'dog', refresh, then click on 'cat', the conditional field does not hide
+            */}
+            {showConditionalInput && <div className={conditionalClass}>
+              <div className={classToApplyGroup}>
+                <label className="govuk-label" htmlFor={`${option.conditionalName}-input`}>
+                  {option.conditionalLabel}
+                </label>
+                <p id={`${option.conditionalName}-error`} className="govuk-error-message">
+                  <span className="govuk-visually-hidden">Error:</span> {error}
+                </p>
+                <input
+                  className={classToApplyInput}
+                  id={`${option.conditionalName}-input`}
+                  name={option.conditionalName}
+                  type='text'
+                  onChange={handleChange}
+                  onPaste={handleChange}
+                />
+              </div>
+            </div>}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+InputConditional.propTypes = {
+  autoComplete: PropTypes.string,
+  fieldDetails: PropTypes.shape({
+    fieldName: PropTypes.string.isRequired,
+    hint: PropTypes.string,
+    className: PropTypes.string,
+    radioOptions: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+        checked: PropTypes.bool,
+        conditional: PropTypes.bool,
+        labelConditional: PropTypes.string,
+      })).isRequired,
+    value: PropTypes.string,
+  }).isRequired,
+  handleChange: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+};
+
+export default InputConditional;

--- a/src/components/formFields/InputConditionalBackup.jsx
+++ b/src/components/formFields/InputConditionalBackup.jsx
@@ -1,0 +1,74 @@
+// import PropTypes from 'prop-types';
+
+const InputConditional = ({ autoComplete, error, fieldDetails, handleChange, type }) => {
+
+  const classToApplyGroup = error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group';
+  const classToApplyInput = error ? 'govuk-input govuk-!-width-one-half govuk-input--error' : 'govuk-input govuk-!-width-one-half';
+  return (
+    <div className={fieldDetails.className} data-module="govuk-radios">
+        
+            <div className="govuk-radios__item" key={fieldDetails.id}>
+              <input
+                className="govuk-radios__input"
+                id={`${fieldDetails.fieldName}-input`}
+                autoComplete={autoComplete}
+                name={fieldDetails.name}
+                value={fieldDetails.value}
+                type={type}
+                onChange={handleChange}
+                aria-describedby={fieldDetails.hint ? `${fieldDetails.fieldName}-hint` : null}
+              />
+              <label className="govuk-label govuk-radios__label" htmlFor={`${fieldDetails.fieldName}-input`}>
+                {fieldDetails.label}
+              </label>
+            </div>
+            {/* 
+            -sPCR uses formData to check whether the field is clicked - not generic. How to instantly check whether the field selected? 
+            - checkedState only works after refresh
+            - Without it being conditional, the top level error will error on the conditional too
+            */}
+              <div className="govuk-radios__conditional">
+                <div className={classToApplyGroup} >
+                  <label className="govuk-label" htmlFor={`${fieldDetails.conditionalField.fieldName}-input`}>
+                    {fieldDetails.conditionalField.label}
+                  </label>
+                  <p id={`${fieldDetails.conditionalField.fieldName}-error`} className="govuk-error-message">
+                    <span className="govuk-visually-hidden">Error:</span> {error}
+                  </p>
+                  <input
+                    className={classToApplyInput}
+                    id={`${fieldDetails.conditionalField.fieldName}-input`}
+                    name={fieldDetails.conditionalField.fieldName}
+                    type='text'
+                    onChange={handleChange}
+                    onPaste={handleChange}
+                  />
+                </div>
+              </div>
+    </div>
+  );
+};
+
+// InputConditional.propTypes = {
+//   autoComplete: PropTypes.string,
+//   fieldDetails: PropTypes.shape({
+//     fieldName: PropTypes.string.isRequired,
+//     hint: PropTypes.string,
+//     className: PropTypes.string,
+//     radioOptions: PropTypes.arrayOf(
+//       PropTypes.shape({
+//         id: PropTypes.string.isRequired,
+//         name: PropTypes.string.isRequired,
+//         label: PropTypes.string.isRequired,
+//         value: PropTypes.string.isRequired,
+//         checked: PropTypes.bool,
+//         conditional: PropTypes.bool,
+//         labelConditional: PropTypes.string,
+//       })).isRequired,
+//     value: PropTypes.string,
+//   }).isRequired,
+//   handleChange: PropTypes.func.isRequired,
+//   type: PropTypes.string.isRequired,
+// };
+
+export default InputConditional;

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -6,6 +6,7 @@ export const FIELD_EMAIL = 'email';
 export const FIELD_PASSWORD = 'password';
 export const FIELD_TEXT = 'text';
 export const FIELD_RADIO = 'radio';
+export const FIELD_CONDITIONAL = 'conditional';
 // Forms: states
 export const CHECKED_TRUE = true;
 export const CHECKED_FALSE = false;

--- a/src/pages/TempPages/SecondPageBackup.jsx
+++ b/src/pages/TempPages/SecondPageBackup.jsx
@@ -38,7 +38,6 @@ const SecondPage = () => {
       type: FIELD_RADIO,
       label: 'What is your favourite colour',
       fieldName: 'favouriteColour',
-      className: 'govuk-radios',
       grouped: true,
       radioOptions: [
         {
@@ -79,57 +78,40 @@ const SecondPage = () => {
     },
     {
       type: FIELD_CONDITIONAL,
-      label: 'What is your favourite animal',
+      label: 'Cat',
       fieldName: 'favouriteAnimal',
-      className: 'govuk-radios',
-      grouped: true,
-      radioOptions: [
-        {
-          label: 'Cat',
-          name: 'favouriteAnimal',
-          id: 'cat',
-          value: 'cat',
-          checked: CHECKED_FALSE
-        },
-        {
-          label: 'Dog',
-          name: 'favouriteAnimal',
-          id: 'dog',
-          value: 'dog',
-          checked: CHECKED_FALSE,
-          conditional: true,
-          // Shows in form data storage but does not count as a field 
-          conditionalLabel: 'Enter your favourite dog',
-          conditionalName: 'favouriteAnimalDog',
-          conditionalId: 'favouriteAnimalDog',
-        },
-        // This field needs it's own validation, not getting it because it doesn't count as a field
-        {
-          label: 'Other',
-          name: 'favouriteAnimal',
-          id: 'other',
-          value: 'other',
-          checked: CHECKED_FALSE,
-          conditional: true,
-          // Shows in form data storage but does not count as a field 
-          conditionalLabel: 'Enter your favourite animal',
-          conditionalName: 'favouriteAnimalOther',
-          conditionalId: 'favouriteAnimalOther',
-          // validation: [
-          //   {
-          //     type: VALIDATE_REQUIRED,
-          //     message: 'Enter your favourite animal',
-          //   },
-          // ],
-        },
-      ],
+      value: 'cat',
+      checked: CHECKED_FALSE,
+      conditionalField: {
+        label: 'Enter your favourite type of cat',
+        fieldName: 'catBreed',
+        // validation: [
+        //   {
+        //     type: VALIDATE_REQUIRED,
+        //     message: 'Enter your favourite cat breed',
+        //   },
+        // ],
+      },
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Select your favourite animal',
+          message: 'Enter your favourite cat breed',
         },
       ],
     },
+
+    {
+      type: FIELD_TEXT,
+      label: 'Enter your favourite animal',
+      fieldName: 'favouriteAnimalOther',
+      className: 'govuk-radios__conditional govuk-radios__conditional--hidden',
+      // validation: [
+      //   {
+      //     type: VALIDATE_REQUIRED,
+      //     message: 'Enter your favourite animal',
+      //   },
+      // ],
+    }
   ];
 
   const handleSubmit = ({ formData }) => {

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -2,7 +2,7 @@ import {
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED,
-  } from '../constants/AppConstants';
+} from '../constants/AppConstants';
 
 const validateField = ({ type, value, condition }) => {
   switch (type) {
@@ -16,11 +16,11 @@ const validateField = ({ type, value, condition }) => {
         return 'error';
       }
       break;
-      case VALIDATE_EMAIL_ADDRESS:
-        if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
-          return 'error';
-        }
-        break;
+    case VALIDATE_EMAIL_ADDRESS:
+      if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
+        return 'error';
+      }
+      break;
     default: return 'valid';
   }
 };
@@ -30,6 +30,7 @@ const Validator = ({ formData, formFields }) => {
     const key = field[0];
     const value = field[1];
     const rules = formFields.find(field => field.fieldName === key).validation; // find all the rules for this field, if any
+    console.log(formFields.find(field => field.fieldName === key).validation);
 
     if (rules) {
       rules.map((rule) => {
@@ -48,7 +49,7 @@ const Validator = ({ formData, formFields }) => {
     return result;
   }, []);
 
-return errors;
+  return errors;
 };
 
 export default Validator;


### PR DESCRIPTION
# Ticket

NMSW-140

----

## AC

Given I am on a form with conditional fields
When I select an option that has a connected text input
Then I should see the connected text input
 
Given I am on a form with conditional fields
When I select an option that does not have the connected text input
Then I should not see the connected text input
 
Given I can see the connected text input
When I click submit
And I have not entered anything in the connected field
And the connected field is required
Then I should see an error message for this connected field
 
Given a connected field has an error
When a click on the error link in the error summary for that field
Then the page should scroll to the question
And the connected field should be in focus
 
Given I can see an error for the connected field
When I enter something in the connected field
Then the error should clear
 
Given there are no other errors
When I click submit
Then the form should submit as normal


----

## To test

- run app locally
- go to localhost:3000
- sign in
- go to second page form
- select 'other' from the radio buttons
- > you should see a new, connected text input
- click submit
- > you should see an error that you must enter something in the connected text input
- the connected input should be highlighted red along with the rest of the question
- the connected input should be focused on (or the related radio button)
- enter something in the field
- click submit
- > you should see the confirmation page

----

## Notes
