### PR TITLE
NMSW-33 Autocomplete input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nmsw-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nmsw-ui",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "accessible-autocomplete": "^2.0.4",
         "govuk-frontend": "^4.3.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -4937,6 +4938,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "dependencies": {
+        "preact": "^8.3.1"
       }
     },
     "node_modules/acorn": {
@@ -13776,6 +13785,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
+      "hasInstallScript": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -20163,6 +20178,14 @@
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
+      }
+    },
+    "accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "requires": {
+        "preact": "^8.3.1"
       }
     },
     "acorn": {
@@ -26631,6 +26654,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-dev-server": "^4.11.0"
   },
   "dependencies": {
+    "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "^4.3.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,4 +1,5 @@
 @import '~govuk-frontend/govuk/all';
+@import "accessible-autocomplete";
 
 // ===================
 // Layout Overrides

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -91,3 +91,12 @@ body {
 }
 
 
+// ===================
+// Form Overrides
+// ===================
+.autocomplete-input .autocomplete__wrapper input {
+  border-color:  $govuk-input-border-colour;
+}
+.autocomplete-input--error .autocomplete__wrapper input {
+  border-color:  $govuk-error-colour;
+}

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { FIELD_PASSWORD } from '../constants/AppConstants';
+import { EXPANDED_DETAILS, FIELD_PASSWORD } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
 import determineFieldType from './formFields/DetermineFieldType';
 import { scrollToElementId } from '../utils/ScrollToElementId';
@@ -25,7 +25,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
 
     // create the dataset to store, accounting for objects coming from autocomplete
     const dataSet = e.target.additionalDetails 
-      ? { [`${[e.target.name]}ExpandedDetails`]: e.target.additionalDetails, [e.target.name]: e.target.value }
+      ? { [`${[e.target.name]}${EXPANDED_DETAILS}`]: e.target.additionalDetails, [e.target.name]: e.target.value }
       :  { [e.target.name]: e.target.value };
 
     // we do not store passwords in session data

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -30,7 +30,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
 
     // we do not store passwords in session data
     if (e.target.name !== FIELD_PASSWORD) {
-      setSessionData({ ...sessionData, dataSet});
+      setSessionData({ ...sessionData, ...dataSet});
       sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, ...dataSet}));
     }
     // we do store all values into form data

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { EXPANDED_DETAILS, FIELD_PASSWORD } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
 import determineFieldType from './formFields/DetermineFieldType';
-import { scrollToElementId } from '../utils/ScrollToElementId';
+import { scrollToH1 } from '../utils/ScrollToElement';
 import Validator from '../utils/Validator';
 
 const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
@@ -52,7 +52,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
       handleSubmit(formData);
       sessionStorage.removeItem('formData');
     } else {
-      scrollToElementId(formId);
+      scrollToH1();
     }
   };
 

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DisplayForm from '../DisplayForm';
 import {
+  FIELD_AUTOCOMPLETE,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   FIELD_RADIO,
@@ -9,7 +10,7 @@ import {
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED,
-  } from '../../constants/AppConstants';
+} from '../../constants/AppConstants';
 
 /*
  * These tests check that we can pass a variety of
@@ -26,6 +27,7 @@ describe('Display Form', () => {
   const handleSubmit = jest.fn();
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+  // For action buttons
   const formActions = {
     submit: {
       className: 'govuk-button',
@@ -51,51 +53,35 @@ describe('Display Form', () => {
       type: 'button',
     },
   };
-  const formMandatoryTextInput = [
+  // For formFields
+  const formRequiredAutocompleteInput = [
     {
-      type: FIELD_TEXT,
-      label: 'Text input',
-      hint: 'This is a hint for a text input',
-      fieldName: 'testField',
+      type: FIELD_AUTOCOMPLETE,
+      label: 'Autocomplete input',
+      fieldName: 'items',
+      hint: 'Hint for Autocomplete input',
+      dataAPIEndpoint: [
+        {
+          name: 'ObjectOne',
+          identifier: 'one'
+        },
+        {
+          name: 'ObjectTwo',
+          identifier: 'two'
+        },
+        {
+          name: 'ObjectThree',
+          identifier: 'three'
+        },
+      ], // for while we're passing in a mocked array of data
+      responseKey: 'name',
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter your text input value',
+          message: 'Select your Autocomplete input item',
         },
       ],
-    }
-  ];
-  const formMinimumLengthTextInput = [
-    {
-      type: FIELD_TEXT,
-      label: 'Text input',
-      fieldName: 'testField',
-      validation: [
-        {
-          type: VALIDATE_MIN_LENGTH,
-          message: 'Field must be a minimum of 8 characters',
-          condition: 8,
-        },
-      ],
-    }
-  ];
-  const formMultipleValidationRules = [
-    {
-      type: FIELD_TEXT,
-      label: 'Text input',
-      fieldName: 'testField',
-      validation: [
-        {
-          type: VALIDATE_REQUIRED,
-          message: 'Enter your text input value',
-        },
-        {
-          type: VALIDATE_MIN_LENGTH,
-          message: 'Field must be a minimum of 8 characters',
-          condition: 8,
-        },
-      ],
-    }
+    },
   ];
   const formRequiredRadioInput = [
     {
@@ -136,6 +122,20 @@ describe('Display Form', () => {
       ],
     },
   ];
+  const formRequiredTextInput = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      hint: 'This is a hint for a text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+      ],
+    }
+  ];
   const formSpecialInputs = [
     {
       type: FIELD_TEXT,
@@ -168,10 +168,25 @@ describe('Display Form', () => {
   ];
   const formWithMultipleFields = [
     {
-      type: FIELD_TEXT,
-      label: 'Text input',
-      hint: 'This is a hint for a text input',
-      fieldName: 'testField',
+      type: FIELD_AUTOCOMPLETE,
+      label: 'Autocomplete input',
+      fieldName: 'items',
+      hint: 'Hint for Autocomplete input',
+      dataAPIEndpoint: [
+        {
+          name: 'ObjectOne',
+          identifier: 'one'
+        },
+        {
+          name: 'ObjectTwo',
+          identifier: 'two'
+        },
+        {
+          name: 'ObjectThree',
+          identifier: 'three'
+        },
+      ], // for while we're passing in a mocked array of data
+      responseKey: 'name',
     },
     {
       type: FIELD_PASSWORD,
@@ -202,17 +217,57 @@ describe('Display Form', () => {
         },
       ]
     },
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      hint: 'This is a hint for a text input',
+      fieldName: 'testField',
+    },
+  ];
+  // For formFields.validation
+  const formMinimumLengthTextInput = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_MIN_LENGTH,
+          message: 'Field must be a minimum of 8 characters',
+          condition: 8,
+        },
+      ],
+    }
+  ];
+  const formMultipleValidationRules = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+        {
+          type: VALIDATE_MIN_LENGTH,
+          message: 'Field must be a minimum of 8 characters',
+          condition: 8,
+        },
+      ],
+    }
   ];
 
   beforeEach(() => {
     window.sessionStorage.clear();
   });
 
+  // Action buttons
   it('should render a submit and cancel button if both exist', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActions}
         handleSubmit={handleSubmit}
       />
@@ -225,7 +280,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -239,7 +294,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -252,18 +307,20 @@ describe('Display Form', () => {
     expect(handleSubmit).toHaveBeenCalled();
   });
 
-  it('should render a text input', () => {
+  // Render field by type
+  it('should render an autocomplete input', async () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredAutocompleteInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
     );
-    expect(screen.getByLabelText('Text input')).toBeInTheDocument();
-    expect(screen.getByText('This is a hint for a text input').outerHTML).toEqual('<div id="testField-hint" class="govuk-hint">This is a hint for a text input</div>');
-    expect(screen.getByRole('textbox', { name: 'Text input' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Autocomplete input')).toBeInTheDocument();
+    expect(screen.getByText('Hint for Autocomplete input').outerHTML).toEqual('<div id="items-hint" class="govuk-hint">Hint for Autocomplete input</div>');
+    expect(screen.getByRole('combobox', { name: 'Autocomplete input' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
   });
 
   it('should render a radio button input', () => {
@@ -283,6 +340,20 @@ describe('Display Form', () => {
     expect(screen.getByRole('radio', { name: 'Radio one' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Radio two' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Radio three' })).toBeInTheDocument();
+  });
+
+  it('should render a text input', () => {
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formRequiredTextInput}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByLabelText('Text input')).toBeInTheDocument();
+    expect(screen.getByText('This is a hint for a text input').outerHTML).toEqual('<div id="testField-hint" class="govuk-hint">This is a hint for a text input</div>');
+    expect(screen.getByRole('textbox', { name: 'Text input' })).toBeInTheDocument();
   });
 
   it('should render the special input types', () => {
@@ -308,12 +379,13 @@ describe('Display Form', () => {
     expect(screen.getByTestId('password-passwordField')).toBeInTheDocument();
   });
 
+  // Render & manage errors
   it('should render error summary & field error if there are field errors', async () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -374,7 +446,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -408,7 +480,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -421,9 +493,10 @@ describe('Display Form', () => {
     await user.type(screen.getByRole('textbox', { name: 'Text input' }), 'Hello');
     // error class and message is cleared
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
-    
+
   });
 
+  // Store, prefill, and clear during session
   it('should store form data in the session for use on refresh', async () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo"}';
@@ -439,6 +512,7 @@ describe('Display Form', () => {
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
     await user.click(screen.getByRole('radio', { name: 'Radio two' }));
     expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 
@@ -476,6 +550,28 @@ describe('Display Form', () => {
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 
+  it('should store expanded data if it is provided from an autocomplete field', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","itemsExpandedDetails":{"items":{"name":"ObjectTwo","identifier":"two"}},"items":"ObjectTwo"}';
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.type(screen.getByLabelText('Text input'), 'Hello');
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
+    await user.click(screen.getByRole('radio', { name: 'Radio two' }));
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    await user.type(screen.getByRole('combobox', { name: 'Autocomplete input' }), 'Object');
+    await user.click(screen.getByText('ObjectTwo'));
+    expect(screen.getByRole('combobox', { name: 'Autocomplete input' })).toHaveValue('ObjectTwo');
+
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
+
   it('should clear session data when form is ready to submit', async () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
@@ -497,3 +593,4 @@ describe('Display Form', () => {
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });
+

--- a/src/components/formFields/AutocompleteSuggester.jsx
+++ b/src/components/formFields/AutocompleteSuggester.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import Autocomplete from 'accessible-autocomplete/react';
+// import { portList } from '../../pages/TempPages/TempMockList-port';
+import { countries } from '../../pages/TempPages/TempMockList-country';
+
+// there is an open PR to fix the aria-activedescendent issue: 
+// https://github.com/alphagov/accessible-autocomplete/issues/434
+// https://github.com/alphagov/accessible-autocomplete/pull/553/files
+
+// The aria-activedescendent looks to work correctly, if you use your mouse to select an item from the list
+// then aria-activedescendent's value changes and voice over reads it out correctly
+// The error occurs because when the combobox pop up (list) is closed, the value of aria-activedescendent is set to = 'false'
+// and false is an invalid value for it.
+
+// some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
+
+const Sugggester = () => {
+  // needs to take in
+    // defaultValue - for if there is a value to prepop
+    // endpoint for getting data
+    // response key to show (or if statement if merged) if statement (so for port, we have if statement around unlocode perhaps, for country it's just result = name)
+  
+
+  // userQuery is what user is typing
+
+
+
+  const defaultValue = ''; // can assume we pass this in on props
+  const [currentValue, setCurrentValue] = useState(defaultValue);
+
+  const suggest = (userQuery, populateResults) => {
+    // We should look at using lodash.debounce to prevent calls being made too fast as user types
+    // We also need to add in a restrictor so we only start searching once a user has entered the second character
+    
+    // this will be replaced with the api call to return the first [x] values of the dataset
+    const apiResponseData = countries;
+
+    // adding a filter in here to mimic the userQuery being used to get a response
+    // this will be replaced with the api call to return a filtered dataset based on the userQuery
+    const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
+
+    // this is part of the Autocomplete componet and how we return results to the list
+    populateResults(filteredResults);
+  };
+
+  const handleOnConfirm = (e) => {
+    setCurrentValue(e);
+  };
+
+  function template(result) {
+    // using just a source list and not the templates in the autocomplete component results in console errors
+    // related to specifying the input as `readonly` instead of `readOnly` and therefore the value being invalid
+    // using the templates method to populate the list removes those errors
+    // we can also use the template function to format the unlocode/name into a valid string
+
+    // if result is null (i.e. user has not typed in the field, and there's no default port) do nothing
+    if (!result) {
+      return;
+    }
+    let response;
+    response = result.name;
+    // if (result.unlocode) { 
+    //   response = `${result.name} (${result.unlocode})`;
+    // } else if (result.name) {
+    //   response = result.name;
+    // } else { 
+    //   response = result;
+    // }
+
+    return response;
+  }
+
+  return (
+    <>
+      <label htmlFor="autocomplete">Default value</label>
+      <Autocomplete
+        id="autocomplete"
+        name="defaultValue"
+        defaultValue={currentValue}
+        showNoOptionsFound={false}
+        source={suggest}
+        templates={{
+          inputValue: template,
+          suggestion: template,
+        }}
+        onConfirm={(e) => handleOnConfirm(e)}
+      />
+    </>
+  );
+};
+
+export default Sugggester;

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -6,7 +6,7 @@ import {
   FIELD_TEXT,
   FIELD_RADIO
 } from '../../constants/AppConstants';
-import AutocompleteSuggester from './AutocompleteSuggester';
+import InputAutocomplete from './InputAutocomplete';
 import InputRadio from './InputRadio';
 import InputText from './InputText';
 
@@ -61,7 +61,7 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
       break;
 
     case FIELD_AUTOCOMPLETE: fieldToReturn =
-      <AutocompleteSuggester
+      <InputAutocomplete
         autoComplete='email'
         error={error} // if error true, error styling applied to input
         fieldDetails={fieldDetails}

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 import {
+  FIELD_AUTOCOMPLETE,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   FIELD_TEXT,
   FIELD_RADIO
 } from '../../constants/AppConstants';
+import AutocompleteSuggester from './AutocompleteSuggester';
 import InputRadio from './InputRadio';
 import InputText from './InputText';
 
@@ -58,6 +60,16 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
       />;
       break;
 
+    case FIELD_AUTOCOMPLETE: fieldToReturn =
+      <AutocompleteSuggester
+        autoComplete='email'
+        error={error} // if error true, error styling applied to input
+        fieldDetails={fieldDetails}
+        handleChange={parentHandleChange}
+        type='autocomplete'
+      />;
+      break;
+
     case FIELD_PASSWORD: fieldToReturn =
       <InputText
         error={error}
@@ -65,15 +77,6 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
         handleChange={parentHandleChange}
         type='password'
         dataTestid={`${fieldDetails.fieldName}-passwordField`}
-      />;
-      break;
-
-    case FIELD_TEXT: fieldToReturn =
-      <InputText
-        error={error}
-        fieldDetails={fieldDetails}
-        handleChange={parentHandleChange}
-        type='text'
       />;
       break;
 
@@ -85,6 +88,15 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
         type='radio'
       />;
       break;
+
+      case FIELD_TEXT: fieldToReturn =
+        <InputText
+          error={error}
+          fieldDetails={fieldDetails}
+          handleChange={parentHandleChange}
+          type='text'
+        />;
+        break;
 
     default: fieldToReturn = null;
   }

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -29,7 +29,6 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
 
   const suggest = (userQuery, populateResults) => {
     // We should look at using lodash.debounce to prevent calls being made too fast as user types
-    // We also need to add in a restrictor so we only start searching once a user has entered the second character
     
     // this will be replaced with the api call to return the first [x] values of the dataset
     const apiResponseData = countries;
@@ -90,9 +89,10 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
     <>
       <Autocomplete
         data-testid={dataTestid}
-        id={`${fieldDetails.fieldName}-input`}
-        name={fieldDetails.fieldName}
         defaultValue={currentValue}
+        id={`${fieldDetails.fieldName}-input`}
+        minLength={2}
+        name={fieldDetails.fieldName}
         showNoOptionsFound={false}
         source={suggest}
         templates={{

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -125,6 +125,7 @@ const InputAutocomplete = ({ error, fieldDetails, handleChange }) => {
 };
 
 InputAutocomplete.propTypes = {
+  error: PropTypes.string,
   fieldDetails: PropTypes.shape({
     // dataAPIEndpoint: PropTypes.string.isRequired, // when we implement the endpoint
     dataAPIEndpoint: PropTypes.array.isRequired, // for while we're passing in a mocked array of data

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -74,7 +74,7 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
     handleChange(formattedEvent);
   };
 
-  // See issue#424 at alphagov/accessible-autocomplete
+  // See issue#424, #495, at alphagov/accessible-autocomplete
   // There is an ongoing issue around setting defaultValue when using template
   // whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
   // it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import Autocomplete from 'accessible-autocomplete/react';
 // import { portList } from '../../pages/TempPages/TempMockList-port';
 import { countries } from '../../pages/TempPages/TempMockList-country';
@@ -14,7 +15,7 @@ import { countries } from '../../pages/TempPages/TempMockList-country';
 
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
-const Sugggester = () => {
+const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   // needs to take in
     // defaultValue - for if there is a value to prepop
     // endpoint for getting data
@@ -22,10 +23,10 @@ const Sugggester = () => {
   
 
   // userQuery is what user is typing
+  console.log(error);
 
 
-
-  const defaultValue = ''; // can assume we pass this in on props
+  const defaultValue = fieldDetails.value ||''; // can assume we pass this in on props
   const [currentValue, setCurrentValue] = useState(defaultValue);
 
   const suggest = (userQuery, populateResults) => {
@@ -72,10 +73,10 @@ const Sugggester = () => {
 
   return (
     <>
-      <label htmlFor="autocomplete">Default value</label>
       <Autocomplete
-        id="autocomplete"
-        name="defaultValue"
+        data-testid={dataTestid}
+        id={`${fieldDetails.fieldName}-input`}
+        name={fieldDetails.fieldName}
         defaultValue={currentValue}
         showNoOptionsFound={false}
         source={suggest}
@@ -84,9 +85,21 @@ const Sugggester = () => {
           suggestion: template,
         }}
         onConfirm={(e) => handleOnConfirm(e)}
+        onChange={handleChange}
       />
     </>
   );
+};
+
+Sugggester.propTypes = {
+  dataTestid: PropTypes.string,
+  error: PropTypes.string,
+  fieldDetails: PropTypes.shape({
+    fieldName: PropTypes.string.isRequired,
+    hint: PropTypes.string,
+    value: PropTypes.string,
+  }).isRequired,
+  handleChange: PropTypes.func.isRequired,
 };
 
 export default Sugggester;

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -10,21 +10,20 @@ import Autocomplete from 'accessible-autocomplete/react';
 // then aria-activedescendent's value changes and voice over reads it out correctly
 // The error occurs because when the combobox pop up (list) is closed, the value of aria-activedescendent is set to = 'false'
 // and false is an invalid value for it.
-
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
-const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
+const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) => {
   console.log('error', error);
   const responseKey = fieldDetails.responseKey;
   const [currentValue, setCurrentValue] = useState(fieldDetails.value || '');
 
   const suggest = (userQuery, populateResults) => {
-    // We should look at using lodash.debounce to prevent calls being made too fast as user types
-    // apiResponseData will be replaced with the api call to return the first [x] values of the dataset
+    // TODO: We should look at using lodash.debounce to prevent calls being made too fast as user types
+    // TODO: apiResponseData will be replaced with the api call to return the first [x] values of the dataset
     const apiResponseData = fieldDetails.dataAPIEndpoint;
 
     // adding a filter in here to mimic the userQuery being used to get a response
-    // filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
+    // TODO: filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
     const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
 
     // this is part of the Autocomplete componet and how we return results to the list
@@ -54,7 +53,7 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
       // this occurs when there is a defaultValue on page render
       response = currentValue;
     } else {
-      // this covered when user hasn't typed in field yet / field is null
+      // this covers when user hasn't typed in field yet / field is null
       return;
     }
     
@@ -95,11 +94,12 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   );
 };
 
-Sugggester.propTypes = {
+InputAutocomplete.propTypes = {
   dataTestid: PropTypes.string,
   error: PropTypes.string,
   fieldDetails: PropTypes.shape({
-    dataAPIEndpoint: PropTypes.string.isRequired,
+    // dataAPIEndpoint: PropTypes.string.isRequired, // when we implement the endpoint
+    dataAPIEndpoint: PropTypes.array.isRequired, // for while we're passing in a mocked array of data
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
     responseKey: PropTypes.string.isRequired,
@@ -108,4 +108,4 @@ Sugggester.propTypes = {
   handleChange: PropTypes.func.isRequired,
 };
 
-export default Sugggester;
+export default InputAutocomplete;

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -16,18 +16,16 @@ import { countries } from '../../pages/TempPages/TempMockList-country';
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
 const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
+  console.log(error);
   // needs to take in
     // defaultValue - for if there is a value to prepop
     // endpoint for getting data
     // response key to show (or if statement if merged) if statement (so for port, we have if statement around unlocode perhaps, for country it's just result = name)
-  
+    const responseKey = 'name';
 
   // userQuery is what user is typing
-  console.log(error);
 
-
-  const defaultValue = fieldDetails.value ||''; // can assume we pass this in on props
-  const [currentValue, setCurrentValue] = useState(defaultValue);
+  const [currentValue, setCurrentValue] = useState(fieldDetails.value || '');
 
   const suggest = (userQuery, populateResults) => {
     // We should look at using lodash.debounce to prevent calls being made too fast as user types
@@ -45,6 +43,9 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   };
 
   const handleOnConfirm = (e) => {
+    // we replicate the e.target.name and e.target.value that other input fields return, so we can return this value in the same format
+    const target = {target: { name: fieldDetails.fieldName, value: e.name }};
+    handleChange(target);
     setCurrentValue(e);
   };
 
@@ -55,11 +56,19 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
     // we can also use the template function to format the unlocode/name into a valid string
 
     // if result is null (i.e. user has not typed in the field, and there's no default port) do nothing
-    if (!result) {
+    console.log('result', result);
+    let response;
+    if (result) {
+      response = result[responseKey];
+    } else {
       return;
     }
-    let response;
-    response = result.name;
+    // if (!result) {
+    //   return;
+    // }
+    // let response;
+    // response = result?.name;
+    // console.log('response', response)
     // if (result.unlocode) { 
     //   response = `${result.name} (${result.unlocode})`;
     // } else if (result.name) {
@@ -85,7 +94,6 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
           suggestion: template,
         }}
         onConfirm={(e) => handleOnConfirm(e)}
-        onChange={handleChange}
       />
     </>
   );

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -50,7 +50,11 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
     let response;
     if (result && result[responseKey]) {
       // this occurs when user has typed in the field
-      response = result[responseKey];
+      if (fieldDetails.additionalKey && result[fieldDetails.additionalKey]) {
+        response = `${result[responseKey]} ${result[fieldDetails.additionalKey]}`;
+      } else {
+        response = result[responseKey];
+      }
     } else if (result) {
       // this occurs when there is a defaultValue on page render
       response = currentValue;
@@ -105,7 +109,7 @@ InputAutocomplete.propTypes = {
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
     responseKey: PropTypes.string.isRequired,  // a field that always exists in the dataset that we can use as a key for returning results
-    additionalKeys: PropTypes.array,  // optional other fields that we want to append to the returned result if it exists in the dataset
+    additionalKey: PropTypes.string,  // optional other field that we want to append to the returned result if it exists in the dataset (e.g. country ISO code, unlocode)
     value: PropTypes.string,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -43,9 +43,10 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   };
 
   const handleOnConfirm = (e) => {
+    if (!e) { return; }
     // we replicate the e.target.name and e.target.value that other input fields return, so we can return this value in the same format
-    const target = {target: { name: fieldDetails.fieldName, value: e.name }};
-    handleChange(target);
+    const resposeMimickingE = {target: { name: fieldDetails.fieldName, value: e[responseKey] }};
+    handleChange(resposeMimickingE);
     setCurrentValue(e[responseKey]);
   };
 
@@ -56,13 +57,7 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
     // we can also use the template function to format the unlocode/name into a valid string
     // for more details see https://github.com/alphagov/accessible-autocomplete
 
-    // if result is null (i.e. user has not typed in the field, and there's no default port) do nothing
     let response;
-
-    // there is no result : user hasn't typed anything/field is null
-    // there is a result but result[responseKey] is undefined : we have a default value/current value
-    // there is a result with result[responseKey] : user has typed
-
     if (result && result[responseKey]) {
       // this occurs when user has typed in the field
       response = result[responseKey];
@@ -73,16 +68,6 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
       // this covered when user hasn't typed in field yet / field is null
       return;
     }
-
-
-    // if (!result) {
-    //   console.log('result', 'no', result)
-    // } else {
-    //   console.log('result', 'yes', result[responseKey])
-    //   console.log('result', 'result', result)
-    //   // console.log({currentValue})
-    //   response = result[responseKey];
-    // }
     
     // if (!result) {
     //   return;

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -14,26 +14,30 @@ import Autocomplete from 'accessible-autocomplete/react';
 
 const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) => {
   console.log('error', error);
+  // TODO: defaultValue just setting the name
+  // problem happening in I think the template function
+  // I would expect it to return nothing, but it's returning undefined
+  // Preference is for the dropdown to behave as it does after you select an item e.g. doesn't show again until two more keystrokes
 
   const [currentValue, setCurrentValue] = useState(fieldDetails.value || '');
   const responseKey = fieldDetails.responseKey;
 
-
   const suggest = (userQuery, populateResults) => {
+    if (!userQuery) { return; }
     // TODO: We should look at using lodash.debounce to prevent calls being made too fast as user types
     // TODO: apiResponseData will be replaced with the api call to return the first [x] values of the dataset
     const apiResponseData = fieldDetails.dataAPIEndpoint;
 
     // adding a filter in here to mimic the userQuery being used to get a response
     // TODO: filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
-    const filteredResults = userQuery ? apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase()))) : null;
+    const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
 
     // this is part of the Autocomplete componet and how we return results to the list
     populateResults(filteredResults);
   };
 
   const handleOnConfirm = (e) => {
-    if (!e ) { return; }
+    if (!e) { return; }
     let displayValue;
     if (fieldDetails.additionalKey && e[fieldDetails.additionalKey]) {
       displayValue = `${e[responseKey]} ${e[fieldDetails.additionalKey]}`;
@@ -63,9 +67,6 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
       } else {
         response = result[responseKey];
       }
-    } else if (result) {
-      // this occurs when there is a defaultValue on page render
-      response = currentValue;
     } else {
       // this covers when user hasn't typed in field yet / field is null
       return;

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -13,10 +13,9 @@ import { useEffect } from 'react';
 // and false is an invalid value for it.
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
-const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) => {
-  console.log('renderpage', error);
+const InputAutocomplete = ({ dataTestid, fieldDetails, handleChange }) => {
   const responseKey = fieldDetails.responseKey;
-  const [hideCombo, setHideCombo] = useState(false);
+  const [hideCombo, setHideCombo] = useState(false); // only used for defaultValue bug workaround
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -34,6 +33,9 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
 
 
   const template = (result) => {
+    // as the user types their query, this formats what is displayed in the input (inputValue)
+    // and combolist suggestions (suggestion)
+    // result being from the results of the suggest function
     let response;
     if (result && result[responseKey]) {
       // this occurs when user has typed in the field
@@ -53,14 +55,16 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
     if (!e) { return; }
     let displayValue;
 
-    // For when we want to show concatenated value e.g. port name + port unlocode
+    // Returns either a concatenated value if required and available e.g. port name + port unlocode
+    // Or the single string e.g. ports without a unlocode, field that does not have an additionalKey set
     if (fieldDetails.additionalKey && e[fieldDetails.additionalKey]) {
       displayValue = `${e[responseKey]} ${e[fieldDetails.additionalKey]}`;
     } else {
       displayValue = e[responseKey];
     }
 
-    // Formatted to send both the display value, and any additional field object information received from the API
+    // We want to include both the display value, and any additional field object information received from the API
+    // So the page's handleSubmit can decide what to send on the POST/PUT call
     const formattedEvent = {
       target: {
         name: fieldDetails.fieldName,

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -26,27 +26,35 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
 
     // adding a filter in here to mimic the userQuery being used to get a response
     // TODO: filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
-    const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
+    const filteredResults = userQuery ? apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase()))) : null;
 
     // this is part of the Autocomplete componet and how we return results to the list
     populateResults(filteredResults);
   };
 
   const handleOnConfirm = (e) => {
-    if (!e) { return; }
-    // we replicate the e.target.name and e.target.value that other input fields return, so we can return this value in the same format
-    const resposeMimickingE = {target: { name: fieldDetails.fieldName, value: e[responseKey] }};
-    handleChange(resposeMimickingE);
+    if (!e ) { return; }
+    let displayValue;
+    if (fieldDetails.additionalKey && e[fieldDetails.additionalKey]) {
+      displayValue = `${e[responseKey]} ${e[fieldDetails.additionalKey]}`;
+    } else {
+      displayValue = e[responseKey];
+    }
+
+    const formattedEvent = {
+      target: {
+        name: fieldDetails.fieldName,
+        value: displayValue,
+        additionalDetails: {
+          [fieldDetails.fieldName]: e
+        },
+      }
+    };
+    handleChange(formattedEvent);
     setCurrentValue(e[responseKey]);
   };
 
   function template(result) {
-    // using just a source list and not the templates in the autocomplete component results in console errors
-    // related to specifying the input as `readonly` instead of `readOnly` and therefore the value being invalid
-    // using the templates method to populate the list removes those errors
-    // we can also use the template function to format the unlocode/name into a valid string
-    // for more details see https://github.com/alphagov/accessible-autocomplete
-
     let response;
     if (result && result[responseKey]) {
       // this occurs when user has typed in the field
@@ -62,24 +70,15 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
       // this covers when user hasn't typed in field yet / field is null
       return;
     }
-    
-    // if (!result) {
-    //   return;
-    // }
-    // let response;
-    // response = result?.name;
-    // console.log('response', response)
-    // if (result.unlocode) { 
-    //   response = `${result.name} (${result.unlocode})`;
-    // } else if (result.name) {
-    //   response = result.name;
-    // } else { 
-    //   response = result;
-    // }
 
     return response;
   }
 
+  // using just a source list and not the templates in the autocomplete component results in console errors
+  // related to specifying the input as `readonly` instead of `readOnly` and therefore the value being invalid
+  // using the templates method to populate the list removes those errors
+  // we can also use the template function to format the unlocode/name into a valid string
+  // for more details see https://github.com/alphagov/accessible-autocomplete
   return (
     <>
       <Autocomplete

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -14,8 +14,10 @@ import Autocomplete from 'accessible-autocomplete/react';
 
 const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) => {
   console.log('error', error);
-  const responseKey = fieldDetails.responseKey;
+
   const [currentValue, setCurrentValue] = useState(fieldDetails.value || '');
+  const responseKey = fieldDetails.responseKey;
+
 
   const suggest = (userQuery, populateResults) => {
     // TODO: We should look at using lodash.debounce to prevent calls being made too fast as user types
@@ -102,7 +104,8 @@ InputAutocomplete.propTypes = {
     dataAPIEndpoint: PropTypes.array.isRequired, // for while we're passing in a mocked array of data
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
-    responseKey: PropTypes.string.isRequired,
+    responseKey: PropTypes.string.isRequired,  // a field that always exists in the dataset that we can use as a key for returning results
+    additionalKeys: PropTypes.array,  // optional other fields that we want to append to the returned result if it exists in the dataset
     value: PropTypes.string,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -13,9 +13,9 @@ import { useEffect } from 'react';
 // and false is an invalid value for it.
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
-const InputAutocomplete = ({ dataTestid, fieldDetails, handleChange }) => {
+const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   const responseKey = fieldDetails.responseKey;
-  const [hideCombo, setHideCombo] = useState(false); // only used for defaultValue bug workaround
+  const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -89,15 +89,15 @@ const InputAutocomplete = ({ dataTestid, fieldDetails, handleChange }) => {
       return;
     }
     document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
-    setHideCombo(true);
+    setHideListBox(true);
   },[fieldDetails.value]);
 
   useEffect(() => {
-    if (hideCombo) {
+    if (hideListBox) {
       document.getElementById(`${fieldDetails.fieldName}-input__listbox`).className = 'autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden';
-      setHideCombo(false);
+      setHideListBox(false);
     }
-  }, [hideCombo]);
+  }, [hideListBox]);
 
   // We need to use the template function to handle our results coming in objects
   // this lets us format the strings to display as we like
@@ -109,7 +109,6 @@ const InputAutocomplete = ({ dataTestid, fieldDetails, handleChange }) => {
     <>
       <Autocomplete
         confirmOnBlur={false}
-        data-testid={dataTestid}
         id={`${fieldDetails.fieldName}-input`}
         minLength={2}
         name={fieldDetails.fieldName}
@@ -125,8 +124,6 @@ const InputAutocomplete = ({ dataTestid, fieldDetails, handleChange }) => {
 };
 
 InputAutocomplete.propTypes = {
-  dataTestid: PropTypes.string,
-  error: PropTypes.string,
   fieldDetails: PropTypes.shape({
     // dataAPIEndpoint: PropTypes.string.isRequired, // when we implement the endpoint
     dataAPIEndpoint: PropTypes.array.isRequired, // for while we're passing in a mocked array of data

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -16,7 +16,7 @@ import { countries } from '../../pages/TempPages/TempMockList-country';
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
 const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
-  console.log(error);
+  console.log('error', error);
   // needs to take in
     // defaultValue - for if there is a value to prepop
     // endpoint for getting data
@@ -46,7 +46,7 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
     // we replicate the e.target.name and e.target.value that other input fields return, so we can return this value in the same format
     const target = {target: { name: fieldDetails.fieldName, value: e.name }};
     handleChange(target);
-    setCurrentValue(e);
+    setCurrentValue(e[responseKey]);
   };
 
   function template(result) {
@@ -54,15 +54,36 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
     // related to specifying the input as `readonly` instead of `readOnly` and therefore the value being invalid
     // using the templates method to populate the list removes those errors
     // we can also use the template function to format the unlocode/name into a valid string
+    // for more details see https://github.com/alphagov/accessible-autocomplete
 
     // if result is null (i.e. user has not typed in the field, and there's no default port) do nothing
-    console.log('result', result);
     let response;
-    if (result) {
+
+    // there is no result : user hasn't typed anything/field is null
+    // there is a result but result[responseKey] is undefined : we have a default value/current value
+    // there is a result with result[responseKey] : user has typed
+
+    if (result && result[responseKey]) {
+      // this occurs when user has typed in the field
       response = result[responseKey];
+    } else if (result) {
+      // this occurs when there is a defaultValue on page render
+      response = currentValue;
     } else {
+      // this covered when user hasn't typed in field yet / field is null
       return;
     }
+
+
+    // if (!result) {
+    //   console.log('result', 'no', result)
+    // } else {
+    //   console.log('result', 'yes', result[responseKey])
+    //   console.log('result', 'result', result)
+    //   // console.log({currentValue})
+    //   response = result[responseKey];
+    // }
+    
     // if (!result) {
     //   return;
     // }

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Autocomplete from 'accessible-autocomplete/react';
-// import { portList } from '../../pages/TempPages/TempMockList-port';
-import { countries } from '../../pages/TempPages/TempMockList-country';
 
 // there is an open PR to fix the aria-activedescendent issue: 
 // https://github.com/alphagov/accessible-autocomplete/issues/434
@@ -23,7 +21,7 @@ const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   const suggest = (userQuery, populateResults) => {
     // We should look at using lodash.debounce to prevent calls being made too fast as user types
     // apiResponseData will be replaced with the api call to return the first [x] values of the dataset
-    const apiResponseData = countries;
+    const apiResponseData = fieldDetails.dataAPIEndpoint;
 
     // adding a filter in here to mimic the userQuery being used to get a response
     // filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -17,24 +17,16 @@ import { countries } from '../../pages/TempPages/TempMockList-country';
 
 const Sugggester = ({ dataTestid, error, fieldDetails, handleChange }) => {
   console.log('error', error);
-  // needs to take in
-    // defaultValue - for if there is a value to prepop
-    // endpoint for getting data
-    // response key to show (or if statement if merged) if statement (so for port, we have if statement around unlocode perhaps, for country it's just result = name)
-    const responseKey = 'name';
-
-  // userQuery is what user is typing
-
+  const responseKey = fieldDetails.responseKey;
   const [currentValue, setCurrentValue] = useState(fieldDetails.value || '');
 
   const suggest = (userQuery, populateResults) => {
     // We should look at using lodash.debounce to prevent calls being made too fast as user types
-    
-    // this will be replaced with the api call to return the first [x] values of the dataset
+    // apiResponseData will be replaced with the api call to return the first [x] values of the dataset
     const apiResponseData = countries;
 
     // adding a filter in here to mimic the userQuery being used to get a response
-    // this will be replaced with the api call to return a filtered dataset based on the userQuery
+    // filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
     const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
 
     // this is part of the Autocomplete componet and how we return results to the list
@@ -109,8 +101,10 @@ Sugggester.propTypes = {
   dataTestid: PropTypes.string,
   error: PropTypes.string,
   fieldDetails: PropTypes.shape({
+    dataAPIEndpoint: PropTypes.string.isRequired,
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
+    responseKey: PropTypes.string.isRequired,
     value: PropTypes.string,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -16,6 +16,7 @@ import { useEffect } from 'react';
 const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) => {
   console.log('renderpage', error);
   const responseKey = fieldDetails.responseKey;
+  const [hideCombo, setHideCombo] = useState(false);
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -31,6 +32,7 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
     populateResults(filteredResults);
   };
 
+
   const template = (result) => {
     let response;
     if (result && result[responseKey]) {
@@ -44,8 +46,6 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
       // this covers when user hasn't typed in field yet / field is null
       return;
     }
-
-    console.log('response', response)
     return response;
   };
 
@@ -77,21 +77,30 @@ const InputAutocomplete = ({ dataTestid, error, fieldDetails, handleChange }) =>
   // See issue#424 at alphagov/accessible-autocomplete
   // There is an ongoing issue around setting defaultValue when using template
   // whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
-  // it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur
+  // it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
   // the workaround is to use javascript to set the value of the input which forces the suggest to run
+  // TODO: when fixed on alphagov/accessible-autocomplete, fix here
   useEffect(() => {
-    console.log(fieldDetails.value);
     if (!fieldDetails.value) {
       return;
     }
     document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
+    setHideCombo(true);
   },[fieldDetails.value]);
 
-  // using just a source list and not the templates in the autocomplete component results in console errors
-  // related to specifying the input as `readonly` instead of `readOnly` and therefore the value being invalid
-  // using the templates method to populate the list removes those errors
-  // we can also use the template function to format the unlocode/name into a valid string
+  useEffect(() => {
+    if (hideCombo) {
+      document.getElementById(`${fieldDetails.fieldName}-input__listbox`).className = 'autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden';
+      setHideCombo(false);
+    }
+  }, [hideCombo]);
+
+  // We need to use the template function to handle our results coming in objects
+  // this lets us format the strings to display as we like
   // for more details see https://github.com/alphagov/accessible-autocomplete
+  // we want the input value & suggestion to show the same value so both call the template function to return the same value
+  // if we wanted to show different values we could call separate functions, or define them in the template function to return 
+  // different results
   return (
     <>
       <Autocomplete

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -13,7 +13,8 @@ import { useEffect } from 'react';
 // and false is an invalid value for it.
 // some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 
-const InputAutocomplete = ({ fieldDetails, handleChange }) => {
+const InputAutocomplete = ({ error, fieldDetails, handleChange }) => {
+  const classToApply = error ? 'autocomplete-input--error' : 'autocomplete-input';
   const responseKey = fieldDetails.responseKey;
   const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
 
@@ -106,7 +107,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   // if we wanted to show different values we could call separate functions, or define them in the template function to return 
   // different results
   return (
-    <>
+    <div className={classToApply}>
       <Autocomplete
         confirmOnBlur={false}
         id={`${fieldDetails.fieldName}-input`}
@@ -119,7 +120,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
         }}
         onConfirm={(e) => handleOnConfirm(e)}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/components/formFields/__tests__/InputAutcomplete.test.jsx
+++ b/src/components/formFields/__tests__/InputAutcomplete.test.jsx
@@ -1,0 +1,186 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InputAutocomplete from '../InputAutocomplete';
+
+/*
+ * These tests check that we can pass in the minimum parameters and it will generate the correct input field HTML
+ * And we can pass in the maximum parameters and it will generate the correct input field HTML
+ * It does NOT test that the full form field component with labels etc is generated
+ */
+
+describe('Text input field generation', () => {
+  const parentHandleChange = jest.fn();
+  const fieldDetailsBasic = {
+    // dataAPIEndpoint: 'theEndpointUrl' // when we implement the endpoint
+    dataAPIEndpoint: [
+      {
+        name: 'ObjectOne',
+        identifier: 'one'
+      },
+      {
+        name: 'ObjectTwo',
+        identifier: 'two'
+      },
+      {
+        name: 'ObjectThree',
+        identifier: 'three'
+      },
+    ], // for while we're passing in a mocked array of data
+    fieldName: 'fullFieldName',
+    responseKey: 'name',
+  };
+  const fieldDetailsAllProps = {
+    // dataAPIEndpoint: 'theEndpointUrl' // when we implement the endpoint
+    dataAPIEndpoint: [
+      {
+        name: 'ObjectOne',
+        identifier: 'one'
+      },
+      {
+        name: 'ObjectTwo',
+        identifier: 'two'
+      },
+      {
+        name: 'ObjectThree',
+        identifier: 'three'
+      },
+    ], // for while we're passing in a mocked array of data
+    fieldName: 'fullFieldName',
+    hint: 'The hint text',
+    responseKey: 'name',
+    additionalKey: 'identifier',
+    value: 'ObjectThree',
+  };
+  const fieldDetailsOneResponseKey = {
+    // dataAPIEndpoint: 'theEndpointUrl' // when we implement the endpoint
+    dataAPIEndpoint: [
+      {
+        name: 'ObjectOne',
+        identifier: 'one'
+      },
+      {
+        name: 'ObjectTwo',
+        identifier: 'two'
+      },
+      {
+        name: 'ObjectThree',
+        identifier: 'three'
+      },
+    ], // for while we're passing in a mocked array of data
+    fieldName: 'fullFieldName',
+    responseKey: 'name',
+  };
+  const fieldDetailsTwoResponseKeys = {
+    // dataAPIEndpoint: 'theEndpointUrl' // when we implement the endpoint
+    dataAPIEndpoint: [
+      {
+        name: 'ObjectOne',
+        identifier: 'one'
+      },
+      {
+        name: 'ObjectTwo',
+        identifier: 'two'
+      },
+      {
+        name: 'ObjectThree',
+        identifier: 'three'
+      },
+    ], // for while we're passing in a mocked array of data
+    fieldName: 'fullFieldName',
+    responseKey: 'name',
+    additionalKey: 'identifier'
+  };
+
+  it('should render the autocomplete input field  with only the required props', () => {
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsBasic}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="">');
+    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"></ul>');
+  });
+
+  it('should render the autocomplete input field with all props passed', () => {
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="">');
+    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"></ul>');
+  });
+  
+  it('should render the list options based on what the user enters', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsOneResponseKey}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+
+    await user.type(screen.getByRole('combobox', { name: '' }), 'Obje');
+    expect(screen.getByRole('combobox', { name: '' })).toHaveValue('Obje');
+    expect(screen.getByText('ObjectOne')).toBeInTheDocument();
+    expect(screen.getByText('ObjectTwo')).toBeInTheDocument();
+    expect(screen.getByText('ObjectThree')).toBeInTheDocument();
+  });
+
+  it('should return the concatenated value when the field has two response keys', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsTwoResponseKeys}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+
+    await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
+    expect(screen.getByText('ObjectOne one')).toBeInTheDocument();
+    expect(screen.getByText('ObjectTwo two')).toBeInTheDocument();
+    expect(screen.getByText('ObjectThree three')).toBeInTheDocument();
+  });
+
+  it('should update the value of the input if a selection is made from the list', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsTwoResponseKeys}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+
+    await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
+    await user.click(screen.getByText('ObjectTwo two'));
+    expect(screen.getByRole('combobox', { name: '' })).toHaveValue('ObjectTwo two');
+  });
+
+  // TODO: when the autocomplete defaultValue issue is fixed, update the test here to test it is passed in correctly
+  // it('should render the default value in the autocomplete input field when one is provided', async () => {
+  //   await waitFor(() => {
+  //     render(
+  //       <InputAutocomplete
+  //         fieldDetails={fieldDetailsAllProps}
+  //         handleChange={parentHandleChange}
+  //       />
+  //     );
+  //   });
+  //   expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+  //   expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+  //   await waitFor(() => { expect(screen.getByRole('combobox')).toHaveValue('ObjectThree'); });
+  // });
+
+});

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -1,6 +1,8 @@
 // Site
 export const SERVICE_NAME = 'National Maritime Single Window';
 
+// Forms: identifiers
+export const EXPANDED_DETAILS = 'ExpandedDetails';
 // Forms: input types
 export const FIELD_AUTOCOMPLETE = 'autocomplete';
 export const FIELD_EMAIL = 'email';

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -2,6 +2,7 @@
 export const SERVICE_NAME = 'National Maritime Single Window';
 
 // Forms: input types
+export const FIELD_AUTOCOMPLETE = 'autocomplete';
 export const FIELD_EMAIL = 'email';
 export const FIELD_PASSWORD = 'password';
 export const FIELD_TEXT = 'text';

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DisplayForm from '../../components/DisplayForm';
 import { FIELD_RADIO, CHECKED_TRUE, CHECKED_FALSE } from '../../constants/AppConstants';
 import cookieToFind from '../../utils/cookieToFind';
-import { scrollToElementId } from '../../utils/ScrollToElementId';
+import { scrollToElementId } from '../../utils/ScrollToElement';
 import setAnalyticCookie from '../../utils/setAnalyticCookie';
 
 const CookiePolicy = ({ setIsCookieBannerShown }) => {

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../../context/userContext';
 import {
+  FIELD_AUTOCOMPLETE,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   VALIDATE_EMAIL_ADDRESS,

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserContext } from '../../context/userContext';
 import {
-  FIELD_AUTOCOMPLETE,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   VALIDATE_EMAIL_ADDRESS,
@@ -10,7 +9,6 @@ import {
 } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
-import { countries } from '../TempPages/TempMockList-country';
 
 const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -10,6 +10,7 @@ import {
   } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+import { countries } from '../TempPages/TempMockList-country';
 
 const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -7,7 +7,7 @@ import {
   FIELD_PASSWORD,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_REQUIRED,
-  } from '../../constants/AppConstants';
+} from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import { countries } from '../TempPages/TempMockList-country';

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -40,8 +40,8 @@ const SecondPage = () => {
       label: 'Select your port',
       fieldName: 'port',
       dataAPIEndpoint: portList,
-      responseKey: 'name'
-      // responseKeys: {name: 'name', unlocode: 'unlocode'},
+      responseKey: 'name', // a field that always exists in the dataset that we can use as a key for returning results
+      additionalKeys: ['unlocode'] // optional other fields that we want to append to the returned result if it exists in the dataset
     },
     {
       type: FIELD_RADIO,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -41,7 +41,13 @@ const SecondPage = () => {
       label: 'Select your country',
       fieldName: 'country',
       dataAPIEndpoint: countries,
-      responseKey: 'name'
+      responseKey: 'name',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select your country',
+        },
+      ],
     },
     {
       type: FIELD_AUTOCOMPLETE,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -40,8 +40,8 @@ const SecondPage = () => {
       label: 'Select your port',
       fieldName: 'port',
       dataAPIEndpoint: portList,
-      responseKey: 'name', // a field that always exists in the dataset that we can use as a key for returning results
-      additionalKeys: ['unlocode'] // optional other fields that we want to append to the returned result if it exists in the dataset
+      responseKey: 'name',
+      additionalKeys: ['unlocode']
     },
     {
       type: FIELD_RADIO,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import {
+  FIELD_AUTOCOMPLETE,
   FIELD_TEXT,
   FIELD_RADIO,
   CHECKED_FALSE,
@@ -7,6 +8,7 @@ import {
 } from '../../constants/AppConstants';
 import { DASHBOARD_PAGE_NAME, DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+import { portList } from './TempMockList-port';
 
 const SecondPage = () => {
   const navigate = useNavigate();
@@ -32,6 +34,14 @@ const SecondPage = () => {
           message: 'Enter your first name',
         },
       ],
+    },
+    {
+      type: FIELD_AUTOCOMPLETE,
+      label: 'Select your port',
+      fieldName: 'port',
+      dataAPIEndpoint: portList,
+      responseKey: 'name'
+      // responseKeys: {name: 'name', unlocode: 'unlocode'},
     },
     {
       type: FIELD_RADIO,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../constants/AppConstants';
 import { DASHBOARD_PAGE_NAME, DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+import { countries } from './TempMockList-country';
 import { portList } from './TempMockList-port';
 
 const SecondPage = () => {
@@ -37,11 +38,18 @@ const SecondPage = () => {
     },
     {
       type: FIELD_AUTOCOMPLETE,
+      label: 'Select your country',
+      fieldName: 'country',
+      dataAPIEndpoint: countries,
+      responseKey: 'name'
+    },
+    {
+      type: FIELD_AUTOCOMPLETE,
       label: 'Select your port',
       fieldName: 'port',
       dataAPIEndpoint: portList,
       responseKey: 'name',
-      additionalKeys: ['unlocode']
+      additionalKey: 'unlocode'
     },
     {
       type: FIELD_RADIO,

--- a/src/pages/TempPages/TempMockList-country.js
+++ b/src/pages/TempPages/TempMockList-country.js
@@ -1,0 +1,1082 @@
+export const countries = [
+  {
+      name: 'Afghanistan',
+      code: 'AFG'
+  },
+  {
+      name: 'African Development Bank (ADB)',
+      code: 'XBA'
+  },
+  {
+      name: 'African Export-Import Bank (AFREXIM bank)',
+      code: 'XIM'
+  },
+  {
+      name: 'Aland Islands',
+      code: 'ALA'
+  },
+  {
+      name: 'Albania',
+      code: 'ALB'
+  },
+  {
+      name: 'Algeria',
+      code: 'DZA'
+  },
+  {
+      name: 'American Samoa',
+      code: 'ASM'
+  },
+  {
+      name: 'Andorra',
+      code: 'AND'
+  },
+  {
+      name: 'Angola',
+      code: 'AGO'
+  },
+  {
+      name: 'Anguilla',
+      code: 'AIA'
+  },
+  {
+      name: 'Antarctica',
+      code: 'ATA'
+  },
+  {
+      name: 'Antigua and Barbuda',
+      code: 'ATG'
+  },
+  {
+      name: 'Argentina',
+      code: 'ARG'
+  },
+  {
+      name: 'Armenia',
+      code: 'ARM'
+  },
+  {
+      name: 'Aruba',
+      code: 'ABW'
+  },
+  {
+      name: 'Australia',
+      code: 'AUS'
+  },
+  {
+      name: 'Austria',
+      code: 'AUT'
+  },
+  {
+      name: 'Azerbaijan',
+      code: 'AZE'
+  },
+  {
+      name: 'Bahamas (the)',
+      code: 'BHS'
+  },
+  {
+      name: 'Bahraini',
+      code: 'BHR'
+  },
+  {
+      name: 'Bangladesh',
+      code: 'BGD'
+  },
+  {
+      name: 'Barbados',
+      code: 'BRB'
+  },
+  {
+      name: 'Belarus',
+      code: 'BLR'
+  },
+  {
+      name: 'Belgium',
+      code: 'BEL'
+  },
+  {
+      name: 'Belize',
+      code: 'BLZ'
+  },
+  {
+      name: 'Benin',
+      code: 'BEN'
+  },
+  {
+      name: 'Bermuda',
+      code: 'BMU'
+  },
+  {
+      name: 'Bhutan',
+      code: 'BTN'
+  },
+  {
+      name: 'Bolivia (Plurinational State of)',
+      code: 'BOL'
+  },
+  {
+      name: 'Bonaire Sint Eustatius and Saba',
+      code: 'BES'
+  },
+  {
+      name: 'Bosnia and Herzegovina',
+      code: 'BIH'
+  },
+  {
+      name: 'Botswana',
+      code: 'BWA'
+  },
+  {
+      name: 'Bouvet Island',
+      code: 'BVT'
+  },
+  {
+      name: 'Brazil',
+      code: 'BRA'
+  },
+  {
+      name: 'British Indian Ocean Territory (the)',
+      code: 'IOT'
+  },
+  {
+      name: 'British National (Overseas)',
+      code: 'GBN'
+  },
+  {
+      name: 'British Overseas Citizen',
+      code: 'GBO'
+  },
+  {
+      name: 'British Overseas Territories Citizen',
+      code: 'GBD'
+  },
+  {
+      name: 'British Protected person',
+      code: 'GBP'
+  },
+  {
+      name: 'British Subject',
+      code: 'GBS'
+  },
+  {
+      name: 'Brunei Darussalam',
+      code: 'BRN'
+  },
+  {
+      name: 'Bulgaria',
+      code: 'BGR'
+  },
+  {
+      name: 'Burkina Faso',
+      code: 'BFA'
+  },
+  {
+      name: 'Burundi',
+      code: 'BDI'
+  },
+  {
+      name: 'Cabo Verde',
+      code: 'CPV'
+  },
+  {
+      name: 'Cambodia',
+      code: 'KHM'
+  },
+  {
+      name: 'Cameroon',
+      code: 'CMR'
+  },
+  {
+      name: 'Canada',
+      code: 'CAN'
+  },
+  {
+      name: 'Caribbean Community or one of its emissaries (CARICOM)',
+      code: 'XCC'
+  },
+  {
+      name: 'Cayman Islands (the)',
+      code: 'CYM'
+  },
+  {
+      name: 'Central African Republic (the)',
+      code: 'CAF'
+  },
+  {
+      name: 'Chad',
+      code: 'TCD'
+  },
+  {
+      name: 'Chile',
+      code: 'CHL'
+  },
+  {
+      name: 'China',
+      code: 'CHN'
+  },
+  {
+      name: 'Christmas Island',
+      code: 'CXR'
+  },
+  {
+      name: 'Cocos (Keeling) Islands (the)',
+      code: 'CCK'
+  },
+  {
+      name: 'Colombia',
+      code: 'COL'
+  },
+  {
+      name: 'Comoros (the)',
+      code: 'COM'
+  },
+  {
+      name: 'Congo (the Democratic Republic of the)',
+      code: 'COD'
+  },
+  {
+      name: 'Congo (the)',
+      code: 'COG'
+  },
+  {
+      name: 'Cook Islands (the)',
+      code: 'COK'
+  },
+  {
+      name: 'Costa Rica',
+      code: 'CRI'
+  },
+  {
+      name: 'Council of Europe',
+      code: 'XCE'
+  },
+  {
+      name: 'Croatia',
+      code: 'HRV'
+  },
+  {
+      name: 'Cuba',
+      code: 'CUB'
+  },
+  {
+      name: 'Curaçao',
+      code: 'CUW'
+  },
+  {
+      name: 'Cyprus',
+      code: 'CYP'
+  },
+  {
+      name: 'Czechia',
+      code: 'CZE'
+  },
+  {
+      name: 'Denmark',
+      code: 'DNK'
+  },
+  {
+      name: 'Djibouti',
+      code: 'DJI'
+  },
+  {
+      name: 'Dominica',
+      code: 'DMA'
+  },
+  {
+      name: 'Dominican Republic (the)',
+      code: 'DOM'
+  },
+  {
+      name: 'East Timor',
+      code: 'TLS'
+  },
+  {
+      name: 'Economic Community of West African States (ECOWAS)',
+      code: 'XEC'
+  },
+  {
+      name: 'Ecuador',
+      code: 'ECU'
+  },
+  {
+      name: 'Egypt',
+      code: 'EGY'
+  },
+  {
+      name: 'El Salvador',
+      code: 'SLV'
+  },
+  {
+      name: 'Equatorial Guinea',
+      code: 'GNQ'
+  },
+  {
+      name: 'Eritrea',
+      code: 'ERI'
+  },
+  {
+      name: 'Estonia',
+      code: 'EST'
+  },
+  {
+      name: 'Eswatini',
+      code: 'SWZ'
+  },
+  {
+      name: 'Ethiopia',
+      code: 'ETH'
+  },
+  {
+      name: 'European Union',
+      code: 'EUE'
+  },
+  {
+      name: 'Falkland Islands (the)',
+      code: 'FLK'
+  },
+  {
+      name: 'Faroe Islands (the)',
+      code: 'FRO'
+  },
+  {
+      name: 'Fiji',
+      code: 'FJI'
+  },
+  {
+      name: 'Finland',
+      code: 'FIN'
+  },
+  {
+      name: 'France',
+      code: 'FRA'
+  },
+  {
+      name: 'French Guiana',
+      code: 'GUF'
+  },
+  {
+      name: 'French Polynesia',
+      code: 'PYF'
+  },
+  {
+      name: 'French Southern Territories (the)',
+      code: 'ATF'
+  },
+  {
+      name: 'Gabon',
+      code: 'GAB'
+  },
+  {
+      name: 'Gambia (the)',
+      code: 'GMB'
+  },
+  {
+      name: 'Georgia',
+      code: 'GEO'
+  },
+  {
+      name: 'Germany',
+      code: 'DEU'
+  },
+  {
+      name: 'Ghana',
+      code: 'GHA'
+  },
+  {
+      name: 'Gibraltar',
+      code: 'GIB'
+  },
+  {
+      name: 'Greece',
+      code: 'GRC'
+  },
+  {
+      name: 'Greenland',
+      code: 'GRL'
+  },
+  {
+      name: 'Grenada',
+      code: 'GRD'
+  },
+  {
+      name: 'Guadeloupe',
+      code: 'GLP'
+  },
+  {
+      name: 'Guam',
+      code: 'GUM'
+  },
+  {
+      name: 'Guatemala',
+      code: 'GTM'
+  },
+  {
+      name: 'Guernsey',
+      code: 'GGY'
+  },
+  {
+      name: 'Guinea',
+      code: 'GIN'
+  },
+  {
+      name: 'Guinea-Bissau',
+      code: 'GNB'
+  },
+  {
+      name: 'Guyana',
+      code: 'GUY'
+  },
+  {
+      name: 'Haiti',
+      code: 'HTI'
+  },
+  {
+      name: 'Heard Island and McDonald Islands',
+      code: 'HMD'
+  },
+  {
+      name: 'Honduras',
+      code: 'HND'
+  },
+  {
+      name: 'Hong Kong',
+      code: 'HKG'
+  },
+  {
+      name: 'Hungary',
+      code: 'HUN'
+  },
+  {
+      name: 'INTERPOL',
+      code: 'XPO'
+  },
+  {
+      name: 'Iceland',
+      code: 'ISL'
+  },
+  {
+      name: 'India',
+      code: 'IND'
+  },
+  {
+      name: 'Indonesia',
+      code: 'IDN'
+  },
+  {
+      name: 'Iran (Islamic Republic of)',
+      code: 'IRN'
+  },
+  {
+      name: 'Iraq',
+      code: 'IRQ'
+  },
+  {
+      name: 'Ireland',
+      code: 'IRL'
+  },
+  {
+      name: 'Isle of man',
+      code: 'IMN'
+  },
+  {
+      name: 'Israel',
+      code: 'ISR'
+  },
+  {
+      name: 'Italy',
+      code: 'ITA'
+  },
+  {
+      name: 'Ivory Coast',
+      code: 'CIV'
+  },
+  {
+      name: 'Jamaica',
+      code: 'JAM'
+  },
+  {
+      name: 'Japan',
+      code: 'JPN'
+  },
+  {
+      name: 'Jersey',
+      code: 'JEY'
+  },
+  {
+      name: 'Jordan',
+      code: 'JOR'
+  },
+  {
+      name: 'Kazakhstan',
+      code: 'KAZ'
+  },
+  {
+      name: 'Kenya',
+      code: 'KEN'
+  },
+  {
+      name: 'Kiribati',
+      code: 'KIR'
+  },
+  {
+      name: 'Korea (North)',
+      code: 'PRK'
+  },
+  {
+      name: 'Korea (South)',
+      code: 'KOR'
+  },
+  {
+      name: 'Kuwait',
+      code: 'KWT'
+  },
+  {
+      name: 'Kyrgyzstan',
+      code: 'KGZ'
+  },
+  {
+      name: 'Laos',
+      code: 'LAO'
+  },
+  {
+      name: 'Latvia',
+      code: 'LVA'
+  },
+  {
+      name: 'Lebanon',
+      code: 'LBN'
+  },
+  {
+      name: 'Lesotho',
+      code: 'LSO'
+  },
+  {
+      name: 'Liberia',
+      code: 'LBR'
+  },
+  {
+      name: 'Libya',
+      code: 'LBY'
+  },
+  {
+      name: 'Liechtenstein',
+      code: 'LIE'
+  },
+  {
+      name: 'Lithuania',
+      code: 'LTU'
+  },
+  {
+      name: 'Luxembourg',
+      code: 'LUX'
+  },
+  {
+      name: 'Macao',
+      code: 'MAC'
+  },
+  {
+      name: 'Madagascar',
+      code: 'MDG'
+  },
+  {
+      name: 'Malawi',
+      code: 'MWI'
+  },
+  {
+      name: 'Malaysia',
+      code: 'MYS'
+  },
+  {
+      name: 'Maldives',
+      code: 'MDV'
+  },
+  {
+      name: 'Mali',
+      code: 'MLI'
+  },
+  {
+      name: 'Malta',
+      code: 'MLT'
+  },
+  {
+      name: 'Marshall Islands (the)',
+      code: 'MHL'
+  },
+  {
+      name: 'Martinique',
+      code: 'MTQ'
+  },
+  {
+      name: 'Mauritania',
+      code: 'MRT'
+  },
+  {
+      name: 'Mauritius',
+      code: 'MUS'
+  },
+  {
+      name: 'Mayotte',
+      code: 'MYT'
+  },
+  {
+      name: 'Mexico',
+      code: 'MEX'
+  },
+  {
+      name: 'Micronesia (Federated States of)',
+      code: 'FSM'
+  },
+  {
+      name: 'Moldova (the Republic of)',
+      code: 'MDA'
+  },
+  {
+      name: 'Monaco',
+      code: 'MCO'
+  },
+  {
+      name: 'Mongolia',
+      code: 'MNG'
+  },
+  {
+      name: 'Montenegro',
+      code: 'MNE'
+  },
+  {
+      name: 'Montserrat',
+      code: 'MSR'
+  },
+  {
+      name: 'Morocco',
+      code: 'MAR'
+  },
+  {
+      name: 'Mozambique',
+      code: 'MOZ'
+  },
+  {
+      name: 'Myanmar',
+      code: 'MMR'
+  },
+  {
+      name: 'Namibia',
+      code: 'NAM'
+  },
+  {
+      name: 'Nationality Currently Unknown',
+      code: 'ZZZ'
+  },
+  {
+      name: 'Nauru',
+      code: 'NRU'
+  },
+  {
+      name: 'Nepal',
+      code: 'NPL'
+  },
+  {
+      name: 'Netherlands (the)',
+      code: 'NLD'
+  },
+  {
+      name: 'New Caledonia',
+      code: 'NCL'
+  },
+  {
+      name: 'New Zealand',
+      code: 'NZL'
+  },
+  {
+      name: 'Nicaragua',
+      code: 'NIC'
+  },
+  {
+      name: 'Niger (the)',
+      code: 'NER'
+  },
+  {
+      name: 'Nigeria',
+      code: 'NGA'
+  },
+  {
+      name: 'Niue',
+      code: 'NIU'
+  },
+  {
+      name: 'Norfolk Island',
+      code: 'NFK'
+  },
+  {
+      name: 'North Macedonia',
+      code: 'MKD'
+  },
+  {
+      name: 'Northern Mariana Islands',
+      code: 'MNP'
+  },
+  {
+      name: 'Norway',
+      code: 'NOR'
+  },
+  {
+      name: 'Oman',
+      code: 'OMN'
+  },
+  {
+      name: 'Pakistan',
+      code: 'PAK'
+  },
+  {
+      name: 'Palau',
+      code: 'PLW'
+  },
+  {
+      name: 'Palestine, State of',
+      code: 'PSE'
+  },
+  {
+      name: 'Panama',
+      code: 'PAN'
+  },
+  {
+      name: 'Papua New Guinea',
+      code: 'PNG'
+  },
+  {
+      name: 'Paraguay',
+      code: 'PRY'
+  },
+  {
+      name: 'Person of unspecified nationality',
+      code: 'XXX'
+  },
+  {
+      name: 'Peru',
+      code: 'PER'
+  },
+  {
+      name: 'Philippines (the)',
+      code: 'PHL'
+  },
+  {
+      name: 'Pitcairn',
+      code: 'PCN'
+  },
+  {
+      name: 'Poland',
+      code: 'POL'
+  },
+  {
+      name: 'Portugal',
+      code: 'PRT'
+  },
+  {
+      name: 'Puerto Rico',
+      code: 'PRI'
+  },
+  {
+      name: 'Qatar',
+      code: 'QAT'
+  },
+  {
+      name: 'Refugee, as defined in Article 1 of the 1951 Convention',
+      code: 'XXB'
+  },
+  {
+      name: 'Refugee, other than as defined under the code XXB',
+      code: 'XXC'
+  },
+  {
+      name: 'Resident of Kosovo',
+      code: 'UNK'
+  },
+  {
+      name: 'Reunion',
+      code: 'REU'
+  },
+  {
+      name: 'Romania',
+      code: 'ROU'
+  },
+  {
+      name: 'Russian Federation (the)',
+      code: 'RUS'
+  },
+  {
+      name: 'Rwanda',
+      code: 'RWA'
+  },
+  {
+      name: 'Saint Barthelemy',
+      code: 'BML'
+  },
+  {
+      name: 'Saint Helena, Ascension and Tristan da Cunha',
+      code: 'SHN'
+  },
+  {
+      name: 'Saint Kitts and Nevis',
+      code: 'KNA'
+  },
+  {
+      name: 'Saint Lucia',
+      code: 'LCA'
+  },
+  {
+      name: 'Saint Martin (French part)',
+      code: 'MAF'
+  },
+  {
+      name: 'Saint Pierre and Miquelon',
+      code: 'SPM'
+  },
+  {
+      name: 'Saint Vincent and the Grenadines',
+      code: 'VCT'
+  },
+  {
+      name: 'Samoa',
+      code: 'WSM'
+  },
+  {
+      name: 'San Marino',
+      code: 'SMR'
+  },
+  {
+      name: 'Sao Tome and Principe',
+      code: 'STP'
+  },
+  {
+      name: 'Saudi Arabia',
+      code: 'SAU'
+  },
+  {
+      name: 'Senegal',
+      code: 'SEN'
+  },
+  {
+      name: 'Serbia',
+      code: 'SRB'
+  },
+  {
+      name: 'Seychelles',
+      code: 'SYC'
+  },
+  {
+      name: 'Sierra Leone',
+      code: 'SLE'
+  },
+  {
+      name: 'Singapore',
+      code: 'SGP'
+  },
+  {
+      name: 'Sint Marten (Dutch part)',
+      code: 'SXM'
+  },
+  {
+      name: 'Slovakia',
+      code: 'SVK'
+  },
+  {
+      name: 'Slovenia',
+      code: 'SVN'
+  },
+  {
+      name: 'Solomon Islands',
+      code: 'SLB'
+  },
+  {
+      name: 'Somalia',
+      code: 'SOM'
+  },
+  {
+      name: 'South Africa',
+      code: 'ZAF'
+  },
+  {
+      name: 'South Georgia and the South Sandwich Islands',
+      code: 'SGS'
+  },
+  {
+      name: 'South Sudan',
+      code: 'SSD'
+  },
+  {
+      name: 'Southern African Development Community',
+      code: 'XDC'
+  },
+  {
+      name: 'Sovereign Military Order of Malta or one of its emissaries',
+      code: 'XOM'
+  },
+  {
+      name: 'Spain',
+      code: 'ESP'
+  },
+  {
+      name: 'Sri Lanka',
+      code: 'LKA'
+  },
+  {
+      name: 'Stateless person as defined in Article 1 of the 1954 Convention',
+      code: 'XXA'
+  },
+  {
+      name: 'Sudan (the)',
+      code: 'SDN'
+  },
+  {
+      name: 'Suriname',
+      code: 'SUR'
+  },
+  {
+      name: 'Svalbard and Jan Mayen',
+      code: 'SJM'
+  },
+  {
+      name: 'Sweden',
+      code: 'SWE'
+  },
+  {
+      name: 'Switzerland',
+      code: 'CHE'
+  },
+  {
+      name: 'Syrian Arab Republic (the)',
+      code: 'SYR'
+  },
+  {
+      name: 'Taiwan Province of China (the)',
+      code: 'TWN'
+  },
+  {
+      name: 'Tanzania, United Republic of',
+      code: 'TZA'
+  },
+  {
+      name: 'Thailand',
+      code: 'THA'
+  },
+  {
+      name: 'Togo',
+      code: 'TGO'
+  },
+  {
+      name: 'Tokelau',
+      code: 'TKL'
+  },
+  {
+      name: 'Tonga',
+      code: 'TON'
+  },
+  {
+      name: 'Trinidad and Tobago',
+      code: 'TTO'
+  },
+  {
+      name: 'Tunisia',
+      code: 'TUN'
+  },
+  {
+      name: 'Turkey',
+      code: 'TUR'
+  },
+  {
+      name: 'Turkish Controlled Areas of Cyprus',
+      code: 'XXT'
+  },
+  {
+      name: 'Turkmenistan',
+      code: 'TKM'
+  },
+  {
+      name: 'Turks and Caicos Islands (the)',
+      code: 'TCA'
+  },
+  {
+      name: 'Tuvalu',
+      code: 'TUV'
+  },
+  {
+      name: 'Uganda',
+      code: 'UGA'
+  },
+  {
+      name: 'Ukraine',
+      code: 'UKR'
+  },
+  {
+      name: 'United Arab Emirates (the)',
+      code: 'ARE'
+  },
+  {
+      name: 'United Nations Organization or one of its officials',
+      code: 'UNO'
+  },
+  {
+      name: 'United Nations specialized agency or one of its officials',
+      code: 'UNA'
+  },
+  {
+      name: 'United States Minor Outlying Islands (the)',
+      code: 'UMI'
+  },
+  {
+      name: 'United States of America (the)',
+      code: 'USA'
+  },
+  {
+      name: 'Uruguay',
+      code: 'URY'
+  },
+  {
+      name: 'Uzbekistan',
+      code: 'UZB'
+  },
+  {
+      name: 'Vanuatu',
+      code: 'VUT'
+  },
+  {
+      name: 'Vatican City State',
+      code: 'VAT'
+  },
+  {
+      name: 'Venezuela (Bolivarian Republic of)',
+      code: 'VEN'
+  },
+  {
+      name: 'Vietnam',
+      code: 'VNM'
+  },
+  {
+      name: 'Virgin Islands (British)',
+      code: 'VGB'
+  },
+  {
+      name: 'Virgin Islands (U.S.)',
+      code: 'VIR'
+  },
+  {
+      name: 'Wallis and Futuna',
+      code: 'WLF'
+  },
+  {
+      name: 'Western Sahara',
+      code: 'ESH'
+  },
+  {
+      name: 'Yemen',
+      code: 'YEM'
+  },
+  {
+      name: 'Zambia',
+      code: 'ZMB'
+  },
+  {
+      name: 'Zimbabwe',
+      code: 'ZWE'
+  }
+];

--- a/src/pages/TempPages/TempMockList-port.js
+++ b/src/pages/TempPages/TempMockList-port.js
@@ -1,0 +1,17 @@
+export const portList = [
+  {
+    name: 'Dover',
+    unlocode: 'GB DOV',
+  },
+  {
+    name: 'Dover Marina',
+  },
+  {
+    name: 'Portsmouth',
+    unlocode: 'GB POR',
+  },
+  {
+    name: 'Dover Other',
+    unlocode: 'GB POR',
+  },
+];

--- a/src/pages/TempPages/TempMockList-port.js
+++ b/src/pages/TempPages/TempMockList-port.js
@@ -12,6 +12,6 @@ export const portList = [
   },
   {
     name: 'Dover Other',
-    unlocode: 'GB POR',
+    unlocode: 'GR POR',
   },
 ];

--- a/src/utils/ScrollToElement.js
+++ b/src/utils/ScrollToElement.js
@@ -2,3 +2,7 @@ export const scrollToElementId = (id) => {
     document.getElementById(id).scrollIntoView();
     document.activeElement.blur();
 };
+
+export const scrollToH1 = () => {
+  document.getElementsByTagName('html')[0].scrollIntoView();
+};

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -1,8 +1,9 @@
 import {
+  EXPANDED_DETAILS,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED,
-  } from '../constants/AppConstants';
+} from '../constants/AppConstants';
 
 const validateField = ({ type, value, condition }) => {
   switch (type) {
@@ -16,11 +17,11 @@ const validateField = ({ type, value, condition }) => {
         return 'error';
       }
       break;
-      case VALIDATE_EMAIL_ADDRESS:
-        if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
-          return 'error';
-        }
-        break;
+    case VALIDATE_EMAIL_ADDRESS:
+      if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
+        return 'error';
+      }
+      break;
     default: return 'valid';
   }
 };
@@ -29,13 +30,19 @@ const Validator = ({ formData, formFields }) => {
   const fieldsToValidate = Object.entries(formData).reduce((result, field) => { // result is our accumulator that starts as an empty array as defined at end of reduce
     const key = field[0];
     const value = field[1];
-    const rules = formFields.find(field => field.fieldName === key).validation; // find all the rules for this field, if any
 
-    if (rules) {
-      rules.map((rule) => {
-        result.push({ key, value, rule }); // for each rule for this field, push an entry to the result array
-      });
+    if (key.includes(EXPANDED_DETAILS)) {
+      result.push();
+    } else {
+      const rules = formFields.find(field => field.fieldName === key).validation; // find all the rules for this field, if any
+
+      if (rules) {
+        rules.map((rule) => {
+          result.push({ key, value, rule }); // for each rule for this field, push an entry to the result array
+        });
+      }
     }
+
     return result; // we will then have an array with unique(field + rule), and if a field has more than one rule it will have multiple entries in the array
   }, []);
 
@@ -48,7 +55,7 @@ const Validator = ({ formData, formFields }) => {
     return result;
   }, []);
 
-return errors;
+  return errors;
 };
 
 export default Validator;


### PR DESCRIPTION
# Ticket

NMSW-33

To make reviewing easier review & merger these two first:
https://github.com/UKHomeOffice/nmsw-ui/pull/59 - remove sample field from sign in
https://github.com/UKHomeOffice/nmsw-ui/pull/60 - scroll to h1 on errors not form id

Then rebase version-0.5.0 onto this PR and it will reduce it down to just adding the autocomplete input

----

## AC

Given I have to select from a predefined list of items
When I start to type an items name (After 2 characters)
Then I am shown a list of options that could match that item (From start of word)


----

## To test

UPDATE PACKAGES
- run `npm ci` to install alpha gov autocomplete package

NEXT

- run app locally
- go to second page
- submit the form
- > the country field should error as it is mandatory, the port field should not error as it is not mandatory

NEXT:

- type something in the country
- > you should see the filtered list of results
- select an item from the list
- type something in the port name (note only Dover and Portsmouth will work here)
- > you should see the filtered list of results that contain the port name & unlocode (if a unlocode exists)
- select an item from the list
- check the session storage
- > the field name & value should be in the form data object

NEXT:

- refresh the page
- > the field values should be persisted

NEXT:

- submit the form
- > you should be taken to the confirmation page


----

## Notes

- we use a mock list of names to use for this component, this will be replaced with an API call in future
- the API will ultimately determine how the search works, whether it's on start of word, mid word, etc. So we will not test what is returned as part of this ticket

**ACCESSIBILITY**
We expect the following aXe failure for any autocomplete box on screen
```
Ensures all ARIA attributes have valid values : Invalid ARIA attribute value: aria-activedescendant="false"
```

there is an open PR to fix the aria-activedescendent issue: 
- https://github.com/alphagov/accessible-autocomplete/issues/434
- https://github.com/alphagov/accessible-autocomplete/pull/553/files

The aria-activedescendent looks to work correctly, if you use your mouse to select an item from the list then aria-activedescendent's value changes and voice over reads it out correctly
The error occurs because when the combobox pop up (list) is closed, the value of aria-activedescendent is set to = 'false' and false is an invalid value for it.
Some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/

**REACT DEPRECATED FEATURES**
An issue is open for warnings about deprecated lifecycles : https://github.com/alphagov/accessible-autocomplete/issues/418