### PR TITLE
NMSW-33 Remove sample fields from sign in page

### DIFF
--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -5,7 +5,6 @@ import {
   FIELD_EMAIL,
   FIELD_PASSWORD,
   VALIDATE_EMAIL_ADDRESS,
-  VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED,
   } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
@@ -54,23 +53,6 @@ const SignIn = (userDetails) => {
         },
       ],
     },
-    {
-      type: FIELD_PASSWORD,
-      label: 'Sample min length password field for testing',
-      hint: 'Because we would not show a min length error on sign in, only on account creations',
-      fieldName: 'sampleMinLengthTest',
-      validation: [
-        {
-          type: VALIDATE_REQUIRED,
-          message: 'Enter your sample field password',
-        },
-        {
-          type: VALIDATE_MIN_LENGTH,
-          message: 'Sample field must be a minimum of 8 characters',
-          condition: 8,
-        },
-      ],
-    }
   ];
 
   const handleSubmit = () => {

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -141,48 +141,6 @@ describe('Sign in tests', () => {
     expect(screen.queryByText('Enter your password')).not.toBeInTheDocument();
   });
 
-  it('should display the sample field required error if there is no sample field text',async  () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter your sample field password')).toHaveLength(2);
-  });
-
-  it('should scroll to sample field and set focus on sample field input if user clicks on sample field required error link', async () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    await user.click(screen.getByTestId('submit-button'));
-    await user.click(screen.getByRole('button', { name: 'Enter your sample field password'}));
-    expect(scrollIntoViewMock).toHaveBeenCalled();
-    expect(screen.getByTestId('sampleMinLengthTest-passwordField')).toHaveFocus();
-  });
-
-  it('should display the sample field min length error if the text in the field is < 8 characters', async () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    await user.type(screen.getByTestId('sampleMinLengthTest-passwordField'), 'one');
-    await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Sample field must be a minimum of 8 characters')).toHaveLength(2);
-  });
-
-  it('should scroll to sample field and set focus on sample field input if user clicks on sample field min length error link', async () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    await user.type(screen.getByTestId('sampleMinLengthTest-passwordField'), 'one');
-    await user.click(screen.getByTestId('submit-button'));
-    await user.click(screen.getByRole('button', { name: 'Sample field must be a minimum of 8 characters'}));
-    expect(scrollIntoViewMock).toHaveBeenCalled();
-    expect(screen.getByTestId('sampleMinLengthTest-passwordField')).toHaveFocus();
-  });
-
-  it('should NOT display any sample field errors if the text in the field is >= 8 characters', async () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    await user.type(screen.getByTestId('sampleMinLengthTest-passwordField'), '12345678');
-    await user.click(screen.getByTestId('submit-button'));
-    expect(screen.queryByText('Sample field must be a minimum of 8 characters')).not.toBeInTheDocument();
-  });
-
   it('should call the login function on sign in button click if there are no errors', async () => {
     const user = userEvent.setup();
     const userDetails = { name: 'MockedUser', token: '123', group: 'testGroup' };
@@ -190,7 +148,6 @@ describe('Sign in tests', () => {
     renderWithUserContext(userDetails);
     await user.type(screen.getByRole('textbox', {name: /email/i}), 'testemail@email.com');
     await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
-    await user.type(screen.getByTestId('sampleMinLengthTest-passwordField'), 'testminlengthpassword');
     await user.click(screen.getByTestId('submit-button'));
     expect(mockedLogin).toHaveBeenCalled();
   });


### PR DESCRIPTION
# Ticket

NMSW-33

----

## AC

Separating https://github.com/UKHomeOffice/nmsw-ui/pull/58 into multiple PRs for ease of review

This ticket removes the sample field we had to allow testing of some validation. We do not need this field on the sign in page.

----

## To test

- run app locally
- view sign in page
- there should only be email and password fields


----

## Notes

There is still no authentication
