### PR TITLE
NMSW-140 Radio buttons with conditional text fields component (no errors or persisting values yet)

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -14,7 +14,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   const [formData, setFormData] = useState({});
   const [sessionData, setSessionData] = useState(JSON.parse(sessionStorage.getItem('formData')));
 
-  const handleChange = (e, itemToClear) => {
+  const handleChange = (e) => {
     if (errors) {
       // on change any error shown for that field should be cleared so find if field has an error & remove from error list
       const filteredErrors = errors?.filter(errorField => errorField.name !== e.target.name);
@@ -22,11 +22,11 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
     }
     // we do not store passwords in session data
     if (e.target.name !== FIELD_PASSWORD) {
-      setSessionData({ ...sessionData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value });
-      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value }));
+      setSessionData({ ...sessionData, [e.target.name]: e.target.value });
+      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value }));
     }
     // we do store all values into form data
-    setFormData({ ...formData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value });
+    setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleValidation = async (e, formData) => {

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -14,7 +14,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   const [formData, setFormData] = useState({});
   const [sessionData, setSessionData] = useState(JSON.parse(sessionStorage.getItem('formData')));
 
-  const handleChange = (e) => {
+  const handleChange = (e, itemToClear) => {
     if (errors) {
       // on change any error shown for that field should be cleared so find if field has an error & remove from error list
       const filteredErrors = errors?.filter(errorField => errorField.name !== e.target.name);
@@ -22,11 +22,11 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
     }
     // we do not store passwords in session data
     if (e.target.name !== FIELD_PASSWORD) {
-      setSessionData({ ...sessionData, [e.target.name]: e.target.value });
-      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value }));
+      setSessionData({ ...sessionData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value });
+      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value }));
     }
     // we do store all values into form data
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+    setFormData({ ...formData, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value });
   };
 
   const handleValidation = async (e, formData) => {

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DisplayForm from '../DisplayForm';
 import {
+  FIELD_CONDITIONAL,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   FIELD_RADIO,
@@ -51,7 +52,7 @@ describe('Display Form', () => {
       type: 'button',
     },
   };
-  const formMandatoryTextInput = [
+  const formRequiredTextInput = [
     {
       type: FIELD_TEXT,
       label: 'Text input',
@@ -71,24 +72,6 @@ describe('Display Form', () => {
       label: 'Text input',
       fieldName: 'testField',
       validation: [
-        {
-          type: VALIDATE_MIN_LENGTH,
-          message: 'Field must be a minimum of 8 characters',
-          condition: 8,
-        },
-      ],
-    }
-  ];
-  const formMultipleValidationRules = [
-    {
-      type: FIELD_TEXT,
-      label: 'Text input',
-      fieldName: 'testField',
-      validation: [
-        {
-          type: VALIDATE_REQUIRED,
-          message: 'Enter your text input value',
-        },
         {
           type: VALIDATE_MIN_LENGTH,
           message: 'Field must be a minimum of 8 characters',
@@ -135,6 +118,24 @@ describe('Display Form', () => {
         },
       ],
     },
+  ];
+  const formMultipleValidationRules = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+        {
+          type: VALIDATE_MIN_LENGTH,
+          message: 'Field must be a minimum of 8 characters',
+          condition: 8,
+        },
+      ],
+    }
   ];
   const formSpecialInputs = [
     {
@@ -202,17 +203,46 @@ describe('Display Form', () => {
         },
       ]
     },
+    {
+      type: FIELD_CONDITIONAL,
+      className: 'govuk-radios',
+      label: 'This is a radio set with a conditional field',
+      fieldName: 'radioWithConditional',
+      hint: 'Hint for conditional set',
+      grouped: true,
+      radioOptions: [
+        {
+          radioField: true,
+          label: 'Option that has a conditional',
+          name: 'radioWithConditional',
+          value: 'optionWithConditional',
+        },
+        {
+          radioField: false,
+          parentFieldValue: 'optionWithConditional',
+          label: 'Conditional text input',
+          name: 'conditionalTextInput',
+        },
+        {
+          radioField: true,
+          label: 'Option without a conditional',
+          name: 'radioWithConditional',
+          value: 'optionNoConditional',
+        },
+      ],
+    }
   ];
 
   beforeEach(() => {
     window.sessionStorage.clear();
   });
 
+  // ACTION BUTTONS
   it('should render a submit and cancel button if both exist', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActions}
         handleSubmit={handleSubmit}
       />
@@ -225,7 +255,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -239,7 +269,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -252,11 +282,12 @@ describe('Display Form', () => {
     expect(handleSubmit).toHaveBeenCalled();
   });
 
+  // INPUTS
   it('should render a text input', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -285,6 +316,25 @@ describe('Display Form', () => {
     expect(screen.getByRole('radio', { name: 'Radio three' })).toBeInTheDocument();
   });
 
+  it('should render a radio button set with conditional fields input', () => {
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    expect(screen.getByText('This is a radio set with a conditional field')).toBeInTheDocument();
+    expect(screen.getByText('Hint for conditional set').outerHTML).toEqual('<div id="radioWithConditional-hint" class="govuk-hint">Hint for conditional set</div>');
+    expect(screen.getByLabelText('Option that has a conditional')).toBeInTheDocument();
+    expect(screen.getByLabelText('Conditional text input')).toBeInTheDocument();
+    expect(screen.getByLabelText('Option without a conditional')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Option that has a conditional' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Option without a conditional' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Conditional text input' })).not.toBeInTheDocument(); // tests the text field isn't displayed as radio
+  });
+
   it('should render the special input types', () => {
     render(
       <DisplayForm
@@ -308,12 +358,13 @@ describe('Display Form', () => {
     expect(screen.getByTestId('password-passwordField')).toBeInTheDocument();
   });
 
+  // ERRORS
   it('should render error summary & field error if there are field errors', async () => {
     const user = userEvent.setup();
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -374,7 +425,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -408,7 +459,7 @@ describe('Display Form', () => {
     render(
       <DisplayForm
         formId="testForm"
-        fields={formMandatoryTextInput}
+        fields={formRequiredTextInput}
         formActions={formActionsSubmitOnly}
         handleSubmit={handleSubmit}
       />
@@ -424,6 +475,7 @@ describe('Display Form', () => {
     
   });
 
+  // PREFILLING DATA
   it('should store form data in the session for use on refresh', async () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo"}';

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 import {
+  FIELD_CONDITIONAL,
   FIELD_EMAIL,
   FIELD_PASSWORD,
   FIELD_TEXT,
   FIELD_RADIO
 } from '../../constants/AppConstants';
+import InputConditional from './InputConditional';
 import InputRadio from './InputRadio';
 import InputText from './InputText';
 
@@ -48,6 +50,13 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
   let fieldToReturn;
   switch (fieldDetails.type) {
 
+    case FIELD_CONDITIONAL: fieldToReturn =
+      <InputConditional
+        fieldDetails={fieldDetails}
+        handleChange={parentHandleChange}
+      />;
+      break;
+
     case FIELD_EMAIL: fieldToReturn =
       <InputText
         autoComplete='email'
@@ -68,21 +77,21 @@ const determineFieldType = ({ error, fieldDetails, parentHandleChange }) => {
       />;
       break;
 
+    case FIELD_RADIO: fieldToReturn =
+      <InputRadio
+        // there is no input level error styling on a radio button so we do not pass error down here
+        fieldDetails={fieldDetails}
+        handleChange={parentHandleChange}
+        type='radio'
+      />;
+      break;
+
     case FIELD_TEXT: fieldToReturn =
       <InputText
         error={error}
         fieldDetails={fieldDetails}
         handleChange={parentHandleChange}
         type='text'
-      />;
-      break;
-
-    case FIELD_RADIO: fieldToReturn =
-      <InputRadio
-         // there is no input level error styling on a radio button so we do not pass error down here
-        fieldDetails={fieldDetails}
-        handleChange={parentHandleChange}
-        type='radio'
       />;
       break;
 

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -46,10 +46,28 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
   const [checkedItem, setCheckedItem] = useState();
 
   const wrapHandleChange = async (e) => {
+    let formattedItemToClear;
     if (e.target.type === FIELD_RADIO) {
       setCheckedItem(e.target.value);
+      // find any currently active conditional fields and format it so it can be cleared with handleChange
+      // (only one radio can be selected at a time so only one conditional can be open at a time)
+      if (activeConditionalField) {
+        document.getElementById(`${activeConditionalField.name}-input`).value = null;
+        formattedItemToClear = {
+          target: {
+            name: activeConditionalField.name,
+            value: null,
+          }
+        };
+      }
+      // find this radio option's conditional field (if any) and update the activeConditionalField
+      // so we know to clear it if a new radio option is selected
+      const conditionalField = fieldDetails.radioOptions.find(({ parentFieldValue }) => parentFieldValue === e.target.value);
+      setActiveConditionalField(conditionalField);
     }
-    handleChange(e);
+    // pass both the selected radioOption AND any conditionalField that needs to be cleared to handleChange
+    // this is where formData and sessionData are then updated with the new values
+    handleChange(e, formattedItemToClear);
   };
 
   return (

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -1,0 +1,123 @@
+import { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+import { FIELD_RADIO, FIELD_TEXT } from '../../constants/AppConstants';
+
+const RadioField = ({ fieldName, hint, index, label, name, value, handleChange }) => {
+  return (
+    <div className="govuk-radios__item">
+      <input
+        aria-describedby={hint ? `${fieldName}${name}-hint` : null}
+        className="govuk-radios__input"
+        id={`${name}-input[${index}]`}
+        name={name}
+        type={FIELD_RADIO}
+        value={value}
+        onChange={handleChange}
+      />
+      <label className="govuk-label govuk-radios__label" htmlFor={`${name}-input[${index}]`}>
+        {label}
+      </label>
+    </div>
+  );
+};
+
+const TextField = ({ fieldName, hint, isVisible, label, handleChange }) => {
+  return (
+    <div className={isVisible ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden'}>
+      <div className='govuk-form-group'>
+        <label className="govuk-label" htmlFor={`${fieldName}-input`}>
+          {label}
+        </label>
+        <input
+          aria-describedby={hint ? `${fieldName}-hint` : null}
+          className="govuk-input  govuk-!-width-one-third"
+          id={`${fieldName}-input`}
+          name={fieldName}
+          type={FIELD_TEXT}
+          onChange={handleChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+
+const InputConditional = ({ fieldDetails, handleChange }) => {
+  const [checkedItem, setCheckedItem] = useState();
+
+  const wrapHandleChange = async (e) => {
+    if (e.target.type === FIELD_RADIO) {
+      setCheckedItem(e.target.value);
+    }
+    handleChange(e);
+  };
+
+  return (
+    <div className={fieldDetails.className} data-module="govuk-radios">
+      {(fieldDetails.radioOptions).map((option, index) => {
+        const isVisible = checkedItem === option.parentFieldValue ? true : false;
+
+        return (
+          <Fragment key={`${option.name}-input[${index}]`}>
+            {
+              option.radioField ?
+                <RadioField
+                  fieldName={fieldDetails.fieldName}
+                  hint={option.hint}
+                  index={index}
+                  label={option.label}
+                  name={option.name}
+                  value={option.value}
+                  handleChange={wrapHandleChange}
+                />
+                :
+                <TextField
+                  fieldName={option.name}
+                  hint={option.hint}
+                  isVisible={isVisible}
+                  label={option.label}
+                  handleChange={wrapHandleChange}
+                />
+            }
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+RadioField.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  hint: PropTypes.string,
+  index: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+TextField.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  hint: PropTypes.string,
+  isVisible: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+InputConditional.propTypes = {
+  fieldDetails: PropTypes.shape({
+    className: PropTypes.string, // allows us to pass an inline style
+    fieldName: PropTypes.string.isRequired,
+    hint: PropTypes.string,
+    radioOptions: PropTypes.arrayOf(
+      PropTypes.shape({
+        radioField: PropTypes.bool.isRequired,
+        name: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string,
+      })).isRequired,
+  }).isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default InputConditional;

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -22,7 +22,7 @@ const RadioField = ({ index, label, name, value, handleChange }) => {
 
 const TextField = ({ hint, isVisible, label, name, handleChange }) => {
   return (
-    <div className={isVisible ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden'}>
+    <div data-testid={`${name}-container`} className={isVisible ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden'}>
       <div className='govuk-form-group'>
         <label className="govuk-label" htmlFor={`${name}-input`}>
           {label}
@@ -32,7 +32,7 @@ const TextField = ({ hint, isVisible, label, name, handleChange }) => {
         </div>
         <input
           aria-describedby={hint ? `${name}-hint` : null}
-          className="govuk-input  govuk-!-width-one-third"
+          className="govuk-input govuk-!-width-one-third"
           id={`${name}-input`}
           name={name}
           type={FIELD_TEXT}

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -48,39 +48,23 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
   const [checkedItem, setCheckedItem] = useState();
 
   const wrapHandleChange = async (e) => {
-    let formattedItemToClear;
     if (e.target.type === FIELD_RADIO) {
       setCheckedItem(e.target.value);
-      // find any currently active conditional fields and format it so it can be cleared with handleChange
-      // (only one radio can be selected at a time so only one conditional can be open at a time)
-      if (activeConditionalField) {
-        document.getElementById(`${activeConditionalField.name}-input`).value = null;
-        formattedItemToClear = {
-          target: {
-            name: activeConditionalField.name,
-            value: null,
-          }
-        };
-      }
-      // find this radio option's conditional field (if any) and update the activeConditionalField
-      // so we know to clear it if a new radio option is selected
-      const conditionalField = fieldDetails.radioOptions.find(({ parentFieldValue }) => parentFieldValue === e.target.value);
-      setActiveConditionalField(conditionalField);
     }
-    // pass both the selected radioOption AND any conditionalField that needs to be cleared to handleChange
-    // this is where formData and sessionData are then updated with the new values
-    handleChange(e, formattedItemToClear);
+    handleChange(e);
   };
 
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">
       {(fieldDetails.radioOptions).map((option, index) => {
         const isVisible = checkedItem === option.parentFieldValue ? true : false;
+
         return (
           <Fragment key={`${option.name}-input[${index}]`}>
             {
               option.radioField ?
                 <RadioField
+                  hint={option.hint}
                   index={index}
                   label={option.label}
                   name={option.name}

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -2,11 +2,10 @@ import { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FIELD_RADIO, FIELD_TEXT } from '../../constants/AppConstants';
 
-const RadioField = ({ fieldName, hint, index, label, name, value, handleChange }) => {
+const RadioField = ({ index, label, name, value, handleChange }) => {
   return (
     <div className="govuk-radios__item">
       <input
-        aria-describedby={hint ? `${fieldName}${name}-hint` : null}
         className="govuk-radios__input"
         id={`${name}-input[${index}]`}
         name={name}
@@ -21,18 +20,21 @@ const RadioField = ({ fieldName, hint, index, label, name, value, handleChange }
   );
 };
 
-const TextField = ({ fieldName, hint, isVisible, label, handleChange }) => {
+const TextField = ({ hint, isVisible, label, name, handleChange }) => {
   return (
     <div className={isVisible ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden'}>
       <div className='govuk-form-group'>
-        <label className="govuk-label" htmlFor={`${fieldName}-input`}>
+        <label className="govuk-label" htmlFor={`${name}-input`}>
           {label}
         </label>
+        <div id={`${name}-hint`} className="govuk-hint">
+          {hint}
+        </div>
         <input
-          aria-describedby={hint ? `${fieldName}-hint` : null}
+          aria-describedby={hint ? `${name}-hint` : null}
           className="govuk-input  govuk-!-width-one-third"
-          id={`${fieldName}-input`}
-          name={fieldName}
+          id={`${name}-input`}
+          name={name}
           type={FIELD_TEXT}
           onChange={handleChange}
         />
@@ -74,14 +76,11 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
     <div className={fieldDetails.className} data-module="govuk-radios">
       {(fieldDetails.radioOptions).map((option, index) => {
         const isVisible = checkedItem === option.parentFieldValue ? true : false;
-
         return (
           <Fragment key={`${option.name}-input[${index}]`}>
             {
               option.radioField ?
                 <RadioField
-                  fieldName={fieldDetails.fieldName}
-                  hint={option.hint}
                   index={index}
                   label={option.label}
                   name={option.name}
@@ -90,10 +89,10 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
                 />
                 :
                 <TextField
-                  fieldName={option.name}
                   hint={option.hint}
                   isVisible={isVisible}
                   label={option.label}
+                  name={option.name}
                   handleChange={wrapHandleChange}
                 />
             }
@@ -105,8 +104,6 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
 };
 
 RadioField.propTypes = {
-  fieldName: PropTypes.string.isRequired,
-  hint: PropTypes.string,
   index: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
@@ -115,16 +112,16 @@ RadioField.propTypes = {
 };
 
 TextField.propTypes = {
-  fieldName: PropTypes.string.isRequired,
   hint: PropTypes.string,
   isVisible: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
 };
 
 InputConditional.propTypes = {
   fieldDetails: PropTypes.shape({
-    className: PropTypes.string, // allows us to pass an inline style
+    className: PropTypes.string.isRequired,
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
     radioOptions: PropTypes.arrayOf(

--- a/src/components/formFields/__tests__/InputConditonal.test.jsx
+++ b/src/components/formFields/__tests__/InputConditonal.test.jsx
@@ -1,0 +1,160 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FIELD_CONDITIONAL } from '../../../constants/AppConstants';
+import InputConditional from '../InputConditional';
+
+/*
+ * These tests check that we can pass in the minimum parameters and it will generate the correct input field HTML
+ * And we can pass in the maximum parameters and it will generate the correct input field HTML
+ * It does NOT test that the full form field component with labels etc is generated
+ */
+
+describe('Conditional input field generation', () => {
+  const parentHandleChange = jest.fn();
+  const fieldDetailsBasic = {
+    type: FIELD_CONDITIONAL,
+    className: 'govuk-radios',
+    label: 'What is your favourite animal',
+    fieldName: 'favAnimal',
+    grouped: true,
+    radioOptions: [
+      {
+        radioField: true,
+        label: 'Cat',
+        name: 'favAnimal',
+        value: 'cat',
+      },
+      {
+        radioField: false,
+        parentFieldValue: 'cat',
+        label: 'Breed of cat',
+        name: 'breedOfCat',
+      },
+      {
+        radioField: true,
+        label: 'Dog',
+        name: 'favAnimal',
+        value: 'dog',
+      },
+      {
+        radioField: false,
+        parentFieldValue: 'dog',
+        label: 'Breed of dog',
+        name: 'breedOfDog',
+      },
+      {
+        radioField: true,
+        label: 'Rabbit',
+        name: 'favAnimal',
+        value: 'rabbit',
+      },
+      {
+        radioField: true,
+        label: 'Other',
+        name: 'favAnimal',
+        value: 'other',
+      },
+    ],
+  };
+  const fieldDetailsAllProps = {
+    type: FIELD_CONDITIONAL,
+    className: 'govuk-radios',
+    hint: 'A hint on choosing a colour',
+    label: 'What is your favourite colour',
+    fieldName: 'favColour',
+    grouped: true,
+    radioOptions: [
+      {
+        radioField: true,
+        label: 'Red',
+        name: 'favColour',
+        value: 'red',
+      },
+      {
+        radioField: false,
+        parentFieldValue: 'red',
+        hint: 'What shade of red do you like?',
+        label: 'Shade of red',
+        name: 'shadeOfRed',
+      },
+      {
+        radioField: true,
+        label: 'Other',
+        name: 'favColour',
+        value: 'other',
+      },
+    ],
+  };
+  
+  it('should render the radio input fields with only the required props', () => {
+    render(
+      <InputConditional
+        fieldDetails={fieldDetailsBasic}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Cat' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Cat' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[0]" name="favAnimal" type="radio" value="cat">');
+    expect(screen.getByRole('radio', { name: 'Dog' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Dog' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[2]" name="favAnimal" type="radio" value="dog">');
+    expect(screen.getByRole('radio', { name: 'Rabbit' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Rabbit' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[4]" name="favAnimal" type="radio" value="rabbit">');
+    expect(screen.getByRole('radio', { name: 'Other' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Other' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[5]" name="favAnimal" type="radio" value="other">');
+  });
+
+  it('should render the radio input fields with all props', () => {
+    render(
+      <InputConditional
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Red' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Red' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favColour-input[0]" name="favColour" type="radio" value="red">');
+    expect(screen.getByRole('radio', { name: 'Other' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Other' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favColour-input[2]" name="favColour" type="radio" value="other">');
+  });
+
+  it('should make the conditional text input visible when the parent radio is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputConditional
+        fieldDetails={fieldDetailsBasic}
+        handleChange={parentHandleChange}
+      />
+    );
+    
+    // The following are conditional fields, they will exist but should have a hidden class
+    expect(screen.getByTestId('breedOfCat-container')).toBeInTheDocument();
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfDog-container')).toBeInTheDocument();
+    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text"></div></div>');
+    
+    // Click on the cat radio and now the Breed of cat should not have the hidden class aka it is visible
+    await user.click(screen.getByRole('radio', { name: 'Cat' }));
+    expect(screen.getByRole('radio', { name: 'Cat' })).toBeChecked();
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
+  
+    // Click on the dog radio and now Breed of cat should be hidden and breed of dog should be visible
+    await user.click(screen.getByRole('radio', { name: 'Dog' }));
+    expect(screen.getByRole('radio', { name: 'Dog' })).toBeChecked();
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text"></div></div>');
+  });
+
+  it('should render the hint on the conditional text field if one provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputConditional
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+      />
+    );
+    await user.click(screen.getByRole('radio', { name: 'Red' }));
+    // using a text check to test the text is in the html as it should render, but inside a div with a hidden class
+    expect(screen.getByText('What shade of red do you like?')).toBeInTheDocument();
+    // using a html check to test for the class being visible AND the help text and aria-described by being in the div
+    expect(screen.getByTestId('shadeOfRed-container').outerHTML).toEqual('<div data-testid="shadeOfRed-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="shadeOfRed-input">Shade of red</label><div id="shadeOfRed-hint" class="govuk-hint">What shade of red do you like?</div><input aria-describedby="shadeOfRed-hint" class="govuk-input govuk-!-width-one-third" id="shadeOfRed-input" name="shadeOfRed" type="text"></div></div>');
+  });
+});

--- a/src/components/formFields/__tests__/InputConditonal.test.jsx
+++ b/src/components/formFields/__tests__/InputConditonal.test.jsx
@@ -101,6 +101,8 @@ describe('Conditional input field generation', () => {
     expect(screen.getByRole('radio', { name: 'Rabbit' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[4]" name="favAnimal" type="radio" value="rabbit">');
     expect(screen.getByRole('radio', { name: 'Other' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Other' }).outerHTML).toEqual('<input class="govuk-radios__input" id="favAnimal-input[5]" name="favAnimal" type="radio" value="other">');
+    expect(screen.queryByRole('radio', { name: 'breedOfCat' })).not.toBeInTheDocument(); // tests the text field isn't displayed as radio
+    expect(screen.queryByRole('radio', { name: 'breedOfDog' })).not.toBeInTheDocument(); // tests the text field isn't displayed as radio
   });
 
   it('should render the radio input fields with all props', () => {

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -2,6 +2,7 @@
 export const SERVICE_NAME = 'National Maritime Single Window';
 
 // Forms: input types
+export const FIELD_CONDITIONAL = 'conditional';
 export const FIELD_EMAIL = 'email';
 export const FIELD_PASSWORD = 'password';
 export const FIELD_TEXT = 'text';

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -105,6 +105,7 @@ const SecondPage = () => {
         {
           radioField: false,
           parentFieldValue: 'dog',
+          hint: 'What sort of dogs do you like?',
           label: 'Breed of dog',
           name: 'breedOfDog',
         },

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import {
+  FIELD_CONDITIONAL,
   FIELD_TEXT,
   FIELD_RADIO,
   CHECKED_FALSE,
@@ -73,6 +74,51 @@ const SecondPage = () => {
         {
           type: VALIDATE_REQUIRED,
           message: 'Select your favourite colour',
+        },
+      ],
+    },
+    {
+      type: FIELD_CONDITIONAL,
+      label: 'What is your favourite animal',
+      fieldName: 'favAnimal',
+      className: 'govuk-radios',
+      grouped: true,
+      radioOptions: [
+        {
+          radioField: true,
+          label: 'Cat',
+          name: 'favAnimal',
+          value: 'cat',
+        },
+        {
+          radioField: false,
+          parentFieldValue: 'cat',
+          label: 'Breed of cat',
+          name: 'breedOfCat',
+        },
+        {
+          radioField: true,
+          label: 'Dog',
+          name: 'favAnimal',
+          value: 'dog',
+        },
+        {
+          radioField: false,
+          parentFieldValue: 'dog',
+          label: 'Breed of dog',
+          name: 'breedOfDog',
+        },
+        {
+          radioField: true,
+          label: 'Rabbit',
+          name: 'favAnimal',
+          value: 'rabbit',
+        },
+        {
+          radioField: true,
+          label: 'Other',
+          name: 'favAnimal',
+          value: 'other',
         },
       ],
     },

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -29,7 +29,7 @@ const Validator = ({ formData, formFields }) => {
   const fieldsToValidate = Object.entries(formData).reduce((result, field) => { // result is our accumulator that starts as an empty array as defined at end of reduce
     const key = field[0];
     const value = field[1];
-    const rules = formFields.find(field => field.fieldName === key).validation; // find all the rules for this field, if any
+    const rules = formFields.find(field => field.fieldName === key) ?  formFields.find(field => field.fieldName === key).validation : null; // find all the rules for this field, if any
 
     if (rules) {
       rules.map((rule) => {


### PR DESCRIPTION
# Ticket

NMSW-140

----

## AC

Given I am on a form with conditional fields
When I select an option that has a connected text input
Then I should see the connected text input

Given I am on a form with conditional fields
When I select an option that does not have the connected text input
Then I should not see the connected text input

----

## To test

- run locally
- go to second page form
- > the last question should be a set of radio buttons
- select `dog`
- > the breed of dog question should be shown
- type something in that field
- select `cat`
- > the breed of dog field should be hidden
- > the breed of cat field should be displayed
- select `dog`
- > the breed of dog field should be shown
- > the breed of cat field should be hidden
- select `rabbit`
- > the breed of dog field should be hidden

----

## Notes

- there is no error handling yet
- there is no saving to session and prefilling from session yet