### PR TITLE
NMSW-140 Extend conditional field input to persist data on refresh

### DIFF
--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -478,7 +478,7 @@ describe('Display Form', () => {
   // PREFILLING DATA
   it('should store form data in the session for use on refresh', async () => {
     const user = userEvent.setup();
-    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo"}';
+    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","radioWithConditional":"optionWithConditional","conditionalTextInput":"world"}';
     render(
       <DisplayForm
         formId="testForm"
@@ -491,6 +491,10 @@ describe('Display Form', () => {
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
     await user.click(screen.getByRole('radio', { name: 'Radio two' }));
     expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    await user.click(screen.getByRole('radio', { name: 'Option that has a conditional' }));
+    expect(screen.getByRole('radio', { name: 'Option that has a conditional' })).toBeChecked();
+    await user.type(screen.getByLabelText('Conditional text input'), 'world');
+    expect(screen.getByLabelText('Conditional text input')).toHaveValue('world');
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 
@@ -513,8 +517,8 @@ describe('Display Form', () => {
   });
 
   it('should prefill form with data from session if it exists', async () => {
-    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
-    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne","radioWithConditional":"optionWithConditional","conditionalTextInput":"world"}';
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne', radioWithConditional: 'optionWithConditional', conditionalTextInput: 'world' }));
     render(
       <DisplayForm
         formId="testForm"
@@ -525,6 +529,8 @@ describe('Display Form', () => {
     );
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
     expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Option that has a conditional' })).toBeChecked();
+    expect(screen.getByLabelText('Conditional text input')).toHaveValue('world');
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
   });
 

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -2,11 +2,12 @@ import { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FIELD_RADIO, FIELD_TEXT } from '../../constants/AppConstants';
 
-const RadioField = ({ index, label, name, value, handleChange }) => {
+const RadioField = ({ checkedState, index, label, name, value, handleChange }) => {
   return (
     <div className="govuk-radios__item">
       <input
         className="govuk-radios__input"
+        defaultChecked={checkedState}
         id={`${name}-input[${index}]`}
         name={name}
         type={FIELD_RADIO}
@@ -20,7 +21,7 @@ const RadioField = ({ index, label, name, value, handleChange }) => {
   );
 };
 
-const TextField = ({ hint, isVisible, label, name, handleChange }) => {
+const TextField = ({ hint, isVisible, label, name, value, handleChange }) => {
   return (
     <div data-testid={`${name}-container`} className={isVisible ? 'govuk-radios__conditional' : 'govuk-radios__conditional govuk-radios__conditional--hidden'}>
       <div className='govuk-form-group'>
@@ -33,6 +34,7 @@ const TextField = ({ hint, isVisible, label, name, handleChange }) => {
         <input
           aria-describedby={hint ? `${name}-hint` : null}
           className="govuk-input govuk-!-width-one-third"
+          defaultValue={value}
           id={`${name}-input`}
           name={name}
           type={FIELD_TEXT}
@@ -45,18 +47,38 @@ const TextField = ({ hint, isVisible, label, name, handleChange }) => {
 
 
 const InputConditional = ({ fieldDetails, handleChange }) => {
-  const [checkedItem, setCheckedItem] = useState();
+  const [activeConditionalField, setActiveConditionalField] = useState();
+  const [checkedItem, setCheckedItem] = useState(fieldDetails.value);
+  const [conditionalDefaultValue, setConditionalDefaultValue] = useState(fieldDetails.conditionalValueToFill?.value);
 
-  const wrapHandleChange = async (e) => {
+  const wrapHandleChange = (e) => {
+    let formattedItemToClear;
     if (e.target.type === FIELD_RADIO) {
       setCheckedItem(e.target.value);
+      // clear any current conditional fields (only one radio can be selected at a time so only one conditional can be open at a time)
+      if (activeConditionalField) {
+        document.getElementById(`${activeConditionalField.name}-input`).value = null;
+        formattedItemToClear = {
+          target: {
+            name: activeConditionalField.name,
+            value: null,
+          }
+        };
+      }
+      // find it's conditional field (if any) and update it
+      const conditionalField = fieldDetails.radioOptions.find(({ parentFieldValue }) => parentFieldValue === e.target.value);
+      setActiveConditionalField(conditionalField);
+      setConditionalDefaultValue(null); // once the field is changed the default is no longer valid
     }
-    handleChange(e);
+    handleChange(e, formattedItemToClear);
   };
 
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">
       {(fieldDetails.radioOptions).map((option, index) => {
+        const checkedState = checkedItem === option.value ? true : option.checked;
+        const conditionalValuePrefill = checkedItem === option.parentFieldValue ? conditionalDefaultValue : null;
+        
         const isVisible = checkedItem === option.parentFieldValue ? true : false;
 
         return (
@@ -64,7 +86,7 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
             {
               option.radioField ?
                 <RadioField
-                  hint={option.hint}
+                  checkedState={checkedState}
                   index={index}
                   label={option.label}
                   name={option.name}
@@ -77,6 +99,7 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
                   isVisible={isVisible}
                   label={option.label}
                   name={option.name}
+                  value={conditionalValuePrefill}
                   handleChange={wrapHandleChange}
                 />
             }
@@ -88,6 +111,7 @@ const InputConditional = ({ fieldDetails, handleChange }) => {
 };
 
 RadioField.propTypes = {
+  checkedState: PropTypes.bool,
   index: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
@@ -100,12 +124,14 @@ TextField.propTypes = {
   isVisible: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  value: PropTypes.string,
   handleChange: PropTypes.func.isRequired,
 };
 
 InputConditional.propTypes = {
   fieldDetails: PropTypes.shape({
     className: PropTypes.string.isRequired,
+    conditionalValueToFill: PropTypes.object,
     fieldName: PropTypes.string.isRequired,
     hint: PropTypes.string,
     radioOptions: PropTypes.arrayOf(
@@ -115,6 +141,7 @@ InputConditional.propTypes = {
         label: PropTypes.string.isRequired,
         value: PropTypes.string,
       })).isRequired,
+    value: PropTypes.string,
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
 };

--- a/src/components/formFields/__tests__/InputConditonal.test.jsx
+++ b/src/components/formFields/__tests__/InputConditonal.test.jsx
@@ -85,6 +85,36 @@ describe('Conditional input field generation', () => {
       },
     ],
   };
+  const fieldDetailsWithValueSelected = {
+    type: FIELD_CONDITIONAL,
+    className: 'govuk-radios',
+    hint: 'A hint on choosing a colour',
+    label: 'What is your favourite colour',
+    fieldName: 'favColour',
+    grouped: true,
+    radioOptions: [
+      {
+        radioField: true,
+        label: 'Red',
+        name: 'favColour',
+        value: 'red',
+      },
+      {
+        radioField: false,
+        parentFieldValue: 'red',
+        hint: 'What shade of red do you like?',
+        label: 'Shade of red',
+        name: 'shadeOfRed',
+      },
+      {
+        radioField: true,
+        label: 'Other',
+        name: 'favColour',
+        value: 'other',
+      },
+    ],
+    value: 'red',
+  };
   
   it('should render the radio input fields with only the required props', () => {
     render(
@@ -129,20 +159,20 @@ describe('Conditional input field generation', () => {
     
     // The following are conditional fields, they will exist but should have a hidden class
     expect(screen.getByTestId('breedOfCat-container')).toBeInTheDocument();
-    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text" value=""></div></div>');
     expect(screen.getByTestId('breedOfDog-container')).toBeInTheDocument();
-    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text" value=""></div></div>');
     
     // Click on the cat radio and now the Breed of cat should not have the hidden class aka it is visible
     await user.click(screen.getByRole('radio', { name: 'Cat' }));
     expect(screen.getByRole('radio', { name: 'Cat' })).toBeChecked();
-    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text" value=""></div></div>');
   
     // Click on the dog radio and now Breed of cat should be hidden and breed of dog should be visible
     await user.click(screen.getByRole('radio', { name: 'Dog' }));
     expect(screen.getByRole('radio', { name: 'Dog' })).toBeChecked();
-    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text"></div></div>');
-    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text"></div></div>');
+    expect(screen.getByTestId('breedOfCat-container').outerHTML).toEqual('<div data-testid="breedOfCat-container" class="govuk-radios__conditional govuk-radios__conditional--hidden"><div class="govuk-form-group"><label class="govuk-label" for="breedOfCat-input">Breed of cat</label><div id="breedOfCat-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfCat-input" name="breedOfCat" type="text" value=""></div></div>');
+    expect(screen.getByTestId('breedOfDog-container').outerHTML).toEqual('<div data-testid="breedOfDog-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="breedOfDog-input">Breed of dog</label><div id="breedOfDog-hint" class="govuk-hint"></div><input class="govuk-input govuk-!-width-one-third" id="breedOfDog-input" name="breedOfDog" type="text" value=""></div></div>');
   });
 
   it('should render the hint on the conditional text field if one provided', async () => {
@@ -157,6 +187,18 @@ describe('Conditional input field generation', () => {
     // using a text check to test the text is in the html as it should render, but inside a div with a hidden class
     expect(screen.getByText('What shade of red do you like?')).toBeInTheDocument();
     // using a html check to test for the class being visible AND the help text and aria-described by being in the div
-    expect(screen.getByTestId('shadeOfRed-container').outerHTML).toEqual('<div data-testid="shadeOfRed-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="shadeOfRed-input">Shade of red</label><div id="shadeOfRed-hint" class="govuk-hint">What shade of red do you like?</div><input aria-describedby="shadeOfRed-hint" class="govuk-input govuk-!-width-one-third" id="shadeOfRed-input" name="shadeOfRed" type="text"></div></div>');
+    expect(screen.getByTestId('shadeOfRed-container').outerHTML).toEqual('<div data-testid="shadeOfRed-container" class="govuk-radios__conditional"><div class="govuk-form-group"><label class="govuk-label" for="shadeOfRed-input">Shade of red</label><div id="shadeOfRed-hint" class="govuk-hint">What shade of red do you like?</div><input aria-describedby="shadeOfRed-hint" class="govuk-input govuk-!-width-one-third" id="shadeOfRed-input" name="shadeOfRed" type="text" value=""></div></div>');
+  });
+
+  it('should check the field if the value is passed in', () => {
+    render(
+      <InputConditional
+        fieldDetails={fieldDetailsWithValueSelected}
+        handleChange={parentHandleChange}
+        type='radio'
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Red' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Other' })).not.toBeChecked();
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-140

----

## AC

Given I have clicked on a radio with a connected field
When I enter something in that field
And refresh the browser
Then the radio I've selected remains selected
And the value I've entered in the connected field remains

----

## To test

- run app locally
- go to second page
- click on `cat`
- type something in the text field
- refresh browser
- > cat should remain selected
- > the text you typed should remain in the text field

----

## Notes

If you 
- select a radio with a conditional field
- enter something in the conditional text field
- hit refresh
- submit the form with. no other actions
- > the conditional field value is not submitted
This is being worked on now 