### PR TITLE
NMSW-140 Bug fix, conditional field value not storing in form data on page refresh and persist -- FIXED

### DIFF
--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FIELD_RADIO, FIELD_TEXT } from '../../constants/AppConstants';
+import { useEffect } from 'react';
 
 const RadioField = ({ checkedState, index, label, name, value, handleChange }) => {
   return (
@@ -76,6 +77,18 @@ const InputConditional = ({ errors, fieldDetails, handleChange }) => {
     }
     handleChange(e, formattedItemToClear);
   };
+
+  useEffect(() => {
+    if (conditionalDefaultValue) {
+      const formatPrefilledItem = {
+        target: {
+          name: fieldDetails.conditionalValueToFill.name,
+          value: fieldDetails.conditionalValueToFill.value,
+        }
+      };
+      handleChange(formatPrefilledItem);
+    }
+  }, [conditionalDefaultValue]);
 
   return (
     <div className={fieldDetails.className} data-module="govuk-radios">

--- a/src/components/formFields/InputConditional.jsx
+++ b/src/components/formFields/InputConditional.jsx
@@ -42,6 +42,7 @@ const TextField = ({ errors, hint, isVisible, label, name, value, handleChange }
           name={name}
           type={FIELD_TEXT}
           onChange={handleChange}
+          onPaste={handleChange}
         />
       </div>
     </div>

--- a/src/components/formFields/InputText.jsx
+++ b/src/components/formFields/InputText.jsx
@@ -11,6 +11,7 @@ const InputText = ({ autoComplete, dataTestid, error, fieldDetails, handleChange
       type={type}
       autoComplete={autoComplete}
       onChange={handleChange}
+      onPaste={handleChange}
       aria-describedby={fieldDetails.hint ? `${fieldDetails.fieldName}-hint` : null}
       defaultValue={fieldDetails.value}
     />

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -158,7 +158,7 @@ const SecondPage = () => {
           formName: 'Second page',
           nextPageLink: DASHBOARD_URL,
           nextPageName: DASHBOARD_PAGE_NAME,
-          referenceNumber: `${formData.favouriteColour}-123`
+          referenceNumber: `${formData.breedOfCat}-123`
         }
       }
     );


### PR DESCRIPTION
# Ticket

NMSW-140

----

## AC
To replicate bug

- select a radio with a conditional field
- enter something in the conditional text field
- hit refresh
- submit the form with. no other actions 
- > the conditional field value is not submitted


----

## To test

To test

- run locally
- go to second page form
- enter a first name
- select a colour
- select `cat`
- enter something in `breed of cat`
- refresh page
- submit the form with no other actions 
- > the confirmation page should load
- > the reference should include what you typed in breed of cat to show it is being passed through

----

## Notes
