### PR TITLE
NMSW-140 Install accessible autocomplete package from alphagov

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nmsw-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nmsw-ui",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "accessible-autocomplete": "^2.0.4",
         "govuk-frontend": "^4.3.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -4937,6 +4938,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "dependencies": {
+        "preact": "^8.3.1"
       }
     },
     "node_modules/acorn": {
@@ -13776,6 +13785,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
+      "hasInstallScript": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -20163,6 +20178,14 @@
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
+      }
+    },
+    "accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "requires": {
+        "preact": "^8.3.1"
       }
     },
     "acorn": {
@@ -26631,6 +26654,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-dev-server": "^4.11.0"
   },
   "dependencies": {
+    "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "^4.3.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,4 +1,5 @@
 @import '~govuk-frontend/govuk/all';
+@import "accessible-autocomplete";
 
 // ===================
 // Layout Overrides
@@ -37,6 +38,16 @@ body {
   .govuk-header__navigation-list--open {
     display: block !important;
   }
+}
+
+// ===================
+// Form Overrides
+// ===================
+.autocomplete-input .autocomplete__wrapper input {
+  border-color:  $govuk-input-border-colour;
+}
+.autocomplete-input--error .autocomplete__wrapper input {
+  border-color:  $govuk-error-colour;
 }
 
 // ========================


### PR DESCRIPTION
# Ticket

NMSW-140

----

## AC

Install package in preparation for use
https://github.com/alphagov/accessible-autocomplete

----

## To test

- remove node-modules
- run `npm ci`
- `"accessible-autocomplete": "^2.0.4"` should be listed in dependencies

----

## Notes
