### PR TITLE
NMSW-33 Expand autocomplete component to submit additional data

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -25,24 +25,30 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
     }
 
     // create the dataset to store, accounting for objects coming from autocomplete
-    const dataSet = e.target.additionalDetails 
+    const additionalDetails = e.target.additionalDetails
       ? { [`${[e.target.name]}${EXPANDED_DETAILS}`]: e.target.additionalDetails, [e.target.name]: e.target.value }
-      :  { [e.target.name]: e.target.value };
+      : { [e.target.name]: e.target.value };
+
+    const dataSet = {
+      [e.target.name]: e.target.value,
+      ...additionalDetails,
+      [itemToClear?.target.name]: itemToClear?.target.value
+    };
 
     // we do not store passwords in session data
     if (e.target.name !== FIELD_PASSWORD) {
-      setSessionData({ ...sessionData, [e.target.name]: e.target.value, ...dataSet, [itemToClear?.target.name]: itemToClear?.target.value });
-      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, ...dataSet, [e.target.name]: e.target.value, [itemToClear?.target.name]: itemToClear?.target.value }));
+      setSessionData({ ...sessionData, ...dataSet });
+      sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, ...dataSet }));
     }
     // we do store all values into form data
-    setFormData({ ...formData, [e.target.name]: e.target.value, ...dataSet, [itemToClear?.target.name]: itemToClear?.target.value });
+    setFormData({ ...formData, ...dataSet });
   };
 
   const handleValidation = async (e, formData) => {
     e.preventDefault();
     const formErrors = await Validator({ formData: formData.formData, formFields: fields });
     setErrors(formErrors);
-    
+
     if (formErrors.length < 1) {
       /*
        * Returning formData
@@ -99,7 +105,7 @@ const DisplayForm = ({ fields, formId, formActions, handleSubmit }) => {
   useEffect(() => {
     let sessionDataArray;
     if (sessionData) {
-      sessionDataArray = Object.entries(sessionData).map(item => { return {name: item[0], value: item[1]}; });
+      sessionDataArray = Object.entries(sessionData).map(item => { return { name: item[0], value: item[1] }; });
     }
 
     const mappedFormFields = fields.map((field) => {

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -499,7 +499,7 @@ describe('Display Form', () => {
 
   it('should store expanded data if it is provided from an autocomplete field', async () => {
     const user = userEvent.setup();
-    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","itemsExpandedDetails":{"items":{"name":"ObjectTwo","identifier":"two"}},"items":"ObjectTwo"}';
+    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","items":"ObjectTwo","itemsExpandedDetails":{"items":{"name":"ObjectTwo","identifier":"two"}}}';
     render(
       <DisplayForm
         formId="testForm"

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -497,6 +497,28 @@ describe('Display Form', () => {
     expect(screen.getByTestId('password-passwordField')).toBeInTheDocument();
   });
 
+  it('should store expanded data if it is provided from an autocomplete field', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","itemsExpandedDetails":{"items":{"name":"ObjectTwo","identifier":"two"}},"items":"ObjectTwo"}';
+    render(
+      <DisplayForm
+        formId="testForm"
+        fields={formWithMultipleFields}
+        formActions={formActionsSubmitOnly}
+        handleSubmit={handleSubmit}
+      />
+    );
+    await user.type(screen.getByLabelText('Text input'), 'Hello');
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
+    await user.click(screen.getByRole('radio', { name: 'Radio two' }));
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeChecked();
+    await user.type(screen.getByRole('combobox', { name: 'Autocomplete input' }), 'Object');
+    await user.click(screen.getByText('ObjectTwo'));
+    expect(screen.getByRole('combobox', { name: 'Autocomplete input' })).toHaveValue('ObjectTwo');
+
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
+
   // ERRORS
   it('should render error summary & field error if there are field errors', async () => {
     const user = userEvent.setup();

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -59,11 +59,15 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       displayValue = e[fieldDetails.responseKey];
     }
 
-    // format the data so it can be accepted by the handleChange function
+    // We want to include both the display value, and any additional field object information received from the API
+    // So the page's handleSubmit can decide what to send on the POST/PUT call
     const formattedEvent = {
       target: {
         name: fieldDetails.fieldName,
         value: displayValue,
+        additionalDetails: {
+          [fieldDetails.fieldName]: e
+        },
       }
     };
 

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -1,6 +1,8 @@
 // Site
 export const SERVICE_NAME = 'National Maritime Single Window';
 
+// Forms: identifiers
+export const EXPANDED_DETAILS = 'ExpandedDetails';
 // Forms: input types
 export const FIELD_AUTOCOMPLETE = 'autocomplete';
 export const FIELD_CONDITIONAL = 'conditional';

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -182,7 +182,7 @@ const SecondPage = () => {
           formName: 'Second page',
           nextPageLink: DASHBOARD_URL,
           nextPageName: DASHBOARD_PAGE_NAME,
-          referenceNumber: `Country: ${formData.country}, Port: ${formData.port}`
+          referenceNumber: `CountryCode: ${formData.countryExpandedDetails.country.code}, Port: ${formData.portExpandedDetails.port.unlocode}`
         }
       }
     );


### PR DESCRIPTION
# Ticket

NMSW-33

----

## AC

Given an autocomplete field's selected value has additional details
When the form is submitted
Then the additional details should be sent with the form data

----

## To test

- run locally
- go to second form
- fill in all fields
- for port select a port with a unlocode (eg Dover GB DOV)
- click submit
- > the submitted data should include extended data for country (name, code) and port (name, unlocode)
- > the confirmation page should show the country code and unlocode
- go back to second form
- fill in all fields
- for port select a port with NO unlocode (eg Dover Marina)
- click submit
- > the submitted data should include extended data for country (name, code) and port (name)
- > the confirmation page should show the country code correctly, and the unlocode as UNDEFINED

----

## Notes

Field has
- no error handling
- no persist data on refresh