### PR TITLE
NMSW-33 Extend autocomplete component to persist data on refresh and handle errors

### DIFF
--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -15,6 +15,14 @@ import Autocomplete from 'accessible-autocomplete/react';
 const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
 
+  /* 
+   * There is no onBlur event available for us to place a function on
+   * There is no onKeyPress event available for us to place a function on
+   * There is no current way other than vanillaJS to capture that the
+   * user has cleared the field with delete/backspace and then 
+   * clear the value from formData/sessionData
+   */
+
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
     // TODO: We should look at using lodash.debounce to prevent calls being made too fast as user types
@@ -97,6 +105,26 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     }
   }, [hideListBox]);
 
+  useEffect(() => {
+    const handleKeypress = e => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        const formattedEvent = {
+          target: {
+            name: e.target.name,
+            value: null,
+            additionalDetails: {},
+          }
+        };
+        handleChange(formattedEvent);
+      }
+    };
+    const element = document.getElementById(`${fieldDetails.fieldName}-input`);
+    element.addEventListener('keydown', handleKeypress);
+    return () => {
+      element.removeEventListener('keydown', handleKeypress);
+    };
+  }, []);
+
   // We need to use the template function to handle our results coming in objects
   // this lets us format the strings to display as we like
   // for more details see https://github.com/alphagov/accessible-autocomplete
@@ -108,7 +136,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       <Autocomplete
         confirmOnBlur={false}
         id={`${fieldDetails.fieldName}-input`}
-        minLength={2}
+        minLength={1}
         name={fieldDetails.fieldName}
         source={suggest}
         templates={{

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -2,26 +2,17 @@ import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Autocomplete from 'accessible-autocomplete/react';
 
-// there is an open PR to fix the aria-activedescendent issue: 
-// https://github.com/alphagov/accessible-autocomplete/issues/434
-// https://github.com/alphagov/accessible-autocomplete/pull/553/files
-
-// The aria-activedescendent looks to work correctly, if you use your mouse to select an item from the list
-// then aria-activedescendent's value changes and voice over reads it out correctly
-// The error occurs because when the combobox pop up (list) is closed, the value of aria-activedescendent is set to = 'false'
-// and false is an invalid value for it.
-// some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
-
+/* there is an open PR to fix the aria-activedescendent issue: 
+ * https://github.com/alphagov/accessible-autocomplete/issues/434
+ * https://github.com/alphagov/accessible-autocomplete/pull/553/files
+ * The aria-activedescendent looks to work correctly, if you use your mouse to select an item from the list
+ * then aria-activedescendent's value changes and voice over reads it out correctly
+ * The error occurs because when the combobox pop up (list) is closed, the value of aria-activedescendent is set to = 'false'
+ * and false is an invalid value for it.
+ * some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
+*/
 const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
-
-  /* 
-   * There is no onBlur event available for us to place a function on
-   * There is no onKeyPress event available for us to place a function on
-   * There is no current way other than vanillaJS to capture that the
-   * user has cleared the field with delete/backspace and then 
-   * clear the value from formData/sessionData
-   */
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -84,19 +75,24 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     handleChange(formattedEvent);
   };
 
-  // See issue#424, #495, at alphagov/accessible-autocomplete
-  // There is an ongoing issue around setting defaultValue when using template
-  // whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
-  // it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
-  // the workaround is to use javascript to set the value of the input which forces the suggest to run
-  // TODO: when fixed on alphagov/accessible-autocomplete, fix here
+  /* See issue#424, #495, at alphagov/accessible-autocomplete
+    * There is an ongoing issue around setting defaultValue when using template
+    * whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
+    * it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
+    * the workaround is to use javascript to set the value of the input which forces the suggest to run
+    * TODO: when fixed on alphagov/accessible-autocomplete, fix here
+  */
   useEffect(() => {
     if (!fieldDetails.value) {
       return;
     }
     document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
     setHideListBox(true);
+
+    // TODO: when we connect this to an API call we will make the API call here to get the data
+    // trigger a handle confirm so that any additional field values are also passed back to the form data and not lost
   }, [fieldDetails.value]);
+
 
   useEffect(() => {
     if (hideListBox) {
@@ -105,6 +101,13 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     }
   }, [hideListBox]);
 
+  /* 
+   * There is no onBlur event available for us to place a function on
+   * There is no onKeyPress event available for us to place a function on
+   * There is no current way other than vanillaJS to capture that the
+   * user has cleared the field with delete/backspace and then 
+   * clear the value from formData/sessionData
+  */
   useEffect(() => {
     const handleKeypress = e => {
       if (e.key === 'Delete' || e.key === 'Backspace') {

--- a/src/components/formFields/__tests__/InputAutocomplete.test.jsx
+++ b/src/components/formFields/__tests__/InputAutocomplete.test.jsx
@@ -168,4 +168,50 @@ describe('Text input field generation', () => {
     expect(screen.getByRole('combobox', { name: '' })).toHaveValue('ObjectTwo two');
   });
 
+  it('should call handleChange function if user clears field via backspace key', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsTwoResponseKeys}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+
+    const input = screen.getByRole('combobox', { name: '' });
+
+    await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
+    await user.click(screen.getByText('ObjectTwo two'));
+    expect(input).toHaveValue('ObjectTwo two');
+    
+    input.setSelectionRange(0, 14);
+    await user.keyboard('{backspace}');
+    expect(input).toHaveValue('');
+    expect(parentHandleChange).toHaveBeenCalled();
+  });
+
+  it('should call handleChange function if user clears field via delete key', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputAutocomplete
+        fieldDetails={fieldDetailsTwoResponseKeys}
+        handleChange={parentHandleChange}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
+
+    const input = screen.getByRole('combobox', { name: '' });
+
+    await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
+    await user.click(screen.getByText('ObjectOne one'));
+    expect(input).toHaveValue('ObjectOne one');
+    
+    input.setSelectionRange(0, 14);
+    await user.keyboard('{delete}');
+    expect(input).toHaveValue('');
+    expect(parentHandleChange).toHaveBeenCalled();
+  });
+
 });

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -181,6 +181,13 @@ const SecondPage = () => {
   ];
 
   const handleSubmit = ({ formData }) => {
+    let referenceNumber;
+    if (formData.countryExpandedDetails?.country && formData.portExpandedDetails?.port) {
+      referenceNumber = `CountryCode: ${formData.countryExpandedDetails.country.code}, Port: ${formData.portExpandedDetails.port.unlocode}`;
+    } else {
+      referenceNumber = `Country: ${formData.country}, Port: ${formData.port}`;
+    }
+
     navigate(
       FORM_CONFIRMATION_URL,
       {
@@ -188,7 +195,7 @@ const SecondPage = () => {
           formName: 'Second page',
           nextPageLink: DASHBOARD_URL,
           nextPageName: DASHBOARD_PAGE_NAME,
-          referenceNumber: `CountryCode: ${formData.countryExpandedDetails.country.code}, Port: ${formData.portExpandedDetails.port.unlocode}`
+          referenceNumber: referenceNumber
         }
       }
     );

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -160,7 +160,7 @@ const SecondPage = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Select your country',
+          message: 'Select your country from the list',
         },
       ],
     },
@@ -170,7 +170,13 @@ const SecondPage = () => {
       fieldName: 'port',
       dataAPIEndpoint: portList,
       responseKey: 'name',
-      additionalKey: 'unlocode'
+      additionalKey: 'unlocode',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select your port from the list',
+        },
+      ],
     },
   ];
 


### PR DESCRIPTION
# Ticket

NMSW-33

----

## AC

Given I have selected a value in an autocomplete field
When I refresh the page
Then the data should persist in the field

~~Given I have selected a value in an autocomplete field
And I have refreshed the page
When I submit the form
Then the full data should be submitted~~

Given I have attempted to submit a form with an autocomplete field
When the field is required
And has no value
Then an error should be shown

----

## To test

- run locally
- go to second page
- submit the form
- > the country field should error
- > the port field should error
- select a country
- refresh the page
- > the country field should remain populated
- select a port field with a unlocode
- refresh the page
- > the port field should persist with `name unlocode`
- submit the form
- > the form should submit



----

## Notes

This scenario is proving difficult to mock, and given we will only populate autocomplete fields from API calls I have left a comment to add the API function on persisting data as well as on populating fields for when we extend this component to get data from an API endpoint
