### PR TITLE
NMSW-155 New routes & field match validator

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -2,33 +2,92 @@
 
 This app has an in built form creator with reusable components for if you wish to add more forms.
 
+## DisplayForm
+- [Display Form](#display-form)
+
 ## Field actions
-- [Form action options](#FormActionOptions)
+- [Form action options](#form-action-options)
 
 ## Field types
 Standard inputs
-- [Autocomplete](#Autocomplete)
-- [Radio buttons](#RadioButtons)
-- [Radio buttons with conditional text field(s)](#Conditionals)
-- [Text input](#TextInput)
+- [Autocomplete](#autocomplete)
+- [Radio buttons](#radio-buttons)
+- [Radio buttons with conditional text field(s)](#conditionals)
+- [Text input](#text-input)
 
 Specific inputs
-- TODO: [Date](#Date)
-- [Email](#Email)
-- [Password](#Password)
+- TODO: [Date](#date)
+- [Email](#email)
+- [Password](#password)
+- [Phone Number](#phone-number)
 
 Validating fields
-- [Required](#Required)
-- [Conditional](#Conditional)
-- [Email Format](#EmailFormat)
-- [Match](#Match)
-- [Minimum Length](#MinimumLength)
+- [required](#required)
+- [Conditional](#conditional)
+- [Email Format](#email-format)
+- [Match](#match)
+- [Minimum Length](#minimum-length)
+- [Phone Number Format](#phone-number-format)
 
 
 ## Other guides
 - <a href="https://github.com/UKHomeOffice/nmsw-ui/blob/main/docs/form_creator_example.md">Create a new form - step by step example</a>
 - <a href="https://github.com/UKHomeOffice/nmsw-ui/blob/main/docs/form_creator_new_input_type.md">Creating a new input type</a>
 - [Structure diagram for reference](#StructureDiagram) (updated November 2022)
+----
+
+## Display Form
+
+Structure:
+```javascript
+<DisplayForm
+  formId=<required>
+  fields={formFields}
+  formActions={formActions}
+  formType=<required>
+  pageHeading=<required>
+  handleSubmit={handleSubmit}
+/>
+```
+
+You can also pass children to the component
+e.g. if you have a SupportingText component you would pass as follows:
+```javascript
+<DisplayForm
+  formId=<required>
+  fields={formFields}
+  formActions={formActions}
+  formType=<required>
+  pageHeading=<required>
+  handleSubmit={handleSubmit}
+>
+  <SupportingText />
+</DisplayForm>
+```
+
+Parameters
+
+### formId
+An identifier for your form element
+
+### formFields
+Must always be {formFields} which you must define within the component that is calling the DisplayForm component. (see Field Types)
+
+### formAction
+Must always be {formAction} which you must define within the component that is calling the DisplayForm component. (see Form Action Options)
+
+### formType
+Can be SINGLE_PAGE_FORM - if the form has one page. This will clear any session data for the form when `submit` or `back` are clicked
+Or MULTI_PAGE_FORM - if the form has multiple pages. This will persist session data as the user moves through the form and only clear it when they go to another section of the site.
+
+When using MULTI_PAGE_FORM you should add a `sessionStorage.removeItem('formData')` within the handleSubmit of the last page of your form.
+
+### pageHeading
+What will be the h1 of your page. We have to pass it to the form to display as any error summary is shown ABOVE the h1
+
+### handleSubmit
+Your handleSubmit action from the page
+
 ----
 
 ## Form Action Options
@@ -49,9 +108,9 @@ Your `Page` must contain
 Object structure:
 
 ```
-[action]: {
-  className: [required],
-  label: [required],
+<action>: {
+  className: <required>,
+  label: <required>,
 }
 ```
 
@@ -81,12 +140,12 @@ Object structure
 ```
 {
   type: FIELD_AUTOCOMPLETE,
-  dataAPIEndpoint: [required],
-  fieldName: [required],
-  hint: [optional]
-  label: [required],
-  responseKey: [required],
-  additionalKey: [OPTIONAL: additional data key],
+  dataAPIEndpoint: <required>,
+  fieldName: <required>,
+  hint: <optional>
+  label: <required>,
+  responseKey: <required>,
+  additionalKey: <OPTIONAL: additional data key>,
 }
 ```
 
@@ -132,17 +191,17 @@ Object structure
 ```
 {
   type: FIELD_RADIO,
-  className: [required],
-  fieldName: [required],
+  className: <required>,
+  fieldName: <required>,
   grouped: true,
-  hint: [optional]
-  label: [required],
+  hint: <optional>
+  label: <required>,
   radioOptions: [
     {
-      label: [required],
-      name: [required],
-      value: [required],
-      checked: [optional]
+      label: <required>,
+      name: <required>,
+      value: <required>,
+      checked: <optional>
     },
   ],
 },
@@ -195,24 +254,24 @@ Object structure
 ```
 {
   type: FIELD_CONDITIONAL,
-  className: [required],
-  fieldName: [required],
+  className: <required>,
+  fieldName: <required>,
   grouped: true,
-  hint: [optional],
-  label: [required],
+  hint: <optional>,
+  label: <required>,
   radioOptions: [
     {
-      radioField: [required],
-      label: [required],
-      name: [required],
-      value: [required],
+      radioField: <required>,
+      label: <required>,
+      name: <required>,
+      value: <required>,
     },
     {
-      radioField: [required],
-      parentFieldValue: [required],
-      hint: [optional],
-      label: [required],
-      name: [required],
+      radioField: <required>,
+      parentFieldValue: <required>,
+      hint: <optional>,
+      label: <required>,
+      name: <required>,
     },
   ],
 },
@@ -266,9 +325,9 @@ Object structure
 ```
 {
   type: FIELD_TEXT,
-  fieldName: [required],
-  hint: [optional],
-  label: [required]
+  fieldName: <required>,
+  hint: <optional>,
+  label: <required>
 }
 ```
 
@@ -299,9 +358,9 @@ Object structure
 ```
 {
   type: FIELD_EMAIL,
-  fieldName: [required],
-  hint: [optional],
-  label: [required]
+  fieldName: <required>,
+  hint: <optional>,
+  label: <required>
 }
 ```
 
@@ -332,9 +391,9 @@ Object structure
 ```
 {
   type: FIELD_PASSWORD,
-  fieldName: [required],
-  hint: [optional],
-  label: [required]
+  fieldName: <required>,
+  hint: <optional>,
+  label: <required>
 }
 ```
 
@@ -342,6 +401,46 @@ Parameters
 
 ### type
 Import and use `FIELD_PASSWORD` from `src/constants/AppConstants`
+
+### fieldName
+A string that will be used for `name` and to create `id` and other field references.
+
+### grouped
+Always specify this as `true` as phone number fields are grouped inputs and use a different fieldset/label html structure.
+This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `grouped: true` does not need to be specified within the field object
+
+### hint (optional)
+An optional string
+
+### label
+A string that will be shown as the question/label text for the field
+
+----
+
+## Phone Number
+
+Requirements
+
+n/a
+
+Object structure
+
+```
+{
+  type: FIELD_PHONE,
+  fieldName: <required>,
+  hint: <optional>,
+  label: <required>
+}
+```
+
+Parameters
+
+### type
+Import and use `FIELD_PHONE` from `src/constants/AppConstants`
+We use FIELD_PHONE as it provides a specific layout and handles separating the country code from the rest of the phone number, as well as reformatting the number for use within two inputs in the UI as the API will return a single string (with specific formatting)
+
+You should always include phone number validation with a phone number field
 
 ### fieldName
 A string that will be used for `name` and to create `id` and other field references.
@@ -359,7 +458,14 @@ If a field requires validation you add a validation array to the field object.
 A field can have no validation array (no rules), an array with one object (rule), or an array with multiple objects (rules)
 
 1. [Rules](#rules)
+- [Required](#required)
+- [Conditional](#conditional)
+- [Email Format](#email-format)
+- [Match](#match)
+- [Minimum Length](#minimum-length)
+- [Phone Number Format](#phone-number-format)
 2. [Examples](#examples)
+
 
 ### Rules
 
@@ -369,7 +475,7 @@ Field is a mandatory field and cannot be nul
 ```
 {
   type: VALIDATE_REQUIRED,
-  message: [error message to show in UI]
+  message: <error message to show in UI>
 }
 ```
 
@@ -381,10 +487,10 @@ The validation is run based on the rules entered in the nested `condition` objec
 {
   type: VALIDATE_CONDITIONAL,
   condition: {
-    parentValue: [value of parent field],
-    fieldName: [this conditional field's name],
-    ruleToTest: [rule constant],
-    message: [error message to show in UI]
+    parentValue: <value of parent field>,
+    fieldName: <this conditional field's name>,
+    ruleToTest: <rule constant>,
+    message: <error message to show in UI>
   },
 }
 ```
@@ -396,7 +502,7 @@ This test only runs if there is a value in the field and is ignored if field is 
 ```
 {
   type: VALIDATE_EMAIL,
-  message: [error message to show in UI]
+  message: <error message to show in UI>
   },
 }
 ```
@@ -407,8 +513,8 @@ Specifically tests if the value entered matches the value of another field.
 ```
 {
   type: VALIDATE_MATCH,
-  message: [error message to show in UI],
-  condition: [field name to match]
+  message: <error message to show in UI>,
+  condition: <field name to match>
   },
 }
 ```
@@ -420,8 +526,20 @@ This test only runs if there is a value in the field and is ignored if field is 
 ```
 {
   type: VALIDATE_MIN_LENGTH,
-  condition: [minimum length]
-  message: [error message to show in UI]
+  condition: <minimum length>
+  message: <error message to show in UI>
+  },
+}
+```
+
+#### Phone Number Format
+Specifically tests if the value entered matches the API required phone number pattern.
+This test only runs if there is a value in the field and is ignored if field is null.
+
+```
+{
+  type: VALIDATE_PHONE_NUMBER,
+  message: <error message to show in UI>
   },
 }
 ```

--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -20,7 +20,8 @@ Specific inputs
 Validating fields
 - [Required](#Required)
 - [Conditional](#Conditional)
-- [Email](#Email)
+- [Email Format](#EmailFormat)
+- [Match](#Match)
 - [Minimum Length](#MinimumLength)
 
 
@@ -388,7 +389,7 @@ The validation is run based on the rules entered in the nested `condition` objec
 }
 ```
 
-#### Email
+#### Email Format
 Specifically tests if the value entered matches an email pattern.
 This test only runs if there is a value in the field and is ignored if field is null.
 
@@ -396,6 +397,18 @@ This test only runs if there is a value in the field and is ignored if field is 
 {
   type: VALIDATE_EMAIL,
   message: [error message to show in UI]
+  },
+}
+```
+
+#### Match
+Specifically tests if the value entered matches the value of another field.
+
+```
+{
+  type: VALIDATE_MATCH,
+  message: [error message to show in UI],
+  condition: [field name to match]
   },
 }
 ```

--- a/docs/form_creator_example.md
+++ b/docs/form_creator_example.md
@@ -373,36 +373,27 @@ const SecondPage = () => {
 
   const handleSubmit = async (e, formData) => {
     e.preventDefault();
-    const formErrors = await Validator({ formData: formData.formData, formFields: formFields });
-    setErrors(formErrors);
-
-    if (formErrors.length < 1) {
-      navigate(
-        FORM_CONFIRMATION_URL,
-        {
-          state: {
-            formName: 'Example form',
-            nextPageLink: DASHBOARD_URL,
-            nextPageName: DASHBOARD_PAGE_NAME,
-            referenceNumber: referenceNumber
-          }
+    navigate(
+      FORM_CONFIRMATION_URL,
+      {
+        state: {
+          formName: 'Example form',
+          nextPageLink: DASHBOARD_URL,
+          nextPageName: DASHBOARD_PAGE_NAME,
+          referenceNumber: referenceNumber
         }
-      );
-    } else {
-      scrollToElementId('formSecondPage');
-    }
+      }
+    );
   };
 
   return (
     <div className="govuk-grid-row">
-      <h1>Second page</h1>
       <DisplayForm
         formId='formSecondPage'
-        errors={errors}
         fields={formFields}
         formActions={formActions}
+        pageHeading='Second page'
         handleSubmit={handleSubmit}
-        setErrors={setErrors}
       />
     </div >
   );

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
 </head>
 <body className="govuk-template__body">  
   <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-  <div id="root"></div>
+  <div id="root" class="govuk-body"></div>
   <script src="/javascript/all.js"></script>   
   <script>window.GOVUKFrontend.initAll()</script>
 </body> 

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -12,20 +12,31 @@ import {
   FORM_CONFIRMATION_URL,
   LANDING_URL,
   PRIVACY_URL,
+  REGISTER_ACCOUNT,
+  REGISTER_EMAIL,
+  REGISTER_DETAILS,
+  REGISTER_PASSWORD,
   SIGN_IN_URL,
   SECOND_PAGE_URL,
 } from './constants/AppUrlConstants';
 
-// Pages
+// Regulatory pages
 import AccessibilityStatement from './pages/Regulatory/AccessibilityStatement';
 import CookiePolicy from './pages/Regulatory/CookiePolicy';
-import Dashboard from './pages/Dashboard/Dashboard';
-import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
 import Landing from './pages/Landing/Landing';
 import PrivacyNotice from './pages/Regulatory/PrivacyNotice';
+// Register/Sign in pages
+import RegisterEmailAddress from './pages/Register/RegisterEmailAddress';
+import RegisterYourDetails from './pages/Register/RegisterYourDetails';
+import RegisterYourPassword from './pages/Register/RegisterYourPassword';
 import SignIn from './pages/SignIn/SignIn';
-import SecondPage from './pages/TempPages/SecondPage';
+// Other pages (could be protected or not)
+import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
+// Protected pages
+import Dashboard from './pages/Dashboard/Dashboard';
 
+// Temp Pages
+import SecondPage from './pages/TempPages/SecondPage';
 
 const AppRouter = ({ setIsCookieBannerShown }) => {
   const isPermittedToView = useUserIsPermitted();
@@ -36,10 +47,17 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
         <Route path='/' element={<Landing />} />
         <Route path={ACCESSIBILITY_URL} element={<AccessibilityStatement />} />
         <Route path={COOKIE_URL} element={<CookiePolicy setIsCookieBannerShown={setIsCookieBannerShown} />} />
-        <Route path={FORM_CONFIRMATION_URL} element={<FormConfirmationPage />} />
         <Route path={LANDING_URL} element={<Landing />} />
         <Route path={PRIVACY_URL} element={<PrivacyNotice />} />
+
+        <Route path={REGISTER_ACCOUNT} element={<RegisterEmailAddress />} />
+        <Route path={REGISTER_EMAIL} element={<RegisterEmailAddress />} />
+        <Route path={REGISTER_DETAILS} element={<RegisterYourDetails />} />
+        <Route path={REGISTER_PASSWORD} element={<RegisterYourPassword />} />
         <Route path={SIGN_IN_URL} element={<SignIn />} />
+
+        <Route path={FORM_CONFIRMATION_URL} element={<FormConfirmationPage />} />
+
         <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>
           <Route path={DASHBOARD_URL} element={<Dashboard />} />
           <Route path={SECOND_PAGE_URL} element={<SecondPage />} />

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -6,7 +6,7 @@ import determineFieldType from './formFields/DetermineFieldType';
 import { scrollToTop } from '../utils/ScrollToElement';
 import Validator from '../utils/Validator';
 
-const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit }) => {
+const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit, children }) => {
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
   const [errors, setErrors] = useState();
@@ -157,6 +157,7 @@ const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit })
         </div>
       )}
       <h1 className="govuk-heading-l">{pageHeading}</h1>
+      {children}
       <form id={formId} autoComplete="off">
         {
           fieldsWithValues.map((field) => {
@@ -215,6 +216,7 @@ const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit })
 export default DisplayForm;
 
 DisplayForm.propTypes = {
+  children: PropTypes.node, // allows any renderable object
   fields: PropTypes.arrayOf(
     PropTypes.shape({
       fieldName: PropTypes.string.isRequired,

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -15,6 +15,7 @@ export const CHECKED_TRUE = true;
 export const CHECKED_FALSE = false;
 // Forms: validation types
 export const VALIDATE_CONDITIONAL = 'conditional';
+export const VALIDATE_FIELD_MATCH = 'match';
 export const VALIDATE_REQUIRED = 'required';
 export const VALIDATE_MIN_LENGTH = 'minLength';
 export const VALIDATE_EMAIL_ADDRESS = 'emailAddress';

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -12,6 +12,12 @@ export const LANDING_URL = '/';
 export const PRIVACY_URL = '/privacy-notice';
 export const SIGN_IN_URL = '/sign-in';
 
+// Create account/register pages
+export const REGISTER_ACCOUNT = '/create-account/email-address';
+export const REGISTER_EMAIL = '/create-account/email-address';
+export const REGISTER_DETAILS = '/create-account/your-details';
+export const REGISTER_PASSWORD = '/create-account/your-password';
+
 // Test pages
 export const SECOND_PAGE_NAME = 'Second page';
 export const SECOND_PAGE_URL = '/second-page';

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { SERVICE_NAME } from '../../constants/AppConstants';
-import { DASHBOARD_URL, SIGN_IN_URL } from '../../constants/AppUrlConstants';
+import { DASHBOARD_URL, REGISTER_ACCOUNT, SIGN_IN_URL } from '../../constants/AppUrlConstants';
 import useUserIsPermitted from '../../hooks/useUserIsPermitted';
 
 const Landing = () => {
@@ -10,6 +10,7 @@ const Landing = () => {
   return (
     <>
       <h1 className="govuk-heading-l" data-testid="landing-h1">{SERVICE_NAME}</h1>
+      <Link to ={REGISTER_ACCOUNT}>Create account</Link>
       <p className="govuk-body">Use this service to:</p>
       <Link 
         to={isAuthenticated ? DASHBOARD_URL : SIGN_IN_URL}

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -10,8 +10,8 @@ const Landing = () => {
   return (
     <>
       <h1 className="govuk-heading-l" data-testid="landing-h1">{SERVICE_NAME}</h1>
-      <Link to ={REGISTER_ACCOUNT}>Create account</Link>
       <p className="govuk-body">Use this service to:</p>
+      <p className="govuk-body" data-testid="createAccountParagraph">You&apos;ll also need to sign in or <Link to ={REGISTER_ACCOUNT}>create an account</Link> to use this service</p>
       <Link 
         to={isAuthenticated ? DASHBOARD_URL : SIGN_IN_URL}
         role="button"

--- a/src/pages/Landing/Landing.test.jsx
+++ b/src/pages/Landing/Landing.test.jsx
@@ -20,6 +20,11 @@ describe('Landing page tests', () => {
     expect(screen.getByText('Use this service to:')).toBeInTheDocument();
   });
 
+  it('should include a link to create an account', async () => {
+    render(<MemoryRouter><Landing /></MemoryRouter>);
+    expect(screen.getByTestId('createAccountParagraph').outerHTML).toEqual('<p class="govuk-body" data-testid="createAccountParagraph">You\'ll also need to sign in or <a href="/create-account/email-address">create an account</a> to use this service</p>');
+  });
+
   it('should should have a start now button that includes the > and links to the sign-in page', async () => {
     render(<MemoryRouter><Landing /></MemoryRouter>);
     const checkStartNowButton = screen.getByRole('button');

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,7 +1,11 @@
+import { Link } from 'react-router-dom';
 const RegisterEmailAddress = () => {
 
   return (
-    <h1>Email address page</h1>
+    <>
+      <h1>Email address page</h1>
+      <Link to="/create-account/your-details">next page</Link>
+    </>
   );
 };
 

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,0 +1,8 @@
+const RegisterEmailAddress = () => {
+
+  return (
+    <h1>Email address page</h1>
+  );
+};
+
+export default RegisterEmailAddress;

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -3,6 +3,17 @@ import { FIELD_EMAIL, VALIDATE_EMAIL_ADDRESS, VALIDATE_FIELD_MATCH, VALIDATE_REQ
 import { REGISTER_DETAILS } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 
+const SupportingText = () => {
+  return (
+    <>
+      <div className="govuk-inset-text">
+        <p className="govuk-body">This will only be used if you need to recover your sign in details.</p>
+        <p className="govuk-body">To confirm it is your email address we will send you a verification link.</p>
+      </div>
+    </>
+  );
+};
+
 const RegisterEmailAddress = () => {
   const navigate = useNavigate();
 
@@ -63,7 +74,9 @@ const RegisterEmailAddress = () => {
           formActions={formActions}
           pageHeading='What is your email address'
           handleSubmit={handleSubmit}
-        />
+        >
+          <SupportingText />
+        </DisplayForm>
       </div>
     </div>
   );

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,11 +1,66 @@
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { FIELD_EMAIL, VALIDATE_EMAIL_ADDRESS, VALIDATE_REQUIRED } from '../../constants/AppConstants';
+import { REGISTER_DETAILS } from '../../constants/AppUrlConstants';
+import DisplayForm from '../../components/DisplayForm';
+
 const RegisterEmailAddress = () => {
+  const navigate = useNavigate();
+
+  const formActions = {
+    submit: {
+      className: 'govuk-button',
+      dataModule: 'govuk-button',
+      dataTestid: 'submit-button',
+      label: 'Continue',
+      type: 'button',
+    },
+  };
+  const formFields = [
+    {
+      type: FIELD_EMAIL,
+      fieldName: 'emailAddress',
+      label: 'Email address',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter an email address in the correct format, like name@example.com'
+        },
+        {
+          type: VALIDATE_EMAIL_ADDRESS,
+          message: 'Enter an email address in the correct format, like name@example.com'
+        },
+      ]
+    },
+    {
+      type: FIELD_EMAIL,
+      fieldName: 'repeatEmailAddress',
+      label: 'Confirm email address',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Confirm your email address'
+        },
+      ]
+    }
+  ];
+
+  const handleSubmit = async (e, formData) => {
+    console.log('submit', e, formData);
+    navigate(REGISTER_DETAILS);
+  };
 
   return (
-    <>
-      <h1>Email address page</h1>
-      <Link to="/create-account/your-details">next page</Link>
-    </>
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <DisplayForm
+          formId='formRegisterEmailAddress'
+          fields={formFields}
+          formActions={formActions}
+          pageHeading='Second page'
+          handleSubmit={handleSubmit}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -61,7 +61,7 @@ const RegisterEmailAddress = () => {
           formId='formRegisterEmailAddress'
           fields={formFields}
           formActions={formActions}
-          pageHeading='Second page'
+          pageHeading='What is your email address'
           handleSubmit={handleSubmit}
         />
       </div>

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { FIELD_EMAIL, VALIDATE_EMAIL_ADDRESS, VALIDATE_REQUIRED } from '../../constants/AppConstants';
+import { FIELD_EMAIL, VALIDATE_EMAIL_ADDRESS, VALIDATE_FIELD_MATCH, VALIDATE_REQUIRED } from '../../constants/AppConstants';
 import { REGISTER_DETAILS } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 
@@ -39,6 +39,11 @@ const RegisterEmailAddress = () => {
         {
           type: VALIDATE_REQUIRED,
           message: 'Confirm your email address'
+        },
+        {
+          type: VALIDATE_FIELD_MATCH,
+          message: 'Your email addresses must match',
+          condition: 'emailAddress',
         },
       ]
     }

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -1,7 +1,11 @@
+import { Link } from 'react-router-dom';
 const RegisterYourDetails = () => {
 
   return (
-    <h1>Your details page</h1>
+    <>
+      <h1>Your details page</h1>
+      <Link to="/create-account/your-password">next page</Link>
+    </>
   );
 };
 

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -1,0 +1,8 @@
+const RegisterYourDetails = () => {
+
+  return (
+    <h1>Your details page</h1>
+  );
+};
+
+export default RegisterYourDetails;

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -1,0 +1,8 @@
+const RegisterYourPassword = () => {
+
+  return (
+    <h1>Your password page</h1>
+  );
+};
+
+export default RegisterYourPassword;

--- a/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterEmailAddres from '../RegisterEmailAddress';
+
+describe('Register email address tests', () => {
+  const handleSubmit = jest.fn();
+  let scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('should render h1', async () => {
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    expect(screen.getByText('What is your email address')).toBeInTheDocument();
+  });
+
+  // it('should render two intro insets', async () => {
+  //   render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+  //   expect(screen.getByText('What is your email address')).toBeInTheDocument();
+  // });
+
+  it('should render two email address fields', async () => {
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[0].outerHTML).toEqual('<input class="govuk-input" id="emailAddress-input" name="emailAddress" type="email" autocomplete="email" value="">');
+    expect(screen.getByLabelText('Confirm email address')).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[1].outerHTML).toEqual('<input class="govuk-input" id="repeatEmailAddress-input" name="repeatEmailAddress" type="email" autocomplete="email" value="">');
+  });
+
+  it('should display a primary styled continue button', () => {
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
+  });
+
+  it('should NOT call the handleSubmit function on button click if there ARE errors', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.click(screen.getByTestId('submit-button'));
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should display the Error Summary if there are errors', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+  });
+
+  it('should display the email required error if there is no email address', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+  });
+
+  it('should scroll to email field and set focus on email input if user clicks on email required error link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.click(screen.getByTestId('submit-button'));
+    await user.click(screen.getByRole('button', { name: 'Enter an email address in the correct format, like name@example.com'}));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[0]).toHaveFocus();
+  });
+
+  it('should display the email invalid error if the email address has no @', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+  });
+
+  it('should display the email invalid error if the email address has no .xx', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+  });
+
+  it('should scroll to email field and set focus on email input if user clicks on email invalid format error link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo');
+    await user.click(screen.getByTestId('submit-button'));
+    await user.click(screen.getByRole('button', { name: 'Enter an email address in the correct format, like name@example.com'}));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[0]).toHaveFocus();
+  });
+
+  it('should display the emails must match error if the repeat email field value is null', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo.com');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getAllByText('Confirm your email address')).toHaveLength(2);
+  });
+
+  it('should scroll to repeat email field and set focus on repeat email input if user clicks on repeat email required link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo.com');
+    await user.click(screen.getByTestId('submit-button'));
+    await user.click(screen.getByRole('button', { name: 'Confirm your email address'}));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[1]).toHaveFocus();
+  });
+
+  it('should display the emails must match error if the repeat email field value does not match the email value', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo.com');
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[1], 'testemail@boo');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getAllByText('Your email addresses must match')).toHaveLength(2);
+  });
+
+  it('should scroll to repeat email field and set focus on repeat email input if user clicks on emails dont match error link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@boo.com');
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[1], 'testemail@boo');
+    await user.click(screen.getByTestId('submit-button'));
+    await user.click(screen.getByRole('button', { name: 'Your email addresses must match'}));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', {name: /email/i})[1]).toHaveFocus();
+  });
+
+  it('should NOT display the email errors if the email address is a valid format & emails match', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[0], 'testemail@email.com');
+    await user.type(screen.getAllByRole('textbox', {name: /email/i})[1], 'testemail@email.com');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.queryByText('Enter your email address')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enter your email address in the correct format, like name@example.com')).not.toBeInTheDocument();
+    expect(screen.queryByText('Confirm your email address')).not.toBeInTheDocument();
+    expect(screen.queryByText('Your email addresses must match')).not.toBeInTheDocument();
+  });
+
+});

--- a/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
@@ -17,10 +17,11 @@ describe('Register email address tests', () => {
     expect(screen.getByText('What is your email address')).toBeInTheDocument();
   });
 
-  // it('should render two intro insets', async () => {
-  //   render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
-  //   expect(screen.getByText('What is your email address')).toBeInTheDocument();
-  // });
+  it('should render an intro inset', async () => {
+    render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);
+    expect(screen.getByText('This will only be used if you need to recover your sign in details.')).toBeInTheDocument();
+    expect(screen.getByText('To confirm it is your email address we will send you a verification link.')).toBeInTheDocument();
+  });
 
   it('should render two email address fields', async () => {
     render(<MemoryRouter><RegisterEmailAddres /></MemoryRouter>);


### PR DESCRIPTION
# Ticket

NMSW-155

----

## AC

GIVEN I have followed a link to the website
WHEN I arrive on the landing page
THEN there is an option to "Create an account"

GIVEN I have selected to create an account
WHEN the registration page is displayed
THEN I am able to provide the following details:
*Email address
*Confirm email address

Given I provided my email address CORRECTLY
AND they match
When I submit them
Then I am redirected to provide my other details:

----

## To test

- run locally
- click on `create account`
- > you should be taken to a page with h1 `What is your email address`
- > page should have a form with fields for email and confirm email
- click continue
- > both fields should error
- enter something in email address field that is not an email
- click continue
- > field should error as invalid
- enter an email address
- enter something in confirm field that does not match
- click continue
- > confirm field should error as not matching
- enter something in confirm field that matches email address field
- click continue
- > you should be taken to your details page

----

## Notes

- Your details page content coming in next PR
- We are not storing data submitted from email form yet
- We do not have inset text on email address page yet
- We do not have back button yet
