### PR TITLE
NMSW-205 Autocomplete not persisting values correctly

### DIFF
--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -85,8 +85,6 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       const objectExpandedItem = objectItem[fieldDetails.fieldName];
       const objectAdditionalKey = objectExpandedItem[fieldDetails.additionalKey];
       const build = objectAdditionalKey ? `${objectExpandedItem[fieldDetails.responseKey]} ${objectAdditionalKey}` : objectExpandedItem[fieldDetails.responseKey];
-      // console.log('ak', build)
-      // const additionalKeyValue = objectItem[]
       valueToTest = build;
     } else {
       valueToTest = defaultValue;
@@ -108,14 +106,19 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       retrievedValue = e;
     }
 
-    // const retrievedValue = e === valueToTest ? apiResponseData.find(o => o.name === defaultValue) : e;
+    // TODO
+    // scenario to fix still
+    // select a port with unlocode
+    // refresh
+    // click on port field
+    // select same port
+    // port name is setting to undefined -- it should be setting to port.name
 
-    console.log('ret', retrievedValue);
 
     // Returns either a concatenated value if required and available e.g. port name + port unlocode
     // Or the single string e.g. ports without a unlocode, field that does not have an additionalKey set
     if (fieldDetails.additionalKey && retrievedValue[fieldDetails.additionalKey]) {
-      displayValue = `${e[fieldDetails.responseKey]} ${retrievedValue[fieldDetails.additionalKey]}`;
+      displayValue = `${retrievedValue[fieldDetails.responseKey]} ${retrievedValue[fieldDetails.additionalKey]}`;
     } else {
       displayValue = retrievedValue[fieldDetails.responseKey];
     }

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -12,13 +12,16 @@ import Autocomplete from 'accessible-autocomplete/react';
  * some explanation of aria-activedescendant: https://www.holisticseo.digital/technical-seo/web-accessibility/aria-activedescendant/
 */
 const InputAutocomplete = ({ fieldDetails, handleChange }) => {
+  const apiResponseData = fieldDetails.dataAPIEndpoint;
+  const defaultValue = fieldDetails.value ? fieldDetails.value : '';
+  // const [defaultValueObject, setDefaultValueObject] = useState();
   const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
     // TODO: We should look at using lodash.debounce to prevent calls being made too fast as user types
     // TODO: apiResponseData will be replaced with the api call to return the first [x] values of the dataset
-    const apiResponseData = fieldDetails.dataAPIEndpoint;
+    // const apiResponseData = fieldDetails.dataAPIEndpoint;
 
     // adding a filter in here to mimic the userQuery being used to get a response
     // TODO: filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
@@ -41,6 +44,11 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       } else {
         response = result[fieldDetails.responseKey];
       }
+    } else if (defaultValue) {
+      
+      let obj = apiResponseData.find(o => o[fieldDetails.responseKey] === defaultValue);
+      response = obj[fieldDetails.responseKey];
+
     } else {
       // this covers when user hasn't typed in field yet / field is null
       return;
@@ -50,14 +58,15 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
 
   const handleOnConfirm = (e) => {
     if (!e) { return; }
+    let retrievedValue = e === defaultValue ? apiResponseData.find(o => o.name === defaultValue) : e;
     let displayValue;
 
     // Returns either a concatenated value if required and available e.g. port name + port unlocode
     // Or the single string e.g. ports without a unlocode, field that does not have an additionalKey set
-    if (fieldDetails.additionalKey && e[fieldDetails.additionalKey]) {
-      displayValue = `${e[fieldDetails.responseKey]} ${e[fieldDetails.additionalKey]}`;
+    if (fieldDetails.additionalKey && retrievedValue[fieldDetails.additionalKey]) {
+      displayValue = `${e[fieldDetails.responseKey]} ${retrievedValue[fieldDetails.additionalKey]}`;
     } else {
-      displayValue = e[fieldDetails.responseKey];
+      displayValue = retrievedValue[fieldDetails.responseKey];
     }
 
     // We want to include both the display value, and any additional field object information received from the API
@@ -67,7 +76,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
         name: fieldDetails.fieldName,
         value: displayValue,
         additionalDetails: {
-          [fieldDetails.fieldName]: e
+          [fieldDetails.fieldName]: retrievedValue
         },
       }
     };
@@ -138,6 +147,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     <div className='autocomplete-input'>
       <Autocomplete
         confirmOnBlur={false}
+        defaultValue={defaultValue}
         id={`${fieldDetails.fieldName}-input`}
         minLength={1}
         name={fieldDetails.fieldName}

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Autocomplete from 'accessible-autocomplete/react';
 
@@ -14,8 +14,7 @@ import Autocomplete from 'accessible-autocomplete/react';
 const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   const apiResponseData = fieldDetails.dataAPIEndpoint;
   const defaultValue = fieldDetails.value ? fieldDetails.value : '';
-  // const [defaultValueObject, setDefaultValueObject] = useState();
-  const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
+  // const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -33,6 +32,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
 
 
   const template = (result) => {
+    // TODO: refactor this once we connect the APIs -- try to remove the deep nested if statements
     // as the user types their query, this formats what is displayed in the input (inputValue)
     // and combolist suggestions (suggestion)
     // result being from the results of the suggest function
@@ -45,10 +45,13 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
         response = result[fieldDetails.responseKey];
       }
     } else if (defaultValue) {
-      
-      let obj = apiResponseData.find(o => o[fieldDetails.responseKey] === defaultValue);
-      response = obj[fieldDetails.responseKey];
-
+      if (fieldDetails.additionalKey) {
+        // get the expanded details from 
+        console.log('aaaaa');
+      } else {
+        const defaultValueObject = apiResponseData.find(o => o[fieldDetails.responseKey] === defaultValue);
+        response = defaultValueObject[fieldDetails.responseKey];
+      }
     } else {
       // this covers when user hasn't typed in field yet / field is null
       return;
@@ -84,31 +87,32 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     handleChange(formattedEvent);
   };
 
-  /* See issue#424, #495, at alphagov/accessible-autocomplete
-    * There is an ongoing issue around setting defaultValue when using template
-    * whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
-    * it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
-    * the workaround is to use javascript to set the value of the input which forces the suggest to run
-    * TODO: when fixed on alphagov/accessible-autocomplete, fix here
-  */
-  useEffect(() => {
-    if (!fieldDetails.value) {
-      return;
-    }
-    document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
-    setHideListBox(true);
 
-    // TODO: when we connect this to an API call we will make the API call here to get the data
-    // trigger a handle confirm so that any additional field values are also passed back to the form data and not lost
-  }, [fieldDetails.value]);
+  // /* See issue#424, #495, at alphagov/accessible-autocomplete
+  //   * There is an ongoing issue around setting defaultValue when using template
+  //   * whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
+  //   * it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
+  //   * the workaround is to use javascript to set the value of the input which forces the suggest to run
+  //   * TODO: when fixed on alphagov/accessible-autocomplete, fix here
+  // */
+  // useEffect(() => {
+  //   if (!fieldDetails.value) {
+  //     return;
+  //   }
+  //   document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
+  //   setHideListBox(true);
+
+  //   // TODO: when we connect this to an API call we will make the API call here to get the data
+  //   // trigger a handle confirm so that any additional field values are also passed back to the form data and not lost
+  // }, [fieldDetails.value]);
 
 
-  useEffect(() => {
-    if (hideListBox) {
-      document.getElementById(`${fieldDetails.fieldName}-input__listbox`).className = 'autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden';
-      setHideListBox(false);
-    }
-  }, [hideListBox]);
+  // useEffect(() => {
+  //   if (hideListBox) {
+  //     document.getElementById(`${fieldDetails.fieldName}-input__listbox`).className = 'autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden';
+  //     setHideListBox(false);
+  //   }
+  // }, [hideListBox]);
 
   /* 
    * There is no onBlur event available for us to place a function on

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -62,7 +62,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
      * AND: if they click on that item
      * THEN: the value and it's expanded data must persist
      */
-    if (sessionData[fieldDetails.fieldName] && fieldDetails.additionalKey) {
+    if (sessionData && sessionData[fieldDetails.fieldName] && fieldDetails.additionalKey) {
       // If a field has an additional key, when it has a value we include that in the item value
       // when it does not we do not include it to avoid 'undefined' showing in the UI
       const objectExpandedItem = sessionData[`${fieldDetails.fieldName}ExpandedDetails`][fieldDetails.fieldName];

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -46,8 +46,12 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       }
     } else if (defaultValue) {
       if (fieldDetails.additionalKey) {
-        // get the expanded details from 
-        console.log('aaaaa');
+        // get the expanded details from the session
+        const sessionInfo = JSON.parse(sessionStorage.getItem('formData'));
+        const expandedFieldName = `${fieldDetails.fieldName}ExpandedDetails`;
+        const objectItem = sessionInfo[expandedFieldName];
+        const objectExpandedItem = objectItem[fieldDetails.fieldName];
+        response = `${objectExpandedItem[fieldDetails.responseKey]} ${objectExpandedItem[fieldDetails.additionalKey]}`;
       } else {
         const defaultValueObject = apiResponseData.find(o => o[fieldDetails.responseKey] === defaultValue);
         response = defaultValueObject[fieldDetails.responseKey];
@@ -61,7 +65,19 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
 
   const handleOnConfirm = (e) => {
     if (!e) { return; }
-    let retrievedValue = e === defaultValue ? apiResponseData.find(o => o.name === defaultValue) : e;
+    let retrievedValue;
+
+    if (fieldDetails.additionalKey) {
+      // get the expanded details from the session
+      const sessionInfo = JSON.parse(sessionStorage.getItem('formData'));
+      const expandedFieldName = `${fieldDetails.fieldName}ExpandedDetails`;
+      const objectItem = sessionInfo[expandedFieldName];
+      const objectExpandedItem = objectItem[fieldDetails.fieldName];
+      retrievedValue = objectExpandedItem;
+    } else {
+      retrievedValue = e === defaultValue ? apiResponseData.find(o => o.name === defaultValue) : e;
+    }
+
     let displayValue;
 
     // Returns either a concatenated value if required and available e.g. port name + port unlocode

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -84,14 +84,6 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       retrievedValue = e;
     }
 
-    // TODO
-    // scenario to fix still
-    // select a port with unlocode
-    // refresh
-    // click on port field
-    // select same port
-    // port name is setting to undefined -- it should be setting to port.name
-
 
     // Returns either a concatenated value if required and available e.g. port name + port unlocode
     // Or the single string e.g. ports without a unlocode, field that does not have an additionalKey set
@@ -115,33 +107,6 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
 
     handleChange(formattedEvent);
   };
-
-
-  // /* See issue#424, #495, at alphagov/accessible-autocomplete
-  //   * There is an ongoing issue around setting defaultValue when using template
-  //   * whereby the suggest doesn't run and so the dropdown shows 'undefined' instead of not opening/showing the value
-  //   * it also results in an error (seen in console) TypeError: Cannot read properties of undefined (reading 'toLowerCase') onBlur/onConfirm
-  //   * the workaround is to use javascript to set the value of the input which forces the suggest to run
-  //   * TODO: when fixed on alphagov/accessible-autocomplete, fix here
-  // */
-  // useEffect(() => {
-  //   if (!fieldDetails.value) {
-  //     return;
-  //   }
-  //   document.getElementById(`${fieldDetails.fieldName}-input`).value = fieldDetails.value;
-  //   setHideListBox(true);
-
-  //   // TODO: when we connect this to an API call we will make the API call here to get the data
-  //   // trigger a handle confirm so that any additional field values are also passed back to the form data and not lost
-  // }, [fieldDetails.value]);
-
-
-  // useEffect(() => {
-  //   if (hideListBox) {
-  //     document.getElementById(`${fieldDetails.fieldName}-input__listbox`).className = 'autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden';
-  //     setHideListBox(false);
-  //   }
-  // }, [hideListBox]);
 
   /* 
    * There is no onBlur event available for us to place a function on

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -25,7 +25,7 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     // adding a filter in here to mimic the userQuery being used to get a response
     // TODO: filteredResults will be replaced with the api call to return a filtered dataset based on the userQuery
     const filteredResults = apiResponseData.filter(o => Object.keys(o).some(k => o[k].toLowerCase().includes(userQuery.toLowerCase())));
-
+// console.log(filteredResults)
     // this is part of the Autocomplete componet and how we return results to the list
     populateResults(filteredResults);
   };

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -99,16 +99,26 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       retrievedValue = e;
     }
 
-    // Returns either a concatenated value if required and available e.g. port name + port unlocode
-    // Or the single string e.g. ports without a unlocode, field that does not have an additionalKey set
+    /*
+     * GIVEN: an item on the list has been clicked and we have retrieved its object
+     * WHEN: the field has an additionalKey and the retrieved object has a value for that additionalKey
+     * THEN: we concatenate the responseKey value and the additionalKey value together as the displayValue to show in the UI
+     * 
+     * WHEN: the field does not have an additionalKey OR it has an additionalKey but the object has no value for this
+     * THEN: we set the displayValue to just have the responseKey value
+     */
     if (fieldDetails.additionalKey && retrievedValue[fieldDetails.additionalKey]) {
       displayValue = `${retrievedValue[fieldDetails.responseKey]} ${retrievedValue[fieldDetails.additionalKey]}`;
     } else {
       displayValue = retrievedValue[fieldDetails.responseKey];
     }
 
-    // We want to include both the display value, and any additional field object information received from the API
-    // So the page's handleSubmit can decide what to send on the POST/PUT call
+    /*
+     * An items object may include data that is not shown in the UI
+     * We always want to pass that data back to the handleChange function
+     * So that it is available to pass back to the handleSubmit function
+     * and therefore available for use
+     */
     const formattedEvent = {
       target: {
         name: fieldDetails.fieldName,

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -14,8 +14,7 @@ import Autocomplete from 'accessible-autocomplete/react';
 const InputAutocomplete = ({ fieldDetails, handleChange }) => {
   const apiResponseData = fieldDetails.dataAPIEndpoint;
   const defaultValue = fieldDetails.value || '';
-
-  // const [hideListBox, setHideListBox] = useState(false); // only used for defaultValue bug workaround
+  const sessionData = JSON.parse(sessionStorage.getItem('formData'));
 
   const suggest = (userQuery, populateResults) => {
     if (!userQuery) { return; }
@@ -33,10 +32,6 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
 
 
   const template = (result) => {
-    // TODO: refactor this once we connect the APIs -- try to remove the deep nested if statements
-    // as the user types their query, this formats what is displayed in the input (inputValue)
-    // and combolist suggestions (suggestion)
-    // result being from the results of the suggest function
     let response;
     if (result && result[fieldDetails.responseKey]) {
       // this occurs when user has typed in the field
@@ -45,26 +40,9 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
       } else {
         response = result[fieldDetails.responseKey];
       }
-    } else if (defaultValue) {
-      if (fieldDetails.additionalKey) {
-        // get the expanded details from the session
-        const sessionInfo = JSON.parse(sessionStorage.getItem('formData'));
-        const expandedFieldName = `${fieldDetails.fieldName}ExpandedDetails`;
-        const objectItem = sessionInfo[expandedFieldName];
-        const objectExpandedItem = objectItem[fieldDetails.fieldName];
-        if (objectExpandedItem) {
-          if (objectExpandedItem[fieldDetails.additionalKey]) {
-            response = `${objectExpandedItem[fieldDetails.responseKey]} ${objectExpandedItem[fieldDetails.additionalKey]}`;
-          } else {
-            response = objectExpandedItem[fieldDetails.responseKey];
-          }
-        } else {
-          return;
-        }
-      } else {
-        const defaultValueObject = apiResponseData.find(o => o[fieldDetails.responseKey] === defaultValue);
-        response = defaultValueObject[fieldDetails.responseKey];
-      }
+    } else if (sessionData) {
+      // on page load this handles if there is a session to prepopulate the value from
+      response = sessionData[fieldDetails.fieldName];
     } else {
       // this covers when user hasn't typed in field yet / field is null
       return;

--- a/src/components/formFields/InputAutocomplete.jsx
+++ b/src/components/formFields/InputAutocomplete.jsx
@@ -55,15 +55,15 @@ const InputAutocomplete = ({ fieldDetails, handleChange }) => {
     let displayValue;
     let valueToTest;
 
-    if (defaultValue && fieldDetails.additionalKey) {
-      // get the expanded details from the session
-      const sessionInfo = JSON.parse(sessionStorage.getItem('formData'));
-      const expandedFieldName = `${fieldDetails.fieldName}ExpandedDetails`;
-      const objectItem = sessionInfo[expandedFieldName];
-      const objectExpandedItem = objectItem[fieldDetails.fieldName];
-      const objectAdditionalKey = objectExpandedItem[fieldDetails.additionalKey];
-      const build = objectAdditionalKey ? `${objectExpandedItem[fieldDetails.responseKey]} ${objectAdditionalKey}` : objectExpandedItem[fieldDetails.responseKey];
-      valueToTest = build;
+    // If value is prefilled from the session data, this ensures we pass back the expanded details
+    // if the user clicks in the input and clicks the value in the list again
+    if (sessionData[fieldDetails.fieldName] && fieldDetails.additionalKey) {
+      // Not all datasets that have an additionalKey have a value for that key
+      // the below is to avoid having 'undefined' show up in the list
+      const objectExpandedItem = sessionData[`${fieldDetails.fieldName}ExpandedDetails`][fieldDetails.fieldName];
+      valueToTest = objectExpandedItem[fieldDetails.additionalKey]
+        ? `${objectExpandedItem[fieldDetails.responseKey]} ${objectExpandedItem[fieldDetails.additionalKey]}`
+        : objectExpandedItem[fieldDetails.responseKey];
     } else {
       valueToTest = defaultValue;
     }

--- a/src/components/formFields/__tests__/InputAutocomplete.test.jsx
+++ b/src/components/formFields/__tests__/InputAutocomplete.test.jsx
@@ -91,6 +91,10 @@ describe('Text input field generation', () => {
     additionalKey: 'identifier'
   };
 
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('should render the autocomplete input field  with only the required props', () => {
     render(
       <InputAutocomplete
@@ -113,8 +117,8 @@ describe('Text input field generation', () => {
     );
     expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
     expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="">');
-    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"></ul>');
+    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="ObjectThree">');
+    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"><li aria-selected="false" class="autocomplete__option" id="fullFieldName-input__option--0" role="option" tabindex="-1" aria-posinset="1" aria-setsize="1">""</li></ul>');
   });
   
   it('should render the list options based on what the user enters', async () => {

--- a/src/components/formFields/__tests__/InputAutocomplete.test.jsx
+++ b/src/components/formFields/__tests__/InputAutocomplete.test.jsx
@@ -49,7 +49,6 @@ describe('Text input field generation', () => {
     hint: 'The hint text',
     responseKey: 'name',
     additionalKey: 'identifier',
-    value: 'ObjectThree',
   };
   const fieldDetailsOneResponseKey = {
     // dataAPIEndpoint: 'theEndpointUrl' // when we implement the endpoint
@@ -95,7 +94,7 @@ describe('Text input field generation', () => {
     window.sessionStorage.clear();
   });
 
-  it('should render the autocomplete input field  with only the required props', () => {
+  it('should render the autocomplete input field with only the required props', () => {
     render(
       <InputAutocomplete
         fieldDetails={fieldDetailsBasic}
@@ -108,7 +107,7 @@ describe('Text input field generation', () => {
     expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"></ul>');
   });
 
-  it('should render the autocomplete input field with all props passed', () => {
+  it('should render the autocomplete input field with all props passed except value', () => {
     render(
       <InputAutocomplete
         fieldDetails={fieldDetailsAllProps}
@@ -117,10 +116,10 @@ describe('Text input field generation', () => {
     );
     expect(screen.getByRole('combobox', { name: '' })).toBeInTheDocument();
     expect(screen.getByRole('listbox', { name: '' })).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="ObjectThree">');
-    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"><li aria-selected="false" class="autocomplete__option" id="fullFieldName-input__option--0" role="option" tabindex="-1" aria-posinset="1" aria-setsize="1">""</li></ul>');
+    expect(screen.getByRole('combobox', { name: '' }).outerHTML).toEqual('<input aria-expanded="false" aria-activedescendant="false" aria-owns="fullFieldName-input__listbox" aria-autocomplete="list" aria-describedby="fullFieldName-input__assistiveHint" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="fullFieldName-input" name="fullFieldName" placeholder="" type="text" role="combobox" value="">');
+    expect(screen.getByRole('listbox', { name: '' }).outerHTML).toEqual('<ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="fullFieldName-input__listbox" role="listbox"></ul>');
   });
-  
+
   it('should render the list options based on what the user enters', async () => {
     const user = userEvent.setup();
     render(
@@ -188,7 +187,7 @@ describe('Text input field generation', () => {
     await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
     await user.click(screen.getByText('ObjectTwo two'));
     expect(input).toHaveValue('ObjectTwo two');
-    
+
     input.setSelectionRange(0, 14);
     await user.keyboard('{backspace}');
     expect(input).toHaveValue('');
@@ -211,7 +210,7 @@ describe('Text input field generation', () => {
     await user.type(screen.getByRole('combobox', { name: '' }), 'Object');
     await user.click(screen.getByText('ObjectOne one'));
     expect(input).toHaveValue('ObjectOne one');
-    
+
     input.setSelectionRange(0, 14);
     await user.keyboard('{delete}');
     expect(input).toHaveValue('');


### PR DESCRIPTION
# Ticket

NMSW-205

----

## AC

Unable to replicate the value not persisting on local env - so needs to be tested on built version

Given I have typed at least two characters in an autocomplete field
When the list is displayed
Then I should see options related to what I typed

Given I can see a list of options
When I select an item from the list
Then it should show in the input field

Given I have a value in the input field
When I refresh the page
Then the value should persist

Given I have seen a value persist once
When I refresh the page again
Then the value should STILL persist

----

## To test

- make sure you're running docker
- `docker build -t nmsw-ui .`
- `docker run --name nmswui -p 8080:8080 nmsw-ui .`
- in browser go to localhost:8080

- type into the autocomplete fields
- select an item
- > check session data to see item including expandedDetails for the item exists
- refresh page
- > session data should ALL persist
- > value in input field should persist
- click on input
- > only the item that matches the input should show
- click on that item
- > check session data to see item including expandedDetails for the item exists
- refresh the page
- > session data should persist
- > input value should persist
- refresh page again
- > session data should persist
- > input value should persist
- complete form
- submit form
- > form should submit


----

## Notes

This solves the bug

HOWEVER
Once we attach the API's to get the data source this process will fail (as seen in the failing test)

AT that point, I think it makes more sense to do something like
- on page refresh
- if there is value for the autocomplete field in the session retrieve that and use it
- if there is no session value, but there is a value passed in from the form API use that
- otherwise field is empty

The general form creator will get the session value and pass it to the Input<x>, but for autocomplete we need to ignore that cause of the way it needs to retrieve and format the data we're better off just getting from the session directly I think
