### PR TITLE
NMSW-117 Do not persist data after form cancel button click

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -49,8 +49,14 @@ Object structure:
 
 ```
 [action]: {
-  className: [required],
   label: [required],
+}
+```
+If cancel button:
+```
+[action]: {
+  label: [required],
+  redirectURL: [required],
 }
 ```
 
@@ -60,12 +66,11 @@ Parameters:
 - submit : triggers the `handleSubmit` function from your parent `Page`
 - cancel: triggers the `handleCancel` function from your parent `Page`
 
-### className
-- `govuk-button`: applies the style for the visually primary button of the page - mainly used for submit
-- `govuk-button govuk-button--secondary` : applies the style for teh visually secondary button(s) of the page - mainly used for cancel
-
 ### label
 The words you wish to show on your button
+
+### redirectURL
+The page you want to redirect the user to if they click cancel
 
 ----
 

--- a/docs/form_creator_example.md
+++ b/docs/form_creator_example.md
@@ -8,8 +8,7 @@ Below is a step by step example of creating a new form using the creator compone
 2. [Add formFields](#AddFormFields)
 3. [Add validation rules (if required)](#AddValidationRunes)
 4. [Add handleSubmit ](#AddHandleSubmit)
-5. [Add handleCancel](#AddHandleCancel)
-6. [Add <DisplayForm> to your return](#AddDisplayForm)
+5. [Add <DisplayForm> to your return](#AddDisplayForm)
 
 _TODO: refactor Add formActions in DisplayForm to map the form actions rather than specify directly. And then update these docs_
 
@@ -32,18 +31,11 @@ Create an object of formActions for your form
 ```javascript
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Save',
-      type: 'button',
     },
     cancel: {
-      className: 'govuk-button govuk-button--secondary',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Cancel',
-      type: 'button',
+      redirect_URL: DASHBOARD_URL
     }
   };
 ```
@@ -238,11 +230,7 @@ If you use a confirmation page
   };
 ```
 
-### 5. <a id="AddHandleCancel"></a>Add handleCancel
-
-_TODO: Add a handleCancel example_
-
-### 6. <a id="AddDisplayForm"></a>Add <DisplayForm> to your return
+### 5. <a id="AddDisplayForm"></a>Add <DisplayForm> to your return
 
 Add the DisplayForm component to your return
 
@@ -287,18 +275,11 @@ const SecondPage = () => {
 
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Save',
-      type: 'button',
     },
     cancel: {
-      className: 'govuk-button--secondary',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Cancel',
-      type: 'button',
+      redirectURL: DASHBOARD_URL
     }
   };
   const formFields = [

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { EXPANDED_DETAILS, FIELD_CONDITIONAL, FIELD_PASSWORD } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
@@ -9,6 +10,7 @@ import Validator from '../utils/Validator';
 const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit }) => {
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
+  const navigate = useNavigate();
   const [errors, setErrors] = useState();
   const [fieldsWithValues, setFieldsWithValues] = useState();
   const [formData, setFormData] = useState({});
@@ -42,6 +44,11 @@ const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit })
     }
     // we do store all values into form data
     setFormData({ ...formData, ...dataSet });
+  };
+
+  const handleCancel = (redirectURL) => {
+    sessionStorage.removeItem('formData');
+    navigate(redirectURL);
   };
 
   const handleValidation = async (e, formData) => {
@@ -188,20 +195,21 @@ const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit })
         }
         <div className="govuk-button-group">
           <button
-            type={formActions.submit.type}
-            className={formActions.submit.className}
-            data-module={formActions.submit.dataModule}
-            data-testid={formActions.submit.dataTestid}
+            type='button'
+            className='govuk-button'
+            data-module='govuk-button'
+            data-testid='submit-button'
             onClick={(e) => handleValidation(e, { formData })}
           >
             {formActions.submit.label}
           </button>
           {
             formActions.cancel && <button
-              type={formActions.cancel.type}
-              className={formActions.cancel.className}
-              data-module={formActions.cancel.dataModule}
-              data-testid={formActions.cancel.dataTestid}
+              type='button'
+              className='govuk-button govuk-button--secondary'
+              data-module='govuk-button'
+              data-testid='cancel-button'
+              onClick={() => handleCancel(formActions.cancel.redirectURL)}
             >
               {formActions.cancel.label}
             </button>
@@ -225,14 +233,15 @@ DisplayForm.propTypes = {
     }),
   ).isRequired,
   formId: PropTypes.string.isRequired,
-  formActions: PropTypes.objectOf(
-    PropTypes.shape({
-      className: PropTypes.string.isRequired,
-      dataModule: PropTypes.string,
-      dataTestid: PropTypes.string,
+  formActions: PropTypes.shape({
+    submit: PropTypes.shape({
       label: PropTypes.string.isRequired,
-      type: PropTypes.string.isRequired,
+    }),
+    cancel: PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      redirectURL: PropTypes.string.isRequired
     })
+  }
   ),
   pageHeading: PropTypes.string.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -1,3 +1,4 @@
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DisplayForm from '../DisplayForm';
@@ -12,7 +13,8 @@ import {
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED,
-  } from '../../constants/AppConstants';
+} from '../../constants/AppConstants';
+import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 
 /*
  * These tests check that we can pass a variety of
@@ -25,33 +27,29 @@ import {
  * (that is done on the page that hold the specific form)
  */
 
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUseNavigate,
+}));
+
 describe('Display Form', () => {
   const handleSubmit = jest.fn();
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Submit test button',
-      type: 'button',
     },
     cancel: {
-      className: 'govuk-button govuk-button--secondary',
-      dataModule: 'govuk-button',
-      dataTestid: 'cancel-button',
       label: 'Cancel test button',
-      type: 'button',
+      redirectURL: DASHBOARD_URL,
     }
   };
   const formActionsSubmitOnly = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Submit test button',
-      type: 'button',
     },
   };
   const formRequiredAutocompleteInput = [
@@ -364,12 +362,14 @@ describe('Display Form', () => {
   // ACTION BUTTONS
   it('should render a submit and cancel button if both exist', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActions}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActions}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
     expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
@@ -377,12 +377,14 @@ describe('Display Form', () => {
 
   it('should render only a submit button if there is no cancel button', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
     expect(screen.getAllByRole('button')).toHaveLength(1);
@@ -391,12 +393,14 @@ describe('Display Form', () => {
   it('should call handleSubmit function if submit button is clicked and there are no errors', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
 
     await user.type(screen.getByLabelText('Text input'), 'Hello');
@@ -409,12 +413,14 @@ describe('Display Form', () => {
   // INPUTS
   it('should render an autocomplete input', async () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredAutocompleteInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredAutocompleteInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByLabelText('Autocomplete input')).toBeInTheDocument();
     expect(screen.getByText('Hint for Autocomplete input').outerHTML).toEqual('<div id="items-hint" class="govuk-hint">Hint for Autocomplete input</div>');
@@ -424,12 +430,14 @@ describe('Display Form', () => {
 
   it('should render a radio button input', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredRadioInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredRadioInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByText('This is a radio button set')).toBeInTheDocument();
     expect(screen.getByText('radio hint').outerHTML).toEqual('<div id="radioButtonSet-hint" class="govuk-hint">radio hint</div>');
@@ -443,12 +451,14 @@ describe('Display Form', () => {
 
   it('should render a radio button set with conditional fields input', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByText('This is a radio set with a conditional field')).toBeInTheDocument();
     expect(screen.getByText('Hint for conditional set').outerHTML).toEqual('<div id="radioWithConditional-hint" class="govuk-hint">Hint for conditional set</div>');
@@ -462,12 +472,14 @@ describe('Display Form', () => {
 
   it('should render a text input', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByLabelText('Text input')).toBeInTheDocument();
     expect(screen.getByText('This is a hint for a text input').outerHTML).toEqual('<div id="testField-hint" class="govuk-hint">This is a hint for a text input</div>');
@@ -476,12 +488,14 @@ describe('Display Form', () => {
 
   it('should render the special input types', () => {
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formSpecialInputs}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formSpecialInputs}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     /* standard text field */
     expect(screen.getByLabelText('Text input')).toBeInTheDocument();
@@ -501,12 +515,14 @@ describe('Display Form', () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","items":"ObjectTwo","itemsExpandedDetails":{"items":{"name":"ObjectTwo","identifier":"two"}}}';
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.type(screen.getByLabelText('Text input'), 'Hello');
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
@@ -523,12 +539,14 @@ describe('Display Form', () => {
   it('should render error summary & field error if there are field errors', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
 
@@ -543,12 +561,14 @@ describe('Display Form', () => {
   it('should render error summary & field error for a conditional field if there are field errors', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredConditionalTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredConditionalTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
 
     await user.click(screen.getByRole('radio', { name: 'Cat' }));
@@ -565,12 +585,14 @@ describe('Display Form', () => {
   it('should return an error if a minimum character count is not met', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formMinimumLengthTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formMinimumLengthTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.type(screen.getByLabelText('Text input'), 'Ab');
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
@@ -586,12 +608,14 @@ describe('Display Form', () => {
   it('should return the error for the first failing validation rule if there are multiple rules', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formMultipleValidationRules}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formMultipleValidationRules}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
 
@@ -606,12 +630,14 @@ describe('Display Form', () => {
   it('should scroll to erroring field if user clicks an error summary link for a single input field', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
     await user.click(screen.getByRole('button', { name: 'Enter your text input value' }));
@@ -622,12 +648,13 @@ describe('Display Form', () => {
   it('should scroll to erroring field if user clicks an error summary link for a radio button set', async () => {
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredRadioInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredRadioInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        /></MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
     await user.click(screen.getByRole('button', { name: 'Select your radio option' }));
@@ -640,12 +667,13 @@ describe('Display Form', () => {
     // we will test that it does clear in Cypress tests
     const user = userEvent.setup();
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formRequiredTextInput}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        /></MemoryRouter>
     );
 
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
@@ -655,7 +683,7 @@ describe('Display Form', () => {
     await user.type(screen.getByRole('textbox', { name: 'Text input' }), 'Hello');
     // error class and message is cleared
     expect(screen.getByRole('textbox', { name: 'Text input' }).outerHTML).toEqual('<input class="govuk-input" id="testField-input" name="testField" type="text" aria-describedby="testField-hint" value="">');
-    
+
   });
 
   // PREFILLING DATA
@@ -663,12 +691,13 @@ describe('Display Form', () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello","radioButtonSet":"radioTwo","radioWithConditional":"optionWithConditional","conditionalTextInput":"world"}';
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        /></MemoryRouter>
     );
     await user.type(screen.getByLabelText('Text input'), 'Hello');
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello');
@@ -685,12 +714,14 @@ describe('Display Form', () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"radioButtonSet":"radioTwo"}';
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     await user.type(screen.getByLabelText('Password'), 'MyPassword');
     expect(screen.getByLabelText('Password')).toHaveValue('MyPassword');
@@ -703,12 +734,14 @@ describe('Display Form', () => {
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne","radioWithConditional":"optionWithConditional","conditionalTextInput":"world"}';
     window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne', radioWithConditional: 'optionWithConditional', conditionalTextInput: 'world' }));
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
     expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
@@ -722,12 +755,14 @@ describe('Display Form', () => {
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
     window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
     render(
-      <DisplayForm
-        formId="testForm"
-        fields={formWithMultipleFields}
-        formActions={formActionsSubmitOnly}
-        handleSubmit={handleSubmit}
-      />
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
     );
     expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
     expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
@@ -735,6 +770,29 @@ describe('Display Form', () => {
 
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
     expect(handleSubmit).toHaveBeenCalled();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+  });
+
+  it('should clear session data when form is cancelled', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActions}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel test button' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(DASHBOARD_URL);
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -17,11 +17,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
 
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'save-button',
       label: 'Save cookie settings',
-      type: 'button',
     }
   };
   const formFields = [

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -18,11 +18,7 @@ const SignIn = (userDetails) => {
   // Form fields
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Sign in',
-      type: 'button',
     }
   };
   const formFields = [

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -18,11 +18,11 @@ const SecondPage = () => {
 
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Save',
-      type: 'button',
+    },
+    cancel: {
+      label: 'Cancel',
+      redirectURL: DASHBOARD_URL
     }
   };
   const formFields = [


### PR DESCRIPTION
# Ticket

NMSW-117

----

## AC

Given I have cancelled a form that has values added
When I then return back to the form
Then the form is clear (i.e. answers do not persist after cancel)

----

## To test

- run app locally
- click sign in to go to second page
- > second page form should be empty
- enter something in form fields
- refresh page
- > values you entered should remain
- click cancel
- go back to second page form
- > form should be empty

----

## Notes
