### PR TITLE
NMSW-155 Manage data across multi page forms

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -29,6 +29,9 @@ Validating fields
 - [Minimum Length](#minimum-length)
 - [Phone Number Format](#phone-number-format)
 
+## MultiPage Forms
+- [Multi Page Form](#multi-page-forms)
+
 
 ## Other guides
 - <a href="https://github.com/UKHomeOffice/nmsw-ui/blob/main/docs/form_creator_example.md">Create a new form - step by step example</a>
@@ -620,6 +623,32 @@ e.g.
   ],
 }
 ```
+
+----
+
+## Multi Page Forms
+If you are creating a multipage form your `handleSubmit` function must include the following:
+
+### First Page
+Create a `dataToSubmit` variable and populate it with this page's formData
+`const dataToSubmit = { ...formData.formData };`
+
+Within the `navigate` pass the dataToSubmit as state:
+`navigate(URL, { state: { dataToSubmit: dataToSubmit } });`
+
+### Step Pages
+Create a `dataToSubmit` variable and populate it with the data passed from the previous page, and this page's formData
+`const dataToSubmit = { ...state.dataToSubmit, ...formData.formData };`
+
+Within the `navigate` pass the dataToSubmit as state:
+`navigate(URL, { state: { dataToSubmit: dataToSubmit } });`
+
+### Final Page
+Create a `dataToSubmit` variable and populate it with the formData from state and the current page's formData:
+`const dataToSubmit = { ...state.dataToSubmit, ...formData.formData };`
+
+After submit remove all formData from sessionStorage
+`sessionStorage.removeItem('formData');`
 
 ----
 ## Structure Diagram

--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -135,6 +135,9 @@ Parameters:
 ### label
 The words you wish to show on your button
 
+### redirectURL
+The page you want to redirect the user to if they click cancel
+
 ----
 
 ## Autocomplete

--- a/docs/form_creator_example.md
+++ b/docs/form_creator_example.md
@@ -8,7 +8,6 @@ Below is a step by step example of creating a new form using the creator compone
 2. [Add formFields](#AddFormFields)
 3. [Add validation rules (if required)](#AddValidationRunes)
 4. [Add handleSubmit ](#AddHandleSubmit)
-5. [Add handleCancel](#AddHandleCancel)
 6. [Add <DisplayForm> to your return](#AddDisplayForm)
 
 _TODO: refactor Add formActions in DisplayForm to map the form actions rather than specify directly. And then update these docs_
@@ -32,18 +31,11 @@ Create an object of formActions for your form
 ```javascript
   const formActions = {
     submit: {
-      className: 'govuk-button',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Save',
-      type: 'button',
     },
     cancel: {
-      className: 'govuk-button govuk-button--secondary',
-      dataModule: 'govuk-button',
-      dataTestid: 'submit-button',
       label: 'Cancel',
-      type: 'button',
+      redirect_URL: DASHBOARD_URL
     }
   };
 ```
@@ -237,10 +229,6 @@ If you use a confirmation page
     }
   };
 ```
-
-### 5. <a id="AddHandleCancel"></a>Add handleCancel
-
-_TODO: Add a handleCancel example_
 
 ### 6. <a id="AddDisplayForm"></a>Add <DisplayForm> to your return
 

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -1,13 +1,18 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { EXPANDED_DETAILS, FIELD_CONDITIONAL, FIELD_PASSWORD } from '../constants/AppConstants';
+import {
+  EXPANDED_DETAILS,
+  FIELD_CONDITIONAL,
+  FIELD_PASSWORD,
+  SINGLE_PAGE_FORM
+} from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
 import determineFieldType from './formFields/DetermineFieldType';
 import { scrollToTop } from '../utils/ScrollToElement';
 import Validator from '../utils/Validator';
 
-const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit, children }) => {
+const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handleSubmit, children }) => {
   const { user } = useContext(UserContext);
   const fieldsRef = useRef(null);
   const navigate = useNavigate();
@@ -65,7 +70,13 @@ const DisplayForm = ({ fields, formId, formActions, pageHeading, handleSubmit, c
        * so we always pass formData back
        */
       handleSubmit(formData);
-      sessionStorage.removeItem('formData');
+
+      /* If the form is a singlepage form we can clear the session 
+       * we do not clear the session for multipage forms
+      */
+      if (formType === SINGLE_PAGE_FORM) {
+        sessionStorage.removeItem('formData');
+      }
     } else {
       scrollToTop();
     }
@@ -246,8 +257,8 @@ DisplayForm.propTypes = {
       label: PropTypes.string.isRequired,
       redirectURL: PropTypes.string.isRequired
     })
-  }
-  ),
+  }),
+  formType: PropTypes.string.isRequired,
   pageHeading: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
 };

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -10,6 +10,8 @@ import {
   FIELD_PHONE,
   FIELD_RADIO,
   FIELD_TEXT,
+  MULTI_PAGE_FORM,
+  SINGLE_PAGE_FORM,
   VALIDATE_CONDITIONAL,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_MIN_LENGTH,
@@ -412,6 +414,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -427,6 +430,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -443,6 +447,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -463,6 +468,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredAutocompleteInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -480,6 +486,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -498,6 +505,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredRadioInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -519,6 +527,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -540,6 +549,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -556,6 +566,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formSpecialInputs}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -583,6 +594,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -607,6 +619,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -629,6 +642,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -651,6 +665,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -674,6 +689,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -697,6 +713,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -719,6 +736,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredConditionalTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -743,6 +761,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formMinimumLengthTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -766,6 +785,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formMultipleValidationRules}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -788,6 +808,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithBackwardsValidationOrder}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -810,6 +831,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -828,6 +850,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredRadioInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -848,6 +871,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -870,6 +894,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredConditionalTextInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -899,6 +924,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formRequiredPhoneNumberInput}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -943,6 +969,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -967,6 +994,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -987,6 +1015,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -1009,6 +1038,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -1031,6 +1061,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>
@@ -1044,6 +1075,30 @@ describe('Display Form', () => {
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 
+  it('should NOT clear multipage formsession data when form is ready to submit', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formWithMultipleFields}
+          formActions={formActionsSubmitOnly}
+          formType={MULTI_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByLabelText('Text input')).toHaveValue('Hello Test Field');
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeChecked();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    expect(handleSubmit).toHaveBeenCalled();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
+
   it('should clear session data when form is cancelled', async () => {
     const user = userEvent.setup();
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
@@ -1054,6 +1109,7 @@ describe('Display Form', () => {
           formId="testForm"
           fields={formWithMultipleFields}
           formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </MemoryRouter>

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -3,6 +3,8 @@ export const SERVICE_NAME = 'National Maritime Single Window';
 
 // Forms: identifiers
 export const EXPANDED_DETAILS = 'ExpandedDetails';
+export const MULTI_PAGE_FORM = 'multiPageForm';
+export const SINGLE_PAGE_FORM = 'singlePageForm';
 // Forms: input types
 export const FIELD_AUTOCOMPLETE = 'autocomplete';
 export const FIELD_CONDITIONAL = 'conditional';

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,6 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 import { REGISTER_ACCOUNT_ENDPOINT } from '../../constants/AppAPIConstants';
-import { FIELD_EMAIL, VALIDATE_EMAIL_ADDRESS, VALIDATE_FIELD_MATCH, VALIDATE_REQUIRED } from '../../constants/AppConstants';
+import {
+  FIELD_EMAIL,
+  SINGLE_PAGE_FORM,
+  VALIDATE_EMAIL_ADDRESS,
+  VALIDATE_FIELD_MATCH,
+  VALIDATE_REQUIRED
+} from '../../constants/AppConstants';
 import { REGISTER_DETAILS } from '../../constants/AppUrlConstants';
 import usePostData from '../../hooks/usePostData';
 import DisplayForm from '../../components/DisplayForm';
@@ -87,6 +93,7 @@ const RegisterEmailAddress = () => {
           formId='formRegisterEmailAddress'
           fields={formFields}
           formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
           pageHeading='What is your email address'
           handleSubmit={handleSubmit}
         >

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -3,6 +3,7 @@ import {
   FIELD_RADIO,
   FIELD_TEXT,
   FIELD_PHONE,
+  MULTI_PAGE_FORM,
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
@@ -93,10 +94,15 @@ const RegisterYourDetails = () => {
     },
   ];
 
-  const handleSubmit = async (e, formData) => {
-    // This will trigger a PATCH to /registration endpoint
-    // with { "email": "example@mail.com" }
-    console.log('submit', e, formData);
+  const handleSubmit = async (formData) => {
+
+    console.log('submit', formData);
+
+    // do not clear the session storage
+    // do pass formData to next page for use
+
+
+
     // and then take user to the next page
     navigate(REGISTER_PASSWORD);
   };
@@ -108,6 +114,7 @@ const RegisterYourDetails = () => {
           formId='formRegisterYourDetails'
           fields={formFields}
           formActions={formActions}
+          formType={MULTI_PAGE_FORM}
           pageHeading='Your details'
           handleSubmit={handleSubmit}
         />

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -98,13 +98,12 @@ const RegisterYourDetails = () => {
 
     console.log('submit', formData);
 
-    // do not clear the session storage
     // do pass formData to next page for use
 
 
 
     // and then take user to the next page
-    navigate(REGISTER_PASSWORD);
+    navigate(REGISTER_PASSWORD, { state: formData });
   };
 
   return (

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -95,15 +95,9 @@ const RegisterYourDetails = () => {
   ];
 
   const handleSubmit = async (formData) => {
-
+    const dataToSubmit = { ...formData.formData };
     console.log('submit', formData);
-
-    // do pass formData to next page for use
-
-
-
-    // and then take user to the next page
-    navigate(REGISTER_PASSWORD, { state: formData });
+    navigate(REGISTER_PASSWORD, { state: { dataToSubmit: dataToSubmit } });
   };
 
   return (

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import {
   FIELD_PASSWORD,
+  MULTI_PAGE_FORM,
   VALIDATE_FIELD_MATCH,
   VALIDATE_MIN_LENGTH,
   VALIDATE_REQUIRED
@@ -66,8 +67,8 @@ const RegisterYourPassword = () => {
     }
   ];
 
-  const handleSubmit = async (e, formData) => {
-    console.log('submit', e, formData);
+  const handleSubmit = async (formData) => {
+    console.log('submit', formData);
     navigate(
       REGISTER_CONFIRMATION,
       {
@@ -85,6 +86,7 @@ const RegisterYourPassword = () => {
           formId='formRegisterYourPassword'
           fields={formFields}
           formActions={formActions}
+          formType={MULTI_PAGE_FORM}
           pageHeading='Create a password'
           handleSubmit={handleSubmit}
         >

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -70,7 +70,7 @@ const RegisterYourPassword = () => {
 
   const handleSubmit = async (formData) => {
     // combine data from previous page of form
-    const dataToSubmit = { ...state.dataToSubmit, ...formData.formData };
+    const dataToSubmit = { ...state?.dataToSubmit, ...formData.formData };
     console.log(dataToSubmit);
     sessionStorage.removeItem('formData');
     navigate(

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -70,7 +70,7 @@ const RegisterYourPassword = () => {
 
   const handleSubmit = async (formData) => {
     // combine data from previous page of form
-    const dataToSubmit = { ...state.formData, ...formData.formData };
+    const dataToSubmit = { ...state.dataToSubmit, ...formData.formData };
     console.log(dataToSubmit);
     sessionStorage.removeItem('formData');
     navigate(

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   FIELD_PASSWORD,
   MULTI_PAGE_FORM,
@@ -22,6 +22,7 @@ const SupportingText = () => {
 
 const RegisterYourPassword = () => {
   const navigate = useNavigate();
+  const {state} = useLocation();
 
   const formActions = {
     submit: {
@@ -68,7 +69,10 @@ const RegisterYourPassword = () => {
   ];
 
   const handleSubmit = async (formData) => {
-    console.log('submit', formData);
+    // combine data from previous page of form
+    const dataToSubmit = { ...state.formData, ...formData.formData };
+    console.log(dataToSubmit);
+    sessionStorage.removeItem('formData');
     navigate(
       REGISTER_CONFIRMATION,
       {

--- a/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
@@ -109,4 +109,20 @@ describe('Register email address tests', () => {
     expect(screen.queryByText('Enter country')).not.toBeInTheDocument();
     expect(screen.queryByText('Select is your company a shipping agent')).not.toBeInTheDocument();
   });
+
+  it('should NOT clear form session data on submit', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"fullName":"Joe Bloggs","companyName":"Joe Bloggs Company","phoneNumber":"(123)12345","country":"Australia","shippingAgent":"yes"}';
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+
+    await user.type(screen.getByLabelText('Full name'), 'Joe Bloggs');
+    await user.type(screen.getByLabelText('Your company name'), 'Joe Bloggs Company');
+    await user.type(screen.getByLabelText('Country code field'), '123');
+    await user.type(screen.getByLabelText('Phone number field'), '12345');
+    await user.type(screen.getByLabelText('Country'), 'Australia');
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+
+    await user.click(screen.getByTestId('submit-button'));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
 });

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -41,7 +41,7 @@ describe('Register password tests', () => {
 
   it('should render a continue button', async () => {
     render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
-    expect(screen.getByRole('button', {name: 'Continue'}).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
+    expect(screen.getByRole('button', { name: 'Continue' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
   });
 
   it('should NOT call the handleSubmit function on button click if there ARE errors', async () => {
@@ -97,7 +97,7 @@ describe('Register password tests', () => {
 
   it('should NOT display error messagess if fields are valid', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
     await user.click(screen.getByTestId('submit-button'));

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -13,12 +13,12 @@ describe('Register password tests', () => {
   });
 
   it('should render h1', async () => {
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     expect(screen.getByText('Create a password')).toBeInTheDocument();
   });
 
   it('should render an intro', async () => {
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     expect(screen.getByText('Your password must be at least 10 characters long. There is no restriction on the characters you use.')).toBeInTheDocument();
     /*
      * Because the text below is in a paragraph which has a link within it, RTL struggles to find the text in the render
@@ -32,7 +32,7 @@ describe('Register password tests', () => {
   });
 
   it('should render two password questions', async () => {
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByLabelText('Password').outerHTML).toEqual('<input class="govuk-input" id="requirePassword-input" data-testid="requirePassword-passwordField" name="requirePassword" type="password" value="">');
     expect(screen.getByLabelText('Confirm your password')).toBeInTheDocument();
@@ -40,27 +40,27 @@ describe('Register password tests', () => {
   });
 
   it('should render a continue button', async () => {
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     expect(screen.getByRole('button', { name: 'Continue' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
   });
 
   it('should NOT call the handleSubmit function on button click if there ARE errors', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
   it('should display the Error Summary if there are errors', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
   });
 
   it('should display the required error messages if required fields are null', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
     expect(screen.getAllByText('Enter a password')).toHaveLength(2);
@@ -69,7 +69,7 @@ describe('Register password tests', () => {
 
   it('should display the required error messages if just confirm password is null', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe('Register password tests', () => {
 
   it('should display the min length error messages if password field too short', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'shortpwd');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('Register password tests', () => {
 
   it('should display the error messages if password fields do not match', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.type(screen.getByLabelText('Confirm your password'), 'mypass');
     await user.click(screen.getByTestId('submit-button'));
@@ -104,5 +104,16 @@ describe('Register password tests', () => {
     expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter a password')).not.toBeInTheDocument();
     expect(screen.getAllByText('Confirm your password')).toHaveLength(1); // label only
+  });
+
+  it('should clear form session data on submit', async () => {
+    const user = userEvent.setup();
+    const expectedStoredData = '{"requirePassword":"mypasswordis","repeatPassword":"mypasswordis"}';
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+    await user.click(screen.getByTestId('submit-button'));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import DisplayForm from '../../components/DisplayForm';
-import { FIELD_RADIO, CHECKED_TRUE, CHECKED_FALSE } from '../../constants/AppConstants';
+import { FIELD_RADIO, CHECKED_TRUE, CHECKED_FALSE, SINGLE_PAGE_FORM } from '../../constants/AppConstants';
 import cookieToFind from '../../utils/cookieToFind';
 import { scrollToElementId } from '../../utils/ScrollToElement';
 import setAnalyticCookie from '../../utils/setAnalyticCookie';
@@ -92,6 +92,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
         formId='changeYourCookieSettings'
         fields={formFields}
         formActions={formActions}
+        formType={SINGLE_PAGE_FORM}
         handleSubmit={handleSubmit}
       />
     </>

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -4,6 +4,7 @@ import { UserContext } from '../../context/userContext';
 import {
   FIELD_EMAIL,
   FIELD_PASSWORD,
+  SINGLE_PAGE_FORM,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_REQUIRED,
   } from '../../constants/AppConstants';
@@ -64,6 +65,7 @@ const SignIn = (userDetails) => {
           formId='formSignIn'
           fields={formFields}
           formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
           handleSubmit={handleSubmit}
         />
       </div>


### PR DESCRIPTION
# Ticket

NMSW-155

----

## AC

When a form is more than one page long pre submission to API data needs to
- persist in the session
- persist in the form data so it can be submitted

----

## To test

- run app
- open dev tools
- go to create account
- complete email page & continue
- complete your details page & continue
- check session data
- > you should see the your details data under formData in the session
- enter password
- > you should see the password now included with the other details data in formData in the session
- switch to viewing console in dev tools
- confirm password
- click submit
- > you should be taken to the confirmation page
- > you should receive a log in the console of the formData being submitted
- > this log should include values from your details and password page
- switch to viewing session details
- > there should be no formData in the session storage

----

## Notes

This does not yet PATCH data to the API, that is coming in the next ticket
