### PR TITLE
NMSW-230 Add basic error page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -9,6 +9,7 @@ import {
   ACCESSIBILITY_URL,
   COOKIE_URL,
   DASHBOARD_URL,
+  ERROR_URL,
   FORM_CONFIRMATION_URL,
   LANDING_URL,
   PRIVACY_URL,
@@ -33,6 +34,7 @@ import RegisterYourDetails from './pages/Register/RegisterYourDetails';
 import RegisterYourPassword from './pages/Register/RegisterYourPassword';
 import SignIn from './pages/SignIn/SignIn';
 // Other pages (could be protected or not)
+import GenericUnknownError from './pages/Error/GenericUnknownError';
 import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
 // Protected pages
 import Dashboard from './pages/Dashboard/Dashboard';
@@ -59,6 +61,7 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
         <Route path={REGISTER_PASSWORD_URL} element={<RegisterYourPassword />} />
         <Route path={SIGN_IN_URL} element={<SignIn />} />
 
+        <Route path={ERROR_URL} element={<GenericUnknownError />} />
         <Route path={FORM_CONFIRMATION_URL} element={<FormConfirmationPage />} />
 
         <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -7,6 +7,7 @@ export const ACCESSIBILITY_URL = '/accessibility-statement';
 export const COOKIE_URL = '/cookies';
 export const DASHBOARD_PAGE_NAME = 'Dashboard';
 export const DASHBOARD_URL = '/dashboard';
+export const ERROR_URL = '/error';
 export const FORM_CONFIRMATION_URL = '/confirmation';
 export const LANDING_URL = '/';
 export const PRIVACY_URL = '/privacy-notice';

--- a/src/hooks/usePostData.js
+++ b/src/hooks/usePostData.js
@@ -6,7 +6,7 @@ const usePostData = ({url, dataToSubmit, pageSource}) => {
   const data = axios.post(url, dataToSubmit, {
     headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
   })
-    .then((resp) => { return resp.data; })
+    .then((resp) => { return resp; })
     .catch((err) => {
       if (err.response) {
         switch (err.response.status) {

--- a/src/pages/Error/GenericUnknownError.jsx
+++ b/src/pages/Error/GenericUnknownError.jsx
@@ -1,0 +1,19 @@
+import { Link, useLocation } from 'react-router-dom';
+import { LANDING_URL } from '../../constants/AppUrlConstants';
+
+const GenericUnknownError = () => {
+  const { state } = useLocation();
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="govuk-heading-xl">Error</h1>
+          <p className="govuk-body">{state?.message}</p>
+          <Link to={state?.redirectURL || LANDING_URL}>Click here to continue</Link>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default GenericUnknownError;

--- a/src/pages/Error/__tests__/GenericUnknownError.test.jsx
+++ b/src/pages/Error/__tests__/GenericUnknownError.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { LANDING_URL, SIGN_IN_URL } from '../../../constants/AppUrlConstants';
+import GenericUnknownError from '../GenericUnknownError';
+
+const mockUseLocationState = { state: {} };
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
+describe('Error page tests', () => {
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockUseLocationState.state = {};
+  });
+
+  it('should render h1', () => {
+    render(<MemoryRouter><GenericUnknownError /></MemoryRouter>);
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it('should render a click here to continue link to the URL passed to this page', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState.state = { redirectURL: SIGN_IN_URL };
+    render(<MemoryRouter><GenericUnknownError /></MemoryRouter>);
+    expect(screen.getByText('Click here to continue')).toBeInTheDocument();
+    await user.click(screen.getByText('Click here to continue'));
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL,  {'preventScrollReset': undefined, 'relative': undefined, 'replace': false, 'state': undefined}); // params on Link generated links by default
+    });
+  });
+
+
+  it('should render a click here to continue link to the Landing page if no url passed to this page', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState.state = {};
+    render(<MemoryRouter><GenericUnknownError /></MemoryRouter>);
+    expect(screen.getByText('Click here to continue')).toBeInTheDocument();
+    await user.click(screen.getByText('Click here to continue'));
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(LANDING_URL, {'preventScrollReset': undefined, 'relative': undefined, 'replace': true, 'state': undefined}); // params on Link generated links by default
+    });
+  });
+
+});

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -7,7 +7,7 @@ import {
   VALIDATE_FIELD_MATCH,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
-import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
+import { ERROR_URL, REGISTER_EMAIL_URL, REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
 import usePostData from '../../hooks/usePostData';
 import DisplayForm from '../../components/DisplayForm';
 
@@ -76,13 +76,15 @@ const RegisterEmailAddress = () => {
           email: formData.formData.emailAddress,
         }
       });
-      if (response && response.id) { // using response.id as the indicator of success as status isn't passed back on success yet
+      if (response && response.status === 200) {
         navigate(REGISTER_DETAILS_URL);
       } else {
-        console.log('error', response);
+        navigate(ERROR_URL, { state: { 
+          message: response.message ? response.message : 'Something has gone wrong',
+          redirectURL: REGISTER_EMAIL_URL }});
       }
     } catch (err) {
-      console.log('err', err);
+      navigate(ERROR_URL, { state: { message: 'Something has gone wrong', redirectURL: REGISTER_EMAIL_URL }});
     }
   };
 

--- a/src/pages/Register/__tests__/RegisterEmailAddressPost.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddressPost.test.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
+import { ERROR_URL, REGISTER_EMAIL_URL, REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
 import RegisterEmailAddress from '../RegisterEmailAddress';
 
 const mockedUseNavigate = jest.fn();
@@ -22,6 +22,7 @@ describe('Register email address POST tests', () => {
 
   beforeEach(() => {
     mockAxios.reset();
+    mockedUserPostData = {};
     window.sessionStorage.clear();
   });
 
@@ -33,8 +34,11 @@ describe('Register email address POST tests', () => {
   it('should navigate to register details page if successful POST response', async () => {
     const user = userEvent.setup();
     mockedUserPostData = {
-      email: 'jentest202212121535@email.com',
-      id: 'e799cd36-9863-495b-9d6d-60132ea5abf5'
+      status: 200,
+      data: {
+        email: 'testemail@email.com',
+        id: 'e799cd36-9863-495b-9d6d-60132ea5abf5'
+      }
     };
 
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
@@ -48,21 +52,32 @@ describe('Register email address POST tests', () => {
     });
   });
 
-  it('should NOT navigate to register details page if unsuccessful POST response', async () => {
+  it('should redirect to error page with message if a 4xx response received', async () => {
     const user = userEvent.setup();
     mockedUserPostData = {
       message: 'error response',
-      status: '404'
+      status: '400'
     };
 
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@email.com');
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
     await user.click(screen.getByTestId('submit-button'));
-
-    // mocked usePostData returns a successful response (currently we take success as id received as we don't get the success code yet)
     await waitFor(() => {
-      expect(mockedUseNavigate).not.toHaveBeenCalled();
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'message': 'error response', 'redirectURL': REGISTER_EMAIL_URL}}); // on error we redirect to error page
+    });
+  });
+
+  it('should redirect to error page with a generic message if any other error occurs (and the catch of the try/catch is thrown)', async () => {
+    const user = userEvent.setup();
+    mockedUserPostData = undefined;
+
+    render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@email.com');
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
+    await user.click(screen.getByTestId('submit-button'));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'message': 'Something has gone wrong', 'redirectURL': REGISTER_EMAIL_URL}}); // on error we redirect to error page
     });
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-155

----

## AC

To enable testing add the base of an error handling page
And on any error redirect to this page with a message

This is needed so we can easily test what happens if the /registration endpoint returns anything other than a 200

----

## To test

- run app
- go to create account
- enter a new email address & repeat
- click continue
- > you should be taken to the your details page
- go back
- enter the same email address in the email fields
- click continue
- > you should be taken to the error page with a message that the email address already exists

----

## Notes

This is not the final implementation of any error handling, this is a basic form to allow testing.
Tickets are open to handle 4xx and 500 errors