### PR TITLE
NMSW-233 Redirect if no email address when loading register your details page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -16,6 +16,7 @@ import {
   REGISTER_ACCOUNT_URL,
   REGISTER_CONFIRMATION_URL,
   REGISTER_EMAIL_URL,
+  REGISTER_EMAIL_VERIFIED_URL,
   REGISTER_DETAILS_URL,
   REGISTER_PASSWORD_URL,
   SIGN_IN_URL,
@@ -30,6 +31,7 @@ import PrivacyNotice from './pages/Regulatory/PrivacyNotice';
 // Register/Sign in pages
 import RegisterConfirmation from './pages/Register/RegisterConfirmation';
 import RegisterEmailAddress from './pages/Register/RegisterEmailAddress';
+import RegisterEmailVerified from './pages/Register/RegisterEmailVerified';
 import RegisterYourDetails from './pages/Register/RegisterYourDetails';
 import RegisterYourPassword from './pages/Register/RegisterYourPassword';
 import SignIn from './pages/SignIn/SignIn';
@@ -57,6 +59,7 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
         <Route path={REGISTER_CONFIRMATION_URL} element={<RegisterConfirmation />} />
         <Route path={REGISTER_ACCOUNT_URL} element={<RegisterEmailAddress />} />
         <Route path={REGISTER_EMAIL_URL} element={<RegisterEmailAddress />} />
+        <Route path={REGISTER_EMAIL_VERIFIED_URL} element={<RegisterEmailVerified />} />
         <Route path={REGISTER_DETAILS_URL} element={<RegisterYourDetails />} />
         <Route path={REGISTER_PASSWORD_URL} element={<RegisterYourPassword />} />
         <Route path={SIGN_IN_URL} element={<SignIn />} />

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -18,6 +18,7 @@ export const SIGN_IN_URL = '/sign-in';
 export const REGISTER_ACCOUNT_URL = '/create-account/email-address';
 export const REGISTER_CONFIRMATION_URL = '/create-account/account-created';
 export const REGISTER_EMAIL_URL = '/create-account/email-address';
+export const REGISTER_EMAIL_VERIFIED_URL = '/create-account/email-verified';
 export const REGISTER_DETAILS_URL = '/create-account/your-details';
 export const REGISTER_PASSWORD_URL = '/create-account/your-password';
 

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -1,4 +1,5 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   FIELD_RADIO,
   FIELD_TEXT,
@@ -8,11 +9,12 @@ import {
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
-import { REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
+import { REGISTER_EMAIL_VERIFIED_URL, REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 
 const RegisterYourDetails = () => {
   const navigate = useNavigate();
+  const { state } = useLocation();
 
   const formActions = {
     submit: {
@@ -105,6 +107,19 @@ const RegisterYourDetails = () => {
     console.log('submit', formData);
     navigate(REGISTER_PASSWORD_URL, { state: { dataToSubmit: dataToSubmit } });
   };
+
+  /* 
+   * Without an email address we can't submit the PATCH to update the user account
+   * So if a user arrives to this page and we do not have an email address in state
+   * we need to direct them to a place where they can deal with that
+   * TODO: once we have email verification flow journey replace REGISTER_EMAIL_URL_VERIFIED
+   * with a more appropriate page
+   */
+  useEffect(() => {
+    if (!state || !state.dataToSubmit || !state.dataToSubmit.emailAddress) {
+      navigate(REGISTER_EMAIL_VERIFIED_URL);
+    } 
+  }, [state]);
 
   return (
     <>

--- a/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
@@ -1,15 +1,51 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { REGISTER_EMAIL_VERIFIED_URL } from '../../../constants/AppUrlConstants';
 import RegisterYourDetails from '../RegisterYourDetails';
 
-describe('Register email address tests', () => {
+let mockUseLocationState = {};
+const mockedUseNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
+describe('Your details tests', () => {
   const handleSubmit = jest.fn();
   let scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
   beforeEach(() => {
+    mockUseLocationState = {};
     window.sessionStorage.clear();
+  });
+
+  it('should redirect user to other page if there is no state', async () => {
+    mockUseLocationState = {};
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_VERIFIED_URL);
+    });
+  });
+
+  it('should redirect user to other page if there is no dataToSubmit object in state', async () => {
+    mockUseLocationState = { state: {} };
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_VERIFIED_URL);
+    });
+  });
+
+  it('should redirect user to other page if there is no emailAddress in state', async () => {
+    mockUseLocationState = { state: { dataToSubmit: {} } };
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_VERIFIED_URL);
+    });
   });
 
   it('should render h1', async () => {


### PR DESCRIPTION
# Ticket

NMSW-155

----

## AC

Given I have gone to `/create-account/your-details`
When there is no `email address` available in state
Then I should be redirected to the validate email page

----

## To test

- start a new browser session (new tab or new browser instance - this is to ensure there's nothing in your state)
- go to `http://localhost:3000/create-account/your-details`
- > you should be immediately redirected to `http://localhost:3000/create-account/email-verified`
- enter an email address (any, this is for testing only there is no validation here)
- click continue
- > you should be taken to your details

----

## Notes

We will change which page you're redirected to in future when the verify email process is built. For now this page allows testers to enter an email address and continue testing the registration flow
