### PR TITLE
NMSW-234 PATCH registration

### DIFF
--- a/src/hooks/usePatchData.js
+++ b/src/hooks/usePatchData.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import Auth from '../utils/Auth';
+
+const usePatchData = ({ url, dataToSubmit, pageSource }) => {
+  const source = pageSource || location.pathname.substring(1);
+  const data = axios.patch(url, dataToSubmit, {
+    headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+  })
+    .then((resp) => { return resp; })
+    .catch((err) => {
+      if (err.response) {
+        switch (err.response.status) {
+          case 401: window.location.assign(`/sign-in?source=${source}`); break;
+          default: return ({ errors: true, status: err.response.status, message: err.response.data.message });
+        }
+      }
+    });
+  return data;
+};
+
+export default usePatchData;

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -36,7 +36,7 @@ const RegisterEmailVerified = () => {
 
   const handleSubmit = async (formData) => {
     const dataToSubmit = { ...formData.formData };
-    navigate(REGISTER_DETAILS_URL, { state: { dataToSubmit: dataToSubmit } });
+    navigate(REGISTER_DETAILS_URL, { state: { dataToSubmit: { emailAddress: dataToSubmit.emailAddress } } });
   };
 
   return (

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -103,8 +103,7 @@ const RegisterYourDetails = () => {
   ];
 
   const handleSubmit = async (formData) => {
-    const dataToSubmit = { ...formData.formData };
-    console.log('submit', formData);
+    const dataToSubmit = { ...state?.dataToSubmit, ...formData.formData };
     navigate(REGISTER_PASSWORD_URL, { state: { dataToSubmit: dataToSubmit } });
   };
 

--- a/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
@@ -141,5 +141,4 @@ describe('Register email address tests', () => {
     expect(screen.queryByText('Confirm your email address')).not.toBeInTheDocument();
     expect(screen.queryByText('Your email addresses must match')).not.toBeInTheDocument();
   });
-
 });

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -1,7 +1,25 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { ERROR_URL, REGISTER_CONFIRMATION_URL, REGISTER_EMAIL_VERIFIED_URL } from '../../../constants/AppUrlConstants';
 import RegisterYourPassword from '../RegisterYourPassword';
+
+let mockUseLocationState = { state: {} };
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
+let mockedUserPatchData = {};
+jest.mock('../../../hooks/usePatchData', () => {
+  return jest.fn(() => (mockedUserPatchData));
+});
+
 
 describe('Register password tests', () => {
   const handleSubmit = jest.fn();
@@ -9,16 +27,17 @@ describe('Register password tests', () => {
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
   beforeEach(() => {
+    mockUseLocationState = { state: {} };
     window.sessionStorage.clear();
   });
 
   it('should render h1', async () => {
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     expect(screen.getByText('Create a password')).toBeInTheDocument();
   });
 
   it('should render an intro', async () => {
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     expect(screen.getByText('Your password must be at least 10 characters long. There is no restriction on the characters you use.')).toBeInTheDocument();
     /*
      * Because the text below is in a paragraph which has a link within it, RTL struggles to find the text in the render
@@ -32,7 +51,7 @@ describe('Register password tests', () => {
   });
 
   it('should render two password questions', async () => {
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByLabelText('Password').outerHTML).toEqual('<input class="govuk-input" id="requirePassword-input" data-testid="requirePassword-passwordField" name="requirePassword" type="password" value="">');
     expect(screen.getByLabelText('Confirm your password')).toBeInTheDocument();
@@ -40,27 +59,27 @@ describe('Register password tests', () => {
   });
 
   it('should render a continue button', async () => {
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     expect(screen.getByRole('button', { name: 'Continue' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
   });
 
   it('should NOT call the handleSubmit function on button click if there ARE errors', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
   it('should display the Error Summary if there are errors', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
   });
 
   it('should display the required error messages if required fields are null', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
     expect(screen.getAllByText('Enter a password')).toHaveLength(2);
@@ -69,7 +88,7 @@ describe('Register password tests', () => {
 
   it('should display the required error messages if just confirm password is null', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -78,7 +97,7 @@ describe('Register password tests', () => {
 
   it('should display the min length error messages if password field too short', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'shortpwd');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -87,7 +106,7 @@ describe('Register password tests', () => {
 
   it('should display the error messages if password fields do not match', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.type(screen.getByLabelText('Confirm your password'), 'mypass');
     await user.click(screen.getByTestId('submit-button'));
@@ -97,7 +116,7 @@ describe('Register password tests', () => {
 
   it('should NOT display error messagess if fields are valid', async () => {
     const user = userEvent.setup();
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
     await user.click(screen.getByTestId('submit-button'));
@@ -106,14 +125,103 @@ describe('Register password tests', () => {
     expect(screen.getAllByText('Confirm your password')).toHaveLength(1); // label only
   });
 
-  it('should clear form session data on submit', async () => {
+  it('should persist data from previous form (state.dataToSubmit) in session as well as new fields', async () => {
     const user = userEvent.setup();
-    const expectedStoredData = '{"requirePassword":"mypasswordis","repeatPassword":"mypasswordis"}';
-    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    const expectedStoredData = '{"fullName":"Joe Bloggs","companyName":"My company","phoneNumber":"(123)12345","country":"AUS","shippingAgent":"yes","requirePassword":"mypasswordis","repeatPassword":"mypasswordis"}';
+    mockUseLocationState.state = {
+      dataToSubmit: {
+        companyName: 'My company',
+        country: 'AUS',
+        emailAddress: 'testemail@email.com',
+        fullName: 'Joe Bloggs',
+        phoneNumber: '(123)12345',
+        shippingAgent: 'yes'
+      }
+    };
+    mockedUserPatchData = {
+      status: 200,
+      data: {
+        email: 'testemail@email.com',
+        fullName: 'Joe Bloggs',
+        country: 'AUS',
+        phoneNumber: '(123)12345',
+        groupName: 'My company',
+        groupTypeName: 'Shipping Agency',
+        id: '123',
+        groupId: '456',
+        verified: false,
+        dateCreated: '2022-12-14T10:10:17.134835',
+        lastUpdated: '2022-12-14T14:20:23.497658'
+      }
+    };
+
+    // set what would be in the session prior to this page
+    window.sessionStorage.setItem('formData', JSON.stringify({ fullName: 'Joe Bloggs', companyName: 'My company', phoneNumber: '(123)12345', country: 'AUS', shippingAgent: 'yes' }));
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
     await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+    // after successful submit session data should clear
     await user.click(screen.getByTestId('submit-button'));
-    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+    });
+  });
+
+  it('should navigate to confirmation page if successful PATCH response', async () => {
+    const user = userEvent.setup();
+    mockedUserPatchData = {
+      status: 200,
+      data: {
+        email: 'testemail@email.com',
+        fullName: 'Joe Bloggs',
+        country: 'AUS',
+        phoneNumber: '(123)12345',
+        groupName: 'My company',
+        groupTypeName: 'Shipping Agency',
+        id: '123',
+        groupId: '456',
+        verified: false,
+        dateCreated: '2022-12-14T10:10:17.134835',
+        lastUpdated: '2022-12-14T14:20:23.497658'
+      }
+    };
+
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    await user.click(screen.getByTestId('submit-button'));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_CONFIRMATION_URL, { 'state': { 'companyName': 'My company' } });
+    });
+  });
+
+  it('should navigate to error page if failed PATCH response', async () => {
+    const user = userEvent.setup();
+    mockedUserPatchData = {
+      message: 'error response',
+      status: '400'
+    };
+
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    await user.click(screen.getByTestId('submit-button'));
+     await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'message': 'error response', 'redirectURL': REGISTER_EMAIL_VERIFIED_URL}});
+    });
+  });
+
+  it('should navigate to error page if id missing from PATCH response', async () => {
+    const user = userEvent.setup();
+    mockedUserPatchData = undefined;
+
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    await user.click(screen.getByTestId('submit-button'));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'message': 'Something has gone wrong', 'redirectURL': REGISTER_EMAIL_VERIFIED_URL}});
+    });
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-155

----

## AC

Given I have clicked submit on the create-account/your-password page
When I have no errors
Then the code sends a PATCH request to /registration

Given a PATCH request has been sent to /registration
When a success (200) response is received
Then I am taken to the confirmation page

Given a PATCH request has been sent to /registration
When an error response is received
Then I am redirected to the error page

Given a PATCH request has been sent to /registration
When no valid response is received
Then I am redirected to the error page
(this scenario is not tested in the UI, it's the `catch` scenario of the try/catch for if a promise fails unexpectedly)

----

## To test

- run BE in docker
- run app
- go to `http://localhost:3000/create-account/email-verified`
- enter an email address you have NOT previously registered
- fill out your details
- fill out password
- click submit
- > you should be taken to the error page with 'user not registered' message
- click continue to be taken back to the email page
- enter an email address you HAVE previously registered
- continue through the form and submit
- > you should be taken to the confirmation page
----

## Notes

Handling errors is not fully implemented and so sessions are not cleared when errors occur in the test case above.
This is known and will be handled when we finish error implementation for 4xx and 500 errors in future tickets