### PR TITLE
NMSW-226 Do not allow spaces in password creation fields

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -26,7 +26,9 @@ Validating fields
 - [Conditional](#conditional)
 - [Email Format](#email-format)
 - [Match](#match)
+- [Maximum Length](#maximum-length)
 - [Minimum Length](#minimum-length)
+- [No Spaces](#no-spaces)
 - [Phone Number Format](#phone-number-format)
 
 ## MultiPage Forms
@@ -533,14 +535,39 @@ Specifically tests if the value entered matches the value of another field.
 }
 ```
 
+#### Maximum Length
+Specifically tests if the length of the value entered is > the number specified in the `condition` entry.
+This test only runs if there is a value in the field and is ignored if field is null. 
+
+```
+{
+  type: VALIDATE_MAX_LENGTH,
+  condition: <maximum length>
+  message: <error message to show in UI>
+  },
+}
+```
+
 #### Minimum Length
-Specifically tests if the length of the value entered is > the number specified in the `conditions` entry.
+Specifically tests if the length of the value entered is < the number specified in the `condition` entry.
 This test only runs if there is a value in the field and is ignored if field is null.
 
 ```
 {
   type: VALIDATE_MIN_LENGTH,
   condition: <minimum length>
+  message: <error message to show in UI>
+  },
+}
+```
+
+
+#### No Spaces
+Used mainly for fields like passwords, it checks for a [space] and throws an error if any exist anywhere in the string
+
+```
+{
+  type: VALIDATE_NO_SPACES,
   message: <error message to show in UI>
   },
 }

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -24,3 +24,4 @@ export const VALIDATE_MAX_LENGTH = 'maxLength';
 export const VALIDATE_MIN_LENGTH = 'minLength';
 export const VALIDATE_PHONE_NUMBER = 'phoneNumber';
 export const VALIDATE_REQUIRED = 'required';
+export const VALIDATE_NO_SPACES = 'noSpaces';

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -42,17 +42,17 @@ const RegisterYourPassword = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter a password'
+          message: 'Enter password'
         },
         {
           type: VALIDATE_MIN_LENGTH,
           message: 'Passwords must be at least 10 characters long',
           condition: 10
         },
-        // {
-        //   type: VALIDATE_NO_SPACES,
-        //   message: 'Enter a password that does not contain spaces'
-        // }
+        {
+          type: VALIDATE_NO_SPACES,
+          message: 'Enter a password that does not contain spaces'
+        },
       ]
     },
     {

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -4,6 +4,7 @@ import {
   MULTI_PAGE_FORM,
   VALIDATE_FIELD_MATCH,
   VALIDATE_MIN_LENGTH,
+  VALIDATE_NO_SPACES,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
 import { REGISTER_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
@@ -48,6 +49,10 @@ const RegisterYourPassword = () => {
           message: 'Passwords must be at least 10 characters long',
           condition: 10
         },
+        // {
+        //   type: VALIDATE_NO_SPACES,
+        //   message: 'Enter a password that does not contain spaces'
+        // }
       ]
     },
     {

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -42,7 +42,7 @@ const RegisterYourPassword = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter password'
+          message: 'Enter a password'
         },
         {
           type: VALIDATE_MIN_LENGTH,

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -76,7 +76,7 @@ describe('Register password tests', () => {
     expect(screen.getAllByText('Confirm your password')).toHaveLength(3);
   });
 
-  it('should display the min length error messages if password field too short', async () => {
+  it('should display the min length error messages if password value too short', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'shortpwd');
@@ -85,7 +85,7 @@ describe('Register password tests', () => {
     expect(screen.getAllByText('Passwords must be at least 10 characters long')).toHaveLength(2);
   });
 
-  it('should display the error messages if password fields do not match', async () => {
+  it('should display the error messages if password values do not match', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
     await user.type(screen.getByLabelText('Password'), 'mypasswordis');
@@ -94,6 +94,42 @@ describe('Register password tests', () => {
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
     expect(screen.getAllByText('Passwords must match')).toHaveLength(2);
   });
+
+  // it('should display the error messages if password value has spaces', async () => {
+  //   const user = userEvent.setup();
+  //   render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+  //   await user.type(screen.getByLabelText('Password'), 'my password ');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
+  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  //   // remove spaces
+  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+  //   // add space at start
+  //   await user.type(screen.getByLabelText('Password'), ' mypassword');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
+  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  //   // remove spaces
+  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+  //   // add space at end
+  //   await user.type(screen.getByLabelText('Password'), 'mypassword ');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
+  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  //   // remove spaces
+  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+  //   // add only space
+  //   await user.type(screen.getByLabelText('Password'), ' ');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
+  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  // });
 
   it('should NOT display error messagess if fields are valid', async () => {
     const user = userEvent.setup();

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -95,41 +95,52 @@ describe('Register password tests', () => {
     expect(screen.getAllByText('Passwords must match')).toHaveLength(2);
   });
 
-  // it('should display the error messages if password value has spaces', async () => {
-  //   const user = userEvent.setup();
-  //   render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
-  //   await user.type(screen.getByLabelText('Password'), 'my password ');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
-  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
-  //   // remove spaces
-  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
-  //   // add space at start
-  //   await user.type(screen.getByLabelText('Password'), ' mypassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
-  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
-  //   // remove spaces
-  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
-  //   // add space at end
-  //   await user.type(screen.getByLabelText('Password'), 'mypassword ');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
-  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
-  //   // remove spaces
-  //   await user.type(screen.getByLabelText('Password'), 'mypassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
-  //   // add only space
-  //   await user.type(screen.getByLabelText('Password'), ' ');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(screen.getByText('There is a problem')).toBeInTheDocument();
-  //   expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
-  // });
+  it('should display the error messages if password value has spaces', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'my password');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  });
+
+  it('should display the error messages if password value has spaces at the start', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), ' mypassword');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  });
+
+  it('should display the error messages if password value has spaces at the end', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypassword ');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+  });
+
+  it('should display the required error messages if password value is only spaces', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), '          ');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a password')).toHaveLength(2);
+    expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+  });
+
+  it('should display the min length error message if password has spaces and is fewer than 10 characters', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><RegisterYourPassword state={{ dataToSubmit: { sampleField: 'field value', secondField: 'second value' }}} /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), '   s');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Passwords must be at least 10 characters long')).toHaveLength(2);
+    expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+  });
 
   it('should NOT display error messagess if fields are valid', async () => {
     const user = userEvent.setup();

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -4,6 +4,7 @@ import {
   VALIDATE_FIELD_MATCH,
   VALIDATE_MAX_LENGTH,
   VALIDATE_MIN_LENGTH,
+  VALIDATE_NO_SPACES,
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED,
 } from '../constants/AppConstants';
@@ -25,6 +26,11 @@ const validateField = ({ type, value, condition }) => {
         return 'error';
       }
       break;
+    // case VALIDATE_NO_SPACES:
+    //   if (value && !/\s/.test(value)) {
+    //     return 'error';
+    //   }
+    //   break;
     case VALIDATE_EMAIL_ADDRESS:
       if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
         return 'error';

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -10,6 +10,10 @@ import {
 } from '../constants/AppConstants';
 
 const validateField = ({ type, value, condition }) => {
+  /* rules should be in order of importance here
+   * as once a rule is matched for a field, we will stop testing further
+   * rules for that field
+   */
   switch (type) {
     case VALIDATE_REQUIRED:
       if (!value || value.trim() === '') {
@@ -26,11 +30,11 @@ const validateField = ({ type, value, condition }) => {
         return 'error';
       }
       break;
-    // case VALIDATE_NO_SPACES:
-    //   if (value && !/\s/.test(value)) {
-    //     return 'error';
-    //   }
-    //   break;
+    case VALIDATE_NO_SPACES:
+      if (value && !/^\S+$/.test(value)) { // tests for spaces and errors if any found
+        return 'error';
+      }
+      break;
     case VALIDATE_EMAIL_ADDRESS:
       if (value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)) {
         return 'error';
@@ -53,7 +57,7 @@ const validateField = ({ type, value, condition }) => {
 const Validator = ({ formData, formFields }) => {
   const fieldsToValidate = Object.entries(formData).reduce((result, field) => { // result is our accumulator that starts as an empty array as defined at end of reduce
     const key = field[0];
-    const value = field[1];
+    let value = field[1];
     const rules = formFields.find(field => field.fieldName === key) ? formFields.find(field => field.fieldName === key).validation : null; // find all the rules for this field, if any
 
     if (rules) {
@@ -88,7 +92,7 @@ const Validator = ({ formData, formFields }) => {
   }, []);
 
   // Now for each entry in field to validate we can call the validator and see if it errors
-  const errors = fieldsToValidate.reduce((result, field) => {
+  const allErrors = fieldsToValidate.reduce((result, field) => {
     const resp = validateField({ type: field.rule.type, value: field.value, condition: field.rule.condition });
     if (resp === 'error') {
       result.push({ name: field.key, message: field.rule.message });
@@ -96,7 +100,18 @@ const Validator = ({ formData, formFields }) => {
     return result;
   }, []);
 
-  return errors;
+  // TODO: think of a better way to handle this
+  const uniqueFieldErrors = allErrors.reduce((result, error) => {
+    // If there are multiple errors matched for a field, return only the first
+    // error order is determined in the formFields object on the page that contains the form
+    const findFirstErrorForField = allErrors.find(field => field.name === error.name);
+    if (findFirstErrorForField.message === error.message) {
+      result.push(error);
+    }
+    return result;
+  }, []);
+
+  return uniqueFieldErrors;
 };
 
 export default Validator;


### PR DESCRIPTION
# Ticket

NMSW -226

----

## AC

Given I click submit
When there are spaces in the password value
Then I am shown an error

----

## To test

- run app
- go to /create-account/your-password
- click submit
- > `Enter a password` error should be displayed
- enter a password that has spaces in it but is less than 10 characters
- click submit
- > `Password must be at least 10 characters` error should be displayed
- enter a password that is 10 spaces only
- click submit
- `Enter a password` error should be displayed
- enter a password that is at least 10 character and has no spaces
- enter confirmation password as the same
- click submit
- > no errors should show
- > if you have the BE running in docker you should be taken to the confirmation page

----

## Notes
