### PR TITLE
NMSW-119  Do not persist form data when user moves to another section of the site

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import AppRouter from './AppRouter';
 import CookieBanner from './layout/CookieBanner';
 import Footer from './layout/Footer';
@@ -7,11 +9,14 @@ import PhaseBanner from './layout/PhaseBanner';
 // utils
 import cookieToFind from './utils/cookieToFind';
 import setAnalyticCookie from './utils/setAnalyticCookie';
+import { TOP_LEVEL_PAGES } from './constants/AppUrlConstants';
 
 const App = () => {
 
   const cookiePreference = cookieToFind('cookiePreference');
   const [isCookieBannerShown, setIsCookieBannerShown] = useState(true);
+  const { pathname } = useLocation();
+  const topLevelPage = TOP_LEVEL_PAGES.includes(pathname);
 
   useEffect(() => {
     setAnalyticCookie(cookiePreference);
@@ -20,9 +25,16 @@ const App = () => {
     }
   }, [cookiePreference]);
 
+  useEffect(() => {
+    // Removes formData in sessionStorage when on a top level page
+    if (topLevelPage) {
+      sessionStorage.removeItem('formData');
+    }
+  }, [pathname]);
+
   return (
     <>
-      {isCookieBannerShown === true && <CookieBanner isCookieBannerShown={isCookieBannerShown} setIsCookieBannerShown={setIsCookieBannerShown} /> }
+      {isCookieBannerShown === true && <CookieBanner isCookieBannerShown={isCookieBannerShown} setIsCookieBannerShown={setIsCookieBannerShown} />}
       <Header />
       <div className="govuk-width-container">
         <PhaseBanner />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { SERVICE_NAME } from './constants/AppConstants.js';
 import App from './App.jsx';
 
 describe('App tests', () => {
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('should render the heading on the page', () => {
     render(<BrowserRouter><App /></BrowserRouter>);
     expect(screen.getByText('GOV.UK')).toBeInTheDocument();
@@ -77,5 +82,46 @@ describe('App tests', () => {
     expect(rejectButton).not.toBeInTheDocument();
     expect(screen.queryByText('We use some essential cookies to make this service work.')).not.toBeInTheDocument();
     expect(screen.queryByText('We\'d also like to use analytics cookies so we can understand how you use the service and make improvements.')).not.toBeInTheDocument();
+  });
+
+  // Need to use <Memory Router> here to avoid test clicks on pages being pre-loaded in subsequent tests
+
+  it('should clear formData when a footer item is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><App /></MemoryRouter>);
+    const startButton = screen.getByRole('button', { name: 'Start now' });
+    await user.click(startButton);
+    await user.type(screen.getByLabelText('Email address'), 'test@test.com');
+    
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+
+    await user.click(screen.getByText('Accessibility'));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+  });
+
+  it('should clear formData when GOV logo is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><App /></MemoryRouter>);
+    const startButton = screen.getByRole('button', { name: 'Start now' });
+    await user.click(startButton);
+    await user.type(screen.getByLabelText('Email address'), 'test@test.com');
+    
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+
+    await user.click(screen.getByText('GOV.UK'));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+  });
+
+  it('should clear formData when service name is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><App /></MemoryRouter>);
+    const startButton = screen.getByRole('button', { name: 'Start now' });
+    await user.click(startButton);
+    await user.type(screen.getByLabelText('Email address'), 'test@test.com');
+    
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+
+    await user.click(screen.getByText(SERVICE_NAME));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -25,3 +25,6 @@ export const REGISTER_PASSWORD_URL = '/create-account/your-password';
 // Test pages
 export const SECOND_PAGE_NAME = 'Second page';
 export const SECOND_PAGE_URL = '/second-page';
+
+// Pages were we should clear formData
+export const TOP_LEVEL_PAGES = [ACCESSIBILITY_URL, COOKIE_URL, DASHBOARD_URL, LANDING_URL, PRIVACY_URL];

--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -52,6 +52,10 @@ const Nav = () => {
     setNavItems(tempArr);
   };
 
+  const removeFormData = () => {
+    sessionStorage.removeItem('formData');
+  };
+
   useEffect(() => {
     setActivePage(pathname);
   }, [pathname]);
@@ -62,7 +66,7 @@ const Nav = () => {
         <Link
           to={LANDING_URL}
           className="govuk-header__link govuk-header__link--homepage"
-          onClick={() => setActivePage(LANDING_URL)}
+          onClick={() => { setActivePage(LANDING_URL); removeFormData(); }}
         >
           <span className="govuk-header__logotype">
             <svg aria-hidden="true" focusable="false" className="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
@@ -79,13 +83,13 @@ const Nav = () => {
           to={LANDING_URL}
           className="govuk-header__link govuk-header__service-name"
           data-testid="serviceName"
-          onClick={() => setActivePage(LANDING_URL)}
+          onClick={() => { setActivePage(LANDING_URL); removeFormData(); }}
         >
           {SERVICE_NAME}
         </Link>
 
         {showNav && (
-          <nav aria-label="Menu" className="govuk-header__navigation ">
+          <nav aria-label="Menu" className="govuk-header__navigation" id="menu">
             <button
               type="button"
               onClick={(e) => menuToggle(e)}
@@ -121,7 +125,7 @@ const Nav = () => {
                     <Link
                       to={item.urlStem}
                       className="govuk-header__link"
-                      onClick={() => setActivePage(item.urlStem)}
+                      onClick={() => { setActivePage(item.urlStem); removeFormData(); }}
                     >
                       {item.text}
                     </Link>

--- a/src/layout/__tests__/Nav.test.jsx
+++ b/src/layout/__tests__/Nav.test.jsx
@@ -12,6 +12,10 @@ jest.mock('../../hooks/useUserIsPermitted', () => {
 
 describe('Navigation within header tests', () => {
 
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('should render the header with GovUK logo text', () => {
     render(<MemoryRouter><Nav /></MemoryRouter>);
     expect(screen.getByText('GOV.UK')).toBeInTheDocument();
@@ -99,5 +103,18 @@ describe('Navigation within header tests', () => {
     // click to toggle it back to closed
     await user.click(screen.getByRole('button'));
     expect(screen.getByRole('button').outerHTML).toEqual('<button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" aria-expanded="false">Menu</button>');
+  });
+
+  it('should clear formData when a nav item is clicked', async () => {
+    mockedUserIsPermitted = true;
+    const user = userEvent.setup();
+    render(<MemoryRouter><App /></MemoryRouter>);
+    await user.click(screen.getByText('Second page'));
+    await user.type(screen.getByLabelText('First name'), 'Bob');
+    
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"firstName":"Bob"}');
+
+    await user.click(screen.getByText('Dashboard'));
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -11,7 +11,7 @@ const Landing = () => {
     <>
       <h1 className="govuk-heading-l" data-testid="landing-h1">{SERVICE_NAME}</h1>
       <p className="govuk-body">Use this service to:</p>
-      <p className="govuk-body" data-testid="createAccountParagraph">You&apos;ll also need to sign in or <Link to ={REGISTER_ACCOUNT_URL}>create an account</Link> to use this service</p>
+      <p className="govuk-body" data-testid="createAccountParagraph">You&apos;ll also need to sign in or <Link to={REGISTER_ACCOUNT_URL}>create an account</Link> to use this service</p>
       <Link 
         to={isAuthenticated ? DASHBOARD_URL : SIGN_IN_URL}
         role="button"


### PR DESCRIPTION
# Ticket

NMSW-119

----

## AC

Given I have entered anything into form fields
When I go to a different section of the site
And I then return back to the form
Then the form is clear (answers do not persist across site sections)

----

## To test

- run app locally
- click sign in to go to second page
- > second page form should be empty
- enter something in second page form fields
- refresh page
- > values you entered should remain
- click on dashboard page in nav
- go back to second page 
- > form should be empty
- enter something second page form fields
- type the /dashboard url into the address bar
- go back to second page 
- > form should be empty
- enter something in second page form fields
- click on a link from the footer
- go back to second page 
- > form should be empty
- enter something in second page form fields
- click on the service name
- go back to second page 
- > form should be empty
- click on the GOV logo
- type the /dashboard url into the address bar
- go back to second page 
- > form should be empty

----

## Notes

Clear form data when user changes section by:
- clicking a nav item
- typing the url of a new section
- clicking a footer link
- clicking the service name
- clicking the govuk logo
