### PR TITLE
NMSW-219 Add create account link to sign in page

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -40,9 +40,15 @@ body {
   }
 }
 
+
 // ===================
 // Form Overrides
 // ===================
+/* govuk-inset-text has a top margin that creates too much whitespace when combined with the h1 bottom-margin */
+.below-h1 .govuk-inset-text {
+  margin-top: 0px;
+}
+
 .autocomplete-input .autocomplete__wrapper input {
   border-color:  $govuk-input-border-colour;
 }
@@ -107,5 +113,3 @@ body {
   font-weight: 700;
   color: $govuk-focus-text-colour;
 }
-
-

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -188,59 +188,57 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
         </div>
       </div>
       <div className="govuk-grid-row">
-        <form id={formId} className="govuk-grid-column-two-thirds" autoComplete="off">
-          <div className="govuk-grid-column-three-quarters">
-            {
-              fieldsWithValues.map((field) => {
-                const error = errors?.find(errorField => errorField.name === field.fieldName);
-                return (
-                  <div
-                    key={field.fieldName}
-                    id={field.fieldName}
-                    ref={(node) => {
-                      const map = getFieldMap();
-                      if (node) {
-                        map.set(field.fieldName, node); // on mount adds the refs
-                      } else {
-                        map.delete(field.fieldName); // on unmount removes the refs
-                      }
-                    }}
-                  >
-                    {
-                      determineFieldType({
-                        allErrors: errors,  // allows us to add the error handling logic for conditional fields
-                        error: error?.message,
-                        fieldDetails: field,
-                        parentHandleChange: handleChange,
-                      })
+        <form id={formId} className="govuk-grid-column-one-half" autoComplete="off">
+          {
+            fieldsWithValues.map((field) => {
+              const error = errors?.find(errorField => errorField.name === field.fieldName);
+              return (
+                <div
+                  key={field.fieldName}
+                  id={field.fieldName}
+                  ref={(node) => {
+                    const map = getFieldMap();
+                    if (node) {
+                      map.set(field.fieldName, node); // on mount adds the refs
+                    } else {
+                      map.delete(field.fieldName); // on unmount removes the refs
                     }
-                  </div>
-                );
-              })
-            }
-            <div className="govuk-button-group">
-              <button
-                type='button'
-                className='govuk-button'
-                data-module='govuk-button'
-                data-testid='submit-button'
-                onClick={(e) => handleValidation(e, { formData })}
-              >
-                {formActions.submit.label}
-              </button>
-              {
-                formActions.cancel && <button
-                  type='button'
-                  className='govuk-button govuk-button--secondary'
-                  data-module='govuk-button'
-                  data-testid='cancel-button'
-                  onClick={() => handleCancel(formActions.cancel.redirectURL)}
+                  }}
                 >
-                  {formActions.cancel.label}
-                </button>
-              }
+                  {
+                    determineFieldType({
+                      allErrors: errors,  // allows us to add the error handling logic for conditional fields
+                      error: error?.message,
+                      fieldDetails: field,
+                      parentHandleChange: handleChange,
+                    })
+                  }
+                </div>
+              );
+            })
+          }
+          <div className="govuk-button-group">
+            <button
+              type='button'
+              className='govuk-button'
+              data-module='govuk-button'
+              data-testid='submit-button'
+              onClick={(e) => handleValidation(e, { formData })}
+            >
+              {formActions.submit.label}
+            </button>
+            {
+              formActions.cancel && <button
+                type='button'
+                className='govuk-button govuk-button--secondary'
+                data-module='govuk-button'
+                data-testid='cancel-button'
+                onClick={() => handleCancel(formActions.cancel.redirectURL)}
+              >
+                {formActions.cancel.label}
+              </button>
+            }
 
-            </div>
           </div>
         </form>
       </div>

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -182,11 +182,13 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
       <div className="govuk-grid-row">
         <h1 className="govuk-heading-xl govuk-grid-column-full">{pageHeading}</h1>
       </div>
+      
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-three-quarters">
+        <div className="govuk-grid-column-three-quarters below-h1">
           {children}
         </div>
       </div>
+
       <div className="govuk-grid-row">
         <form id={formId} className="govuk-grid-column-one-half" autoComplete="off">
           {
@@ -238,7 +240,6 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
                 {formActions.cancel.label}
               </button>
             }
-
           </div>
         </form>
       </div>

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { REGISTER_ACCOUNT_URL } from '../../constants/AppUrlConstants';
 import { UserContext } from '../../context/userContext';
 import {
   FIELD_EMAIL,
@@ -10,6 +11,16 @@ import {
 } from '../../constants/AppConstants';
 import { DASHBOARD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+
+const SupportingText = () => {
+  return (
+    <>
+      <div className="govuk-inset-text">
+        <p className="govuk-body">If you do not have an account, you can <Link to={REGISTER_ACCOUNT_URL}>create one now</Link>.</p>
+      </div>
+    </>
+  );
+};
 
 const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };
@@ -65,7 +76,9 @@ const SignIn = (userDetails) => {
         formActions={formActions}
         formType={SINGLE_PAGE_FORM}
         handleSubmit={handleSubmit}
-      />
+      >
+        <SupportingText />
+      </DisplayForm>
     </>
   );
 };

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -26,7 +26,6 @@ const SignIn = (userDetails) => {
     {
       type: FIELD_EMAIL,
       label: 'Email address',
-      hint: 'Enter the email address you used when you created your account',
       fieldName: 'email',
       validation: [
         {

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -35,8 +35,13 @@ describe('Sign in tests', () => {
   it('should display an input field for email', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     expect(screen.getByLabelText('Email address')).toBeInTheDocument();
-    expect(screen.getByText('Enter the email address you used when you created your account').outerHTML).toEqual('<div id="email-hint" class="govuk-hint">Enter the email address you used when you created your account</div>');
-    expect(screen.getByRole('textbox', {name: /email/i}).outerHTML).toEqual('<input class="govuk-input" id="email-input" name="email" type="email" autocomplete="email" aria-describedby="email-hint" value="">');
+    expect(screen.getByRole('textbox', {name: /email/i}).outerHTML).toEqual('<input class="govuk-input" id="email-input" name="email" type="email" autocomplete="email" value="">');
+  });
+
+  it('should display a link to create account', () => {
+    render(<MemoryRouter><SignIn /></MemoryRouter>);
+    expect(screen.getByText('create one now')).toBeInTheDocument();
+    expect(screen.getByText('create one now').outerHTML).toEqual('<a href="/create-account/email-address">create one now</a>');
   });
 
   it('should display an input field for password', () => {


### PR DESCRIPTION
# Ticket

NMSW-219

----

## AC

Given I click on the create one now link
Then I am taken to the /create-account/email-address page 

----

## To test

- go to sign in page
- there should be a create one now link
- click the link
- you should be taken to /create-account/email-address

----

## Notes
