### PR TITLE
NMSW-178 Error/Account exists page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -10,6 +10,7 @@ import {
   COOKIE_URL,
   DASHBOARD_URL,
   ERROR_URL,
+  ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
   FORM_CONFIRMATION_URL,
   LANDING_URL,
   PRIVACY_URL,
@@ -39,8 +40,10 @@ import RegisterEmailVerified from './pages/Register/RegisterEmailVerified';
 import RegisterYourDetails from './pages/Register/RegisterYourDetails';
 import RegisterYourPassword from './pages/Register/RegisterYourPassword';
 import SignIn from './pages/SignIn/SignIn';
-// Other pages (could be protected or not)
+// Error/Message pages
 import GenericUnknownError from './pages/Error/GenericUnknownError';
+import AccountAlreadyActive from './pages/Error/AccountAlreadyActive';
+// Other pages (could be protected or not)
 import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
 // Protected pages
 import Dashboard from './pages/Dashboard/Dashboard';
@@ -71,6 +74,8 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
         <Route path={SIGN_IN_URL} element={<SignIn />} />
 
         <Route path={ERROR_URL} element={<GenericUnknownError />} />
+        <Route path={ERROR_ACCOUNT_ALREADY_ACTIVE_URL} element={<AccountAlreadyActive />} />
+
         <Route path={FORM_CONFIRMATION_URL} element={<FormConfirmationPage />} />
 
         <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -7,7 +7,6 @@ export const ACCESSIBILITY_URL = '/accessibility-statement';
 export const COOKIE_URL = '/cookies';
 export const DASHBOARD_PAGE_NAME = 'Dashboard';
 export const DASHBOARD_URL = '/dashboard';
-export const ERROR_URL = '/error';
 export const FORM_CONFIRMATION_URL = '/confirmation';
 export const LANDING_URL = '/';
 export const PRIVACY_URL = '/privacy-notice';
@@ -23,6 +22,10 @@ export const REGISTER_EMAIL_RESEND_URL = '/create-account/request-new-verificati
 export const REGISTER_EMAIL_VERIFIED_URL = '/create-account/email-verified';
 export const REGISTER_DETAILS_URL = '/create-account/your-details';
 export const REGISTER_PASSWORD_URL = '/create-account/your-password';
+
+// Error/message pages
+export const ERROR_URL = '/error';
+export const ERROR_ACCOUNT_ALREADY_ACTIVE_URL = '/create-account/account-already-exists';
 
 // Test pages
 export const SECOND_PAGE_NAME = 'Second page';

--- a/src/pages/Error/AccountAlreadyActive.jsx
+++ b/src/pages/Error/AccountAlreadyActive.jsx
@@ -1,0 +1,29 @@
+import { Link, useLocation } from 'react-router-dom';
+import { SIGN_IN_URL } from '../../constants/AppUrlConstants';
+
+const AccountAlreadyActive = () => {
+  const { state } = useLocation();
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="govuk-heading-xl">You already have an account</h1>
+          <div className="govuk-inset-text">
+            <p className='govuk-body' data-testid='insetText'>Your email address {state?.dataToSubmit?.emailAddress && <strong>{state.dataToSubmit.emailAddress}</strong>} is already registered with this service.</p>
+          </div>
+          <Link
+            to={SIGN_IN_URL}
+            role="button"
+            draggable="false"
+            className="govuk-button govuk-button--primary"
+            data-module="govuk-button"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AccountAlreadyActive;

--- a/src/pages/Error/GenericUnknownError.jsx
+++ b/src/pages/Error/GenericUnknownError.jsx
@@ -7,8 +7,8 @@ const GenericUnknownError = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-xl">Error</h1>
-          <p className="govuk-body">{state?.message}</p>
+          <h1 className="govuk-heading-xl">{state?.title}</h1>
+          {state?.message && <p className="govuk-body">{state?.message}</p>}
           <Link to={state?.redirectURL || LANDING_URL}>Click here to continue</Link>
         </div>
       </div>

--- a/src/pages/Error/__tests__/AccountAlreadyActive.test.jsx
+++ b/src/pages/Error/__tests__/AccountAlreadyActive.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AccountAlreadyActive from '../AccountAlreadyActive';
+
+let mockUseLocationState = {};
+const mockedUseNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
+describe('Account already exists page tests', () => {
+
+  beforeEach(() => {
+    mockUseLocationState = {};
+  });
+
+  it('should render page with content', () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByText('You already have an account')).toBeInTheDocument();
+    expect(screen.getByTestId('insetText').outerHTML).toEqual('<p class="govuk-body" data-testid="insetText">Your email address <strong>testemail@email.com</strong> is already registered with this service.</p>');
+  });
+
+  it('should show the email address from state in the page', () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByText('testemail@email.com')).toBeInTheDocument();
+  });
+
+  it('should include a button to sign in', () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('should include a button to sign in link', async () => {
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByRole('button', { name: 'Sign in' }).outerHTML).toEqual('<a role="button" draggable="false" class="govuk-button govuk-button--primary" data-module="govuk-button" href="/sign-in">Sign in</a>');
+  });
+
+  it('should not fail if state is missing', () => {
+    mockUseLocationState = {};
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByText('You already have an account')).toBeInTheDocument();
+    expect(screen.getByText('Your email address is already registered with this service.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('should not fail if state does not have dataToSubmit object', () => {
+    mockUseLocationState = { state: {} };
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByText('You already have an account')).toBeInTheDocument();
+    expect(screen.getByText('Your email address is already registered with this service.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('should not fail if state does not have email address', () => {
+    mockUseLocationState = { state: { dataToSubmit: {} } };
+    render(<MemoryRouter><AccountAlreadyActive /></MemoryRouter>);
+    expect(screen.getByText('You already have an account')).toBeInTheDocument();
+    expect(screen.getByText('Your email address is already registered with this service.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/Error/__tests__/GenericUnknownError.test.jsx
+++ b/src/pages/Error/__tests__/GenericUnknownError.test.jsx
@@ -22,9 +22,16 @@ describe('Error page tests', () => {
     mockUseLocationState.state = {};
   });
 
-  it('should render h1', () => {
+  it('should render h1 as the title that was passed in', () => {
+    mockUseLocationState.state = { title: 'Page title', redirectURL: SIGN_IN_URL };
     render(<MemoryRouter><GenericUnknownError /></MemoryRouter>);
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('Page title')).toBeInTheDocument();
+  });
+
+  it('should render paragraph if a message was passed in', () => {
+    mockUseLocationState.state = { title: 'Page title', message: 'This is the page message', redirectURL: SIGN_IN_URL };
+    render(<MemoryRouter><GenericUnknownError /></MemoryRouter>);
+    expect(screen.getByText('This is the page message')).toBeInTheDocument();
   });
 
   it('should render a click here to continue link to the URL passed to this page', async () => {

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -83,7 +83,7 @@ const RegisterEmailAddress = () => {
       });
       if (response && response.status === 200) {
         navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
-      } else if (response.message === 'User is already registered') {
+      } else if (response && response.message === 'User is already registered') {
         navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
       } else {
         navigate(ERROR_URL, {

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -7,7 +7,12 @@ import {
   VALIDATE_FIELD_MATCH,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
-import { ERROR_URL, REGISTER_EMAIL_URL, REGISTER_EMAIL_CHECK_URL } from '../../constants/AppUrlConstants';
+import {
+  ERROR_URL,
+  ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
+  REGISTER_EMAIL_URL,
+  REGISTER_EMAIL_CHECK_URL
+} from '../../constants/AppUrlConstants';
 import usePostData from '../../hooks/usePostData';
 import DisplayForm from '../../components/DisplayForm';
 
@@ -78,16 +83,19 @@ const RegisterEmailAddress = () => {
       });
       if (response && response.status === 200) {
         navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
+      } else if (response.message === 'User is already registered') {
+        navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
       } else {
         navigate(ERROR_URL, {
           state: {
-            message: response.message ? response.message : 'Something has gone wrong',
+            title: 'Something has gone wrong',
+            message: response.message,
             redirectURL: REGISTER_EMAIL_URL
           }
         });
       }
     } catch (err) {
-      navigate(ERROR_URL, { state: { message: 'Something has gone wrong', redirectURL: REGISTER_EMAIL_URL } });
+      navigate(ERROR_URL, { state: { title: 'Something has gone wrong', redirectURL: REGISTER_EMAIL_URL } });
     }
   };
 

--- a/src/pages/Register/__tests__/RegisterEmailAddressPost.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddressPost.test.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { ERROR_URL, REGISTER_EMAIL_URL, REGISTER_EMAIL_CHECK_URL } from '../../../constants/AppUrlConstants';
+import { ERROR_URL, ERROR_ACCOUNT_ALREADY_ACTIVE_URL, REGISTER_EMAIL_URL, REGISTER_EMAIL_CHECK_URL } from '../../../constants/AppUrlConstants';
 import RegisterEmailAddress from '../RegisterEmailAddress';
 
 const mockedUseNavigate = jest.fn();
@@ -46,9 +46,23 @@ describe('Register email address POST tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
     await user.click(screen.getByTestId('submit-button'));
 
-    // mocked usePostData returns a successful response (currently we take success as id received as we don't get the success code yet)
     await waitFor(() => {
       expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_CHECK_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } });
+    });
+  });
+
+  it('should redirect to account already active page if account active response received', async () => {
+    const user = userEvent.setup();
+    mockedUserPostData = {
+      message: 'User is already registered',
+      status: '400'
+    };
+    render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@email.com');
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
+    await user.click(screen.getByTestId('submit-button'));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com'} } });
     });
   });
 
@@ -64,7 +78,7 @@ describe('Register email address POST tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
     await user.click(screen.getByTestId('submit-button'));
     await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, { 'state': { 'message': 'error response', 'redirectURL': REGISTER_EMAIL_URL } }); // on error we redirect to error page
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, { 'state': { 'title': 'Something has gone wrong', 'message': 'error response', 'redirectURL': REGISTER_EMAIL_URL } }); // on error we redirect to error page
     });
   });
 
@@ -77,7 +91,7 @@ describe('Register email address POST tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@email.com');
     await user.click(screen.getByTestId('submit-button'));
     await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, { 'state': { 'message': 'Something has gone wrong', 'redirectURL': REGISTER_EMAIL_URL } }); // on error we redirect to error page
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, { 'state': { 'title': 'Something has gone wrong', 'redirectURL': REGISTER_EMAIL_URL } }); // on error we redirect to error page
     });
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-178

----

## AC

**Scenario: Submit email address for existing account**
GIVEN I have completed my email address on the create account/email address page
AND the email address HAS already been used for an active account
AND a verification request is NOT currently active
WHEN I submit it
THEN an error page is shown with a "400: User is already registered" message
AND a link to the sign-in page

**ACTIONS:**
Given the app has requested account creation
When an error response is received
Then I am shown the Error page with the relevant error message and link

----

## To test

- run app
- go to create account
- enter an email address for an existing account
- > you should be taken to account already active page
- > your email address should be in text
- > there should be a sign in link
- click sign in
- > you should be taken to the sign in page
- go to a new tab
- go directly to `http://localhost:3000/create-account/account-already-exists`
- > account already active page should load
- > but you will NOT have your email address on page

----

## Notes
