### PR TITLE
Change class to className so js css is applied properly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,8 @@
   <!-- Fallback for no JavaScript -->
   <noscript><link rel="stylesheet" type="text/css" href="/assets/css/noscript.css"></noscript>
 </head>
-<body class="govuk-template__body">  
-  <script>document.body.class = ((document.body.class) ? document.body.class + ' js-enabled' : 'js-enabled');</script>
+<body className="govuk-template__body">  
+  <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
   <!-- Fallback for no JavaScript -->
   <noscript class="govuk-body">
     <div id="root">


### PR DESCRIPTION
# Ticket



----

## AC

Hidden fields component is showing fields when they should be hidden

>> discovered it was due to an error in having `class` instead of `className`

----

## To test

- run app
- open second page
- > conditional fields should be hidden 
- click on cat
- > conditional field should show

----

## Notes
