### PR TITLE
NMSW-167 Enable redirect via sign in

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -111,11 +111,11 @@ describe('App tests', () => {
   it('should clear formData when a footer item is clicked', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><App /></MemoryRouter>);
-    const startButton = screen.getByRole('button', { name: 'Start now' });
+    const startButton = screen.getByRole('link', { name: 'create an account' });
     await user.click(startButton);
     await user.type(screen.getByLabelText('Email address'), 'test@test.com');
     
-    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"emailAddress":"test@test.com"}');
 
     await user.click(screen.getByText('Accessibility'));
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
@@ -124,11 +124,11 @@ describe('App tests', () => {
   it('should clear formData when GOV logo is clicked', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><App /></MemoryRouter>);
-    const startButton = screen.getByRole('button', { name: 'Start now' });
+    const startButton = screen.getByRole('link', { name: 'create an account' });
     await user.click(startButton);
     await user.type(screen.getByLabelText('Email address'), 'test@test.com');
     
-    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"emailAddress":"test@test.com"}');
 
     await user.click(screen.getByText('GOV.UK'));
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
@@ -137,11 +137,11 @@ describe('App tests', () => {
   it('should clear formData when service name is clicked', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><App /></MemoryRouter>);
-    const startButton = screen.getByRole('button', { name: 'Start now' });
+    const startButton = screen.getByRole('link', { name: 'create an account' });
     await user.click(startButton);
     await user.type(screen.getByLabelText('Email address'), 'test@test.com');
     
-    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"email":"test@test.com"}');
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual('{"emailAddress":"test@test.com"}');
 
     await user.click(screen.getByText(SERVICE_NAME));
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -48,6 +48,7 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
       setSessionData({ ...sessionData, ...dataSet });
       sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, ...dataSet }));
     }
+
     // we do store all values into form data
     setFormData({ ...formData, ...dataSet });
   };
@@ -72,7 +73,8 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
       handleSubmit(formData);
 
       /* If the form is a singlepage form we can clear the session 
-       * we do not clear the session for multipage forms
+       * we do not clear the session for multipage forms or sign in form 
+       * as they have different needs
       */
       if (formType === SINGLE_PAGE_FORM) {
         sessionStorage.removeItem('formData');

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -5,6 +5,7 @@ import {
   EXPANDED_DETAILS,
   FIELD_CONDITIONAL,
   FIELD_PASSWORD,
+  SIGN_IN_FORM,
   SINGLE_PAGE_FORM
 } from '../constants/AppConstants';
 import { UserContext } from '../context/userContext';
@@ -43,8 +44,8 @@ const DisplayForm = ({ fields, formId, formActions, formType, pageHeading, handl
       [itemToClear?.target.name]: itemToClear?.target.value
     };
 
-    // we do not store passwords in session data
-    if (e.target.name !== FIELD_PASSWORD) {
+    // we do not store passwords or sign in details in session data
+    if (e.target.name !== FIELD_PASSWORD && formType !== SIGN_IN_FORM) {
       setSessionData({ ...sessionData, ...dataSet });
       sessionStorage.setItem('formData', JSON.stringify({ ...sessionData, ...dataSet }));
     }

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -11,6 +11,7 @@ import {
   FIELD_RADIO,
   FIELD_TEXT,
   MULTI_PAGE_FORM,
+  SIGN_IN_FORM,
   SINGLE_PAGE_FORM,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_PHONE_NUMBER,
@@ -153,6 +154,28 @@ describe('Display Form', () => {
         },
       ],
     },
+  ];
+  const formSignIn = [
+    {
+      type: FIELD_EMAIL,
+      label: 'Email',
+      fieldName: 'email',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your email address',
+        },
+        {
+          type: VALIDATE_EMAIL_ADDRESS,
+          message: 'Enter your email address in the correct format, like name@example.com',
+        },
+      ],
+    },
+    {
+      type: FIELD_PASSWORD,
+      label: 'Password',
+      fieldName: 'password',
+    }
   ];
   const formSpecialInputs = [
     {
@@ -646,6 +669,24 @@ describe('Display Form', () => {
 
     await user.click(screen.getByRole('button', { name: 'Cancel test button' }));
     expect(mockedUseNavigate).toHaveBeenCalledWith(DASHBOARD_URL);
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
+  });
+
+  it('should not store new session data if form is of type SIGN IN', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formSignIn}
+          formActions={formActionsSubmitOnly}
+          formType={SIGN_IN_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByRole('textbox', {name: /email/i}), 'testemail@email.com');
+    await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
     expect(window.sessionStorage.getItem('formData')).toStrictEqual(null);
   });
 });

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -4,6 +4,7 @@ export const SERVICE_NAME = 'National Maritime Single Window';
 // Forms: identifiers
 export const EXPANDED_DETAILS = 'ExpandedDetails';
 export const MULTI_PAGE_FORM = 'multiPageForm';
+export const SIGN_IN_FORM = 'signInForm';
 export const SINGLE_PAGE_FORM = 'singlePageForm';
 // Forms: input types
 export const FIELD_AUTOCOMPLETE = 'autocomplete';

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -5,7 +5,7 @@ import { UserContext } from '../../context/userContext';
 import {
   FIELD_EMAIL,
   FIELD_PASSWORD,
-  SINGLE_PAGE_FORM,
+  SIGN_IN_FORM,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
@@ -75,7 +75,8 @@ const SignIn = (userDetails) => {
         formId='formSignIn'
         fields={formFields}
         formActions={formActions}
-        formType={SINGLE_PAGE_FORM}
+        formType={SIGN_IN_FORM}
+        keepSessionOnSubmit={state?.redirectURL ? true : false}
         handleSubmit={handleSubmit}
       >
         <SupportingText />

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -65,7 +65,7 @@ const SignIn = (userDetails) => {
 
   const handleSubmit = () => {
     signIn({ ...tempHardCodedUser });
-    state?.redirectUrl ? navigate(state.redirectUrl) : navigate(DASHBOARD_URL);
+    state?.redirectURL ? navigate(state.redirectURL) : navigate(DASHBOARD_URL);
   };
 
   return (

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { REGISTER_ACCOUNT_URL } from '../../constants/AppUrlConstants';
 import { UserContext } from '../../context/userContext';
 import {
@@ -26,6 +26,7 @@ const SignIn = (userDetails) => {
   const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };
   const { signIn } = useContext(UserContext);
   const navigate = useNavigate();
+  const { state } = useLocation();
 
   // Form fields
   const formActions = {
@@ -64,7 +65,7 @@ const SignIn = (userDetails) => {
 
   const handleSubmit = () => {
     signIn({ ...tempHardCodedUser });
-    navigate(DASHBOARD_URL);
+    state?.redirectUrl ? navigate(state.redirectUrl) : navigate(DASHBOARD_URL);
   };
 
   return (

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -4,6 +4,14 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import SignIn from '../../pages/SignIn/SignIn';
 
+const mockUseLocationState = { state: {} };
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationState;
+  })
+}));
+
 describe('Sign in tests', () => {
   const mockedLogin = jest.fn();
   const mockedLogout = jest.fn();
@@ -157,5 +165,21 @@ describe('Sign in tests', () => {
     expect(mockedLogin).toHaveBeenCalled();
   });
 
-  // TODO: Try to get test for 'should set userContext to session storage' to work
+  it('should not clear session storage if user is being redirected to sign in before completing their action', async () => {
+    mockUseLocationState.state = {
+      redirectURL: '/thisurl',
+    };
+    const user = userEvent.setup();
+    /* mock some sessionData that may exist if a user had clicked 'submit' on a form page but their AuthToken had expired */
+    window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne'}));
+    const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
+    const userDetails = { name: 'MockedUser', token: '123', group: 'testGroup' };
+
+    renderWithUserContext(userDetails);
+    await user.type(screen.getByRole('textbox', {name: /email/i}), 'testemail@email.com');
+    await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(mockedLogin).toHaveBeenCalled();
+    expect(window.sessionStorage.getItem('formData')).toStrictEqual(expectedStoredData);
+  });
 });

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -9,7 +9,13 @@ import {
   VALIDATE_CONDITIONAL,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
-import { DASHBOARD_PAGE_NAME, DASHBOARD_URL, FORM_CONFIRMATION_URL } from '../../constants/AppUrlConstants';
+import {
+  DASHBOARD_PAGE_NAME,
+  DASHBOARD_URL,
+  FORM_CONFIRMATION_URL,
+  SECOND_PAGE_URL,
+  SIGN_IN_URL
+} from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import { countries } from './TempMockList-countries';
 import { portList } from './TempMockList-portList';
@@ -202,19 +208,27 @@ const SecondPage = () => {
     );
   };
 
+  const forceSignIn = () => {
+    navigate(SIGN_IN_URL, { state: { redirectURL: SECOND_PAGE_URL }});
+  };
+
   return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-three-quarters">
-        <DisplayForm
-          pageHeading="Second page"
-          formId='formSecondPage'
-          fields={formFields}
-          formActions={formActions}
-          formType={SINGLE_PAGE_FORM}
-          handleSubmit={handleSubmit}
-        />
-      </div >
-    </div>
+    <>
+      <h1>Second page</h1>
+      <p>Click this button to test going to sign in page with navigation state</p>
+      <button onClick={forceSignIn}>Force sign in</button>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-three-quarters">
+          <DisplayForm
+            formId='formSecondPage'
+            fields={formFields}
+            formActions={formActions}
+            formType={SINGLE_PAGE_FORM}
+            handleSubmit={handleSubmit}
+          />
+        </div >
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
# Ticket

NMSW-167

----

## AC

Enabler for redirecting a user via the sign-in page if a token expires/doesn't exist/is invalid

Given a user successfully submits in on the sign in page
When there is a redirectURL in the state
Then the URL in the redirectURL value is loaded

Given a user successfully submits in on the sign in page
When there is NO redirectURL in the state
Then the dashboard is loaded

Given a user has been redirected to sign in from a form page
And they had filled in some of the fields on that page
When they successfully sign in
And are returned to the form page
Then the values of the fields they filled in are persisted

----

## To test

- run app
- sign in
- go to second page
- fill in some files
- click the 'redirect to sign in' test button
- > you should be taken to sign in page
- sign in (note this is still a fake sign in)
- > you should be taken back to the second page
- > the values you entered should be persisted

----

## Notes

While building this and looking at how we handle session data for forms and sign in in particular I've decided not to store any sign in form data in the session. We already did not store password and there's no requirement to store email here. User can still fill the email value from their browser saved usernames.

Added a form type for sign in so we can treat it different to other forms.
