### PR TITLE
NMSW-167 Handle different user sign in after expired token style scenario

### DIFF
--- a/src/context/userContext.js
+++ b/src/context/userContext.js
@@ -15,7 +15,7 @@ const UserProvider = ({ children }) => {
   // Here is where we will make the api call to get the token
 
   // Will take email and password as props
-  const signIn = () => {
+  const signIn = ({ formData }) => {
     // Make an api call to sign in with email and password
     // api returns 200 a name a group and a token
 
@@ -23,6 +23,7 @@ const UserProvider = ({ children }) => {
       token: '123',
       name: 'Bob',
       group: 'Disney Cruises',
+      email: formData.email,
     };
     
     sessionStorage.setItem('isAuthenticated', JSON.stringify(response));

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -22,9 +22,8 @@ const SupportingText = () => {
   );
 };
 
-const SignIn = (userDetails) => {
-  const tempHardCodedUser = Object.entries(userDetails).length > 0 ? userDetails.user : { name: 'MockedUser' };
-  const { signIn } = useContext(UserContext);
+const SignIn = () => {
+  const { signIn, user } = useContext(UserContext);
   const navigate = useNavigate();
   const { state } = useLocation();
 
@@ -63,8 +62,11 @@ const SignIn = (userDetails) => {
     },
   ];
 
-  const handleSubmit = () => {
-    signIn({ ...tempHardCodedUser });
+  const handleSubmit = ({ formData }) => {
+    if (user.email !== formData.email) {
+      sessionStorage.removeItem('formData');
+    }
+    signIn({ formData });
     state?.redirectURL ? navigate(state.redirectURL) : navigate(DASHBOARD_URL);
   };
 


### PR DESCRIPTION
# Ticket

NMSW-167

----

## AC

Given the user has successfully submitted the sign in form
When the email address from the sign in attempt is NOT the same as the email address in user context
Then clear any form session data


----

## To test

- make sure you have a new version of the app running (new tab)
- run app
- sign in
- go to second page form
- enter something in the form
- click the redirect to sign in button
- sign in with a DIFFERENT email address
- > you should be returned to second page form
- > there should be no prefilled data

- make sure you have a new version of the app running (new tab)
- run app
- sign in
- go to second page form
- enter something in the form
- click the redirect to sign in button
- sign in with the SAME email address
- > you should be returned to second page form
- > the data should be prefilled

----

## Notes

We persist form data if a user has partially completed a form, and on submit is redirected via sign in due to missing/expired token, and sign in is successful and we can match the new signed in user to the old one

If we cannot match them then we clear the session under the assumption this is a different user.
