### PR TITLE
NMSW-166 Handle axios or 500 error responses

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -4,5 +4,6 @@ import { apiUrl } from '../constants/Config';
 export const REGISTER_ACCOUNT_ENDPOINT = `${apiUrl}/registration`;
 
 // Responses
+export const AXIOS_ERROR = 'Network Error';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';
 export const USER_ALREADY_REGISTERED = 'User is already registered';

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { REGISTER_ACCOUNT_ENDPOINT, USER_ALREADY_REGISTERED } from '../../constants/AppAPIConstants';
+import { AXIOS_ERROR, REGISTER_ACCOUNT_ENDPOINT, USER_ALREADY_REGISTERED } from '../../constants/AppAPIConstants';
 import {
   FIELD_EMAIL,
   SINGLE_PAGE_FORM,
@@ -87,10 +87,15 @@ const RegisterEmailAddress = () => {
       navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: response.data.email } } });
     } catch (err) {
       // scenarios we need updated response for : 400: User is awaiting verification
-      if (err.response.data.message === USER_ALREADY_REGISTERED) {
+
+      // catch any axios errors and treat as a generic error
+      if (err.message === AXIOS_ERROR) {
+        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', redirectURL: REGISTER_EMAIL_URL } });
+      } else if (err.response?.data?.message === USER_ALREADY_REGISTERED) {
         navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
       } else {
-        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', message: err.response.data.message, redirectURL: REGISTER_EMAIL_URL } });
+        // 500 errors will fall into this bucket
+        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_EMAIL_URL } });
       }
     }
   };

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { REGISTER_ACCOUNT_ENDPOINT, TOKEN_INVALID } from '../../constants/AppAPIConstants';
+import { AXIOS_ERROR, REGISTER_ACCOUNT_ENDPOINT, TOKEN_INVALID } from '../../constants/AppAPIConstants';
 import {
   FIELD_PASSWORD,
   MULTI_PAGE_FORM,
@@ -9,7 +9,7 @@ import {
   VALIDATE_NO_SPACES,
   VALIDATE_REQUIRED
 } from '../../constants/AppConstants';
-import { ERROR_URL, REGISTER_CONFIRMATION_URL, REGISTER_EMAIL_VERIFIED_URL } from '../../constants/AppUrlConstants';
+import { ERROR_URL, REGISTER_CONFIRMATION_URL, REGISTER_EMAIL_VERIFIED_URL, REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import Auth from '../../utils/Auth';
 
@@ -98,10 +98,13 @@ const RegisterYourPassword = () => {
       navigate(REGISTER_CONFIRMATION_URL, { state: { companyName: response.data.groupName } });
       sessionStorage.removeItem('formData');
     } catch (err) {
-      if (err.response.data.message === TOKEN_INVALID) {
+      // catch any axios errors and treat as a generic error
+      if (err.message === AXIOS_ERROR) {
+        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', redirectURL: REGISTER_EMAIL_VERIFIED_URL } });
+      } else if (err.response?.data?.message === TOKEN_INVALID) {
         navigate(ERROR_URL, { state: { title: 'Verification link has expired', redirectURL: REGISTER_EMAIL_VERIFIED_URL } });
       } else {
-        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', message: err.response.data.message, redirectURL: REGISTER_EMAIL_VERIFIED_URL } });
+        navigate(ERROR_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_PASSWORD_URL } });
       }
     }
   };

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { REGISTER_ACCOUNT_ENDPOINT, TOKEN_INVALID } from '../../../constants/AppAPIConstants';
-import { ERROR_URL, REGISTER_CONFIRMATION_URL, REGISTER_EMAIL_VERIFIED_URL } from '../../../constants/AppUrlConstants';
+import { AXIOS_ERROR, REGISTER_ACCOUNT_ENDPOINT, TOKEN_INVALID } from '../../../constants/AppAPIConstants';
+import { ERROR_URL, REGISTER_CONFIRMATION_URL, REGISTER_EMAIL_VERIFIED_URL, REGISTER_PASSWORD_URL } from '../../../constants/AppUrlConstants';
 import RegisterYourPassword from '../RegisterYourPassword';
 
 let mockUseLocationState = { state: {} };
@@ -284,6 +284,38 @@ describe('Register password tests', () => {
     });
   });
 
+  it('should navigate to error page if PATCH response returns axios error', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPatch(REGISTER_ACCOUNT_ENDPOINT)
+      .reply({
+        message: AXIOS_ERROR
+      });
+
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    await user.click(screen.getByTestId('submit-button'));
+     await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'title': 'Something has gone wrong', 'redirectURL': REGISTER_PASSWORD_URL}});
+    });
+  });
+
+  it('should navigate to error page if PATCH response returns 500 error', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPatch(REGISTER_ACCOUNT_ENDPOINT)
+      .reply(500);
+
+    render(<MemoryRouter><RegisterYourPassword /></MemoryRouter>);
+    await user.type(screen.getByLabelText('Password'), 'mypasswordis');
+    await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
+    await user.click(screen.getByTestId('submit-button'));
+     await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'title': 'Something has gone wrong', 'redirectURL': REGISTER_PASSWORD_URL}});
+    });
+  });
+
   it('should navigate to error page if PATCH response returns unknown error', async () => {
     const user = userEvent.setup();
     mockAxios
@@ -297,7 +329,7 @@ describe('Register password tests', () => {
     await user.type(screen.getByLabelText('Confirm your password'), 'mypasswordis');
     await user.click(screen.getByTestId('submit-button'));
      await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'title': 'Something has gone wrong', message: 'an error we do not handle', 'redirectURL': REGISTER_EMAIL_VERIFIED_URL}});
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_URL, {'state': {'title': 'Something has gone wrong', message: 'an error we do not handle', 'redirectURL': REGISTER_PASSWORD_URL}});
     });
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-166

----

## AC

Handle 500 errors

----

## To test

Review tests
run unit/integration tests
they should pass

----

## Notes
- added handling for if axios itself throws an error
- made the generic fallback error handling not require a message so it can handle 500 responses 
