### PR TITLE
NMSW-291 Crew details upload - Error page (mocked errors)

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -4,7 +4,7 @@ import useUserIsPermitted from './hooks/useUserIsPermitted';
 import ProtectedRoutes from './utils/ProtectedRoutes';
 import ScrollToTopOnNewPage from './utils/ScrollToTopOnNewPage';
 
-// URLs
+// Constants
 import {
   ACCESSIBILITY_URL,
   COOKIE_URL,
@@ -24,7 +24,10 @@ import {
   REGISTER_PASSWORD_URL,
   SIGN_IN_URL,
   SECOND_PAGE_URL,
+  ERROR_CREW_DETAILS_UPLOAD,
 } from './constants/AppUrlConstants';
+
+import { SERVICE_NAME } from './constants/AppConstants';
 
 // Regulatory pages
 import AccessibilityStatement from './pages/Regulatory/AccessibilityStatement';
@@ -47,10 +50,10 @@ import AccountAlreadyActive from './pages/Error/AccountAlreadyActive';
 import FormConfirmationPage from './pages/Confirmation/FormConfirmationPage';
 // Protected pages
 import Dashboard from './pages/Dashboard/Dashboard';
+import ErrorsCrewUpload from './pages/Voyage/ErrorsCrewUpload';
 
 // Temp Pages
 import SecondPage from './pages/TempPages/SecondPage';
-import { SERVICE_NAME } from './constants/AppConstants';
 
 const AppRouter = ({ setIsCookieBannerShown }) => {
   document.title = SERVICE_NAME;
@@ -83,6 +86,7 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
         <Route element={<ProtectedRoutes isPermittedToView={isPermittedToView} />}>
           <Route path={DASHBOARD_URL} element={<Dashboard />} />
           <Route path={SECOND_PAGE_URL} element={<SecondPage />} />
+          <Route path={ERROR_CREW_DETAILS_UPLOAD} element={<ErrorsCrewUpload />} />
         </Route>
         <Route path='*' element={<Navigate to='/' replace />} />
       </Routes>

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,5 +1,6 @@
 @import '~govuk-frontend/govuk/all';
 @import "accessible-autocomplete";
+@import './table.scss';
 
 // ===================
 // Layout Overrides
@@ -112,4 +113,15 @@ body {
 .govuk-error-summary__list .govuk-button--text:focus {
   font-weight: 700;
   color: $govuk-focus-text-colour;
+}
+
+// Upload errors
+.govuk-inline {
+  display: inline
+}
+
+.govuk-border-bottom {
+  border-bottom: 1px solid #b1b4b6;
+  padding: 10px 20px 10px 0;
+  margin-bottom: 20px
 }

--- a/src/assets/table.scss
+++ b/src/assets/table.scss
@@ -30,11 +30,6 @@ tbody tr td {
   width: 50%;
 }
 
-.text-align-right {
-  display: inline-block;
-  text-align: right;
-}
-
 @media (min-width: 769px) {
   tbody tr {
     display: table-row;
@@ -68,6 +63,10 @@ tbody tr td {
   }
   .responsive-table__cell {
     width: 100%;
+    text-align: right;
+  }
+  .text-align-right {
+    display: inline-block;
     text-align: right;
   }
 };

--- a/src/assets/table.scss
+++ b/src/assets/table.scss
@@ -3,70 +3,83 @@ tbody tr {
   margin-bottom: 1.5em;
   padding: 0 0.5em;
 }
+
 tbody tr td {
   display: flex;
   justify-content: space-between;
-  min-width: 1px;
+  min-width: 3px;
   text-align: right;
 }
 
-// .govuk-table__cell {
-//   vertical-align: middle;
-// }
-
-.govuk-table__cell--bold {
-  font-weight: 700;
-  padding-left: 15px;
+.govuk-table__cell {
+  vertical-align: middle;
 }
 
-// .govuk-table__cell:last-child {
-//   padding: 10px 20px 10px 0;
-// }
+.govuk-table__cell:last-child {
+  padding: 10px 20px 10px 0;
+}
+
+.responsive-table {
+  margin-bottom: 0;
+  width: 100%;
+}
 
 .responsive-table__heading {
   font-weight: 700;
   text-align: left;
   word-break: initial;
-  width: 50%;
+  width: 50%
+}
+
+.govuk-table__cell--bold {
+  font-weight: 700;
+  // padding-left: 15px;
+}
+
+@media (min-width: 769px) {
+  .responsive-table__heading {
+    display: none;
+  }
 }
 
 @media (min-width: 769px) {
   tbody tr {
     display: table-row;
   }
-  .responsive-table__heading {
-    display: none;
-  }
-  tbody tr td {
-    display: table-cell;
-  }
 }
 
 @media (max-width: 768px) {
   tbody tr td {
     padding-right: 0;
-      width: 100%;
-      text-align: left;
   }
+
   tbody tr td:last-child {
     border-bottom: 0
   }
+
   tbody tr {
     border-bottom: 3px solid grey;
+    padding-left: 0;
   }
+
   thead {
     display: none;
   }
+
   .govuk-table__cell--bold {
     font-weight: 400;
     padding-left: 0;
   }
-  .responsive-table__cell {
-    width: 100%;
-    text-align: right;
-  }
+
   .text-align-right {
     display: inline-block;
     text-align: right;
   }
-};
+
+}
+
+@media (min-width: 769px) {
+  tbody tr td {
+    display: table-cell;
+  }
+}

--- a/src/assets/table.scss
+++ b/src/assets/table.scss
@@ -1,0 +1,73 @@
+tbody tr {
+  display: block;
+  margin-bottom: 1.5em;
+  padding: 0 0.5em;
+}
+tbody tr td {
+  display: flex;
+  justify-content: space-between;
+  min-width: 1px;
+  text-align: right;
+}
+
+// .govuk-table__cell {
+//   vertical-align: middle;
+// }
+
+.govuk-table__cell--bold {
+  font-weight: 700;
+  padding-left: 15px;
+}
+
+// .govuk-table__cell:last-child {
+//   padding: 10px 20px 10px 0;
+// }
+
+.responsive-table__heading {
+  font-weight: 700;
+  text-align: left;
+  word-break: initial;
+  width: 50%;
+}
+
+.text-align-right {
+  display: inline-block;
+  text-align: right;
+}
+
+@media (min-width: 769px) {
+  tbody tr {
+    display: table-row;
+  }
+  .responsive-table__heading {
+    display: none;
+  }
+  tbody tr td {
+    display: table-cell;
+  }
+}
+
+@media (max-width: 768px) {
+  tbody tr td {
+    padding-right: 0;
+      width: 100%;
+      text-align: left;
+  }
+  tbody tr td:last-child {
+    border-bottom: 0
+  }
+  tbody tr {
+    border-bottom: 3px solid grey;
+  }
+  thead {
+    display: none;
+  }
+  .govuk-table__cell--bold {
+    font-weight: 400;
+    padding-left: 0;
+  }
+  .responsive-table__cell {
+    width: 100%;
+    text-align: right;
+  }
+};

--- a/src/assets/table.scss
+++ b/src/assets/table.scss
@@ -19,11 +19,6 @@ tbody tr td {
   padding: 10px 20px 10px 0;
 }
 
-.responsive-table {
-  margin-bottom: 0;
-  width: 100%;
-}
-
 .responsive-table__heading {
   font-weight: 700;
   text-align: left;

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -27,6 +27,9 @@ export const REGISTER_PASSWORD_URL = '/create-account/your-password';
 export const ERROR_URL = '/error';
 export const ERROR_ACCOUNT_ALREADY_ACTIVE_URL = '/create-account/account-already-exists';
 
+//Voyage error pages
+export const ERROR_CREW_DETAILS_UPLOAD= '/create-voyage/check-crew-details';
+
 // Test pages
 export const SECOND_PAGE_NAME = 'Second page';
 export const SECOND_PAGE_URL = '/second-page';

--- a/src/pages/Voyage/ErrorsCrewUpload.jsx
+++ b/src/pages/Voyage/ErrorsCrewUpload.jsx
@@ -85,7 +85,7 @@ const ErrorsCrewUpload = () => {
         <h1 className="govuk-heading-xl govuk-!-margin-bottom-3">Errors found</h1>
         <p className="govuk-body-l govuk-!-font-weight-bold">Your file has errors. Check the file to fix any errors and re-upload your file.</p>
         <div className="govuk-form-group--error">
-          <table className="govuk-table responsive-table">
+          <table className="govuk-table">
             <caption className="govuk-table__caption govuk-table__caption--s govuk-border-bottom">{`${uploadErrors?.length} errors found in ${fileName}`}</caption>
             <thead className="govuk-table__head">
               <tr className="govuk-table__row" role="row">

--- a/src/pages/Voyage/ErrorsCrewUpload.jsx
+++ b/src/pages/Voyage/ErrorsCrewUpload.jsx
@@ -118,6 +118,9 @@ const ErrorsCrewUpload = () => {
             </tbody>
           </table>
         </div>
+        <button className="govuk-button" data-module="govuk-button">
+          Re-upload file
+        </button>
       </div>
     </div>
   );

--- a/src/pages/Voyage/ErrorsCrewUpload.jsx
+++ b/src/pages/Voyage/ErrorsCrewUpload.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+
+// const errors1 = [
+//   { id: '1', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' }
+// ];
+
+// const errors5 = [
+//   { id: '1', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+//   { id: '2', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+//   { id: '3', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+//   { id: '4', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+//   { id: '5', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+// ];
+
+const errors50 = [
+  { id: '1', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '2', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '3', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '4', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '5', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '6', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '7', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '8', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '9', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '10', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '11', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '12', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '13', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '14', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '15', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '16', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '17', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '18', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '19', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '20', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '21', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '22', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '23', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '24', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '25', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '26', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '27', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '28', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '29', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '30', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '31', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '32', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '33', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '34', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '35', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '36', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '37', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '38', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '39', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '40', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '41', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '42', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '43', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '44', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '45', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '46', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+  { id: '47', cell: 'F12', cellValue: 'INDIA', errorMessage: 'These cells have an invalid country code' },
+  { id: '48', cell: 'D6', cellValue: 'rsdfsdfsdf', errorMessage: 'is not a valid document type' },
+  { id: '49', cell: 'C4', cellValue: 'M@ry', errorMessage: 'No special characters' },
+  { id: '50', cell: 'B4', cellValue: '12/31/1991 ', errorMessage: 'Date of birth must be in dd/mm/yyyy format' },
+];
+
+const ErrorsCrewUpload = () => {
+  const [uploadErrors, setUploadErrors] = useState();
+  const fileName = 'CrewDetails.xls';
+
+  const getUploadErrors = () => {
+    setUploadErrors(errors50);
+  };
+
+  useEffect(() => {
+    getUploadErrors();
+  }, []);
+
+  // NOTE: add roles to rows and cells
+
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <h1 className="govuk-heading-xl">There is a problem</h1>
+        <p className="govuk-body govuk-!-font-weight-bold">Your file has errors. Check the file to fix any errors and re upload your file.</p>
+        {/* <div className="govuk-form-group--error"> */}
+        <table className="govuk-table">
+          <caption className="govuk-table__caption govuk-table__caption--s govuk-border-bottom">{`${uploadErrors?.length} Errors found in ${fileName}`}</caption>
+          <thead className="govuk-table__head govuk-form-group--error">
+            <tr className="govuk-table__row">
+              <th scope="col" className="govuk-table__header govuk-!-width-one-third govuk-!-padding-left-3">Cell number</th>
+              <th scope="col" className="govuk-table__header">Error</th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body govuk-form-group--error">
+            {uploadErrors?.map((error) => {
+              return (
+                <tr key={error.id} className="govuk-table__row">
+                  <td className="govuk-table__cell govuk-table__cell--bold">
+                    <span className="responsive-table__heading" aria-hidden="true">
+                      Cell number
+                    </span>
+                    {error.cell}
+                  </td>
+                  <td className="govuk-table__cell">
+                    <span className="responsive-table__heading" aria-hidden="true">
+                      Error
+                    </span>
+                    <div className="text-align-right">
+                      {`${error.cellValue} - `}
+                      <span className="govuk-error-message govuk-inline">{error.errorMessage}</span>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {/* </div> */}
+      </div>
+    </div>
+  );
+};
+
+export default ErrorsCrewUpload;

--- a/src/pages/Voyage/ErrorsCrewUpload.jsx
+++ b/src/pages/Voyage/ErrorsCrewUpload.jsx
@@ -82,42 +82,42 @@ const ErrorsCrewUpload = () => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        <h1 className="govuk-heading-xl">There is a problem</h1>
-        <p className="govuk-body govuk-!-font-weight-bold">Your file has errors. Check the file to fix any errors and re upload your file.</p>
-        {/* <div className="govuk-form-group--error"> */}
-        <table className="govuk-table">
-          <caption className="govuk-table__caption govuk-table__caption--s govuk-border-bottom">{`${uploadErrors?.length} Errors found in ${fileName}`}</caption>
-          <thead className="govuk-table__head govuk-form-group--error">
-            <tr className="govuk-table__row">
-              <th scope="col" className="govuk-table__header govuk-!-width-one-third govuk-!-padding-left-3">Cell number</th>
-              <th scope="col" className="govuk-table__header">Error</th>
-            </tr>
-          </thead>
-          <tbody className="govuk-table__body govuk-form-group--error">
-            {uploadErrors?.map((error) => {
-              return (
-                <tr key={error.id} className="govuk-table__row">
-                  <td className="govuk-table__cell govuk-table__cell--bold">
-                    <span className="responsive-table__heading" aria-hidden="true">
-                      Cell number
-                    </span>
-                    {error.cell}
-                  </td>
-                  <td className="govuk-table__cell">
-                    <span className="responsive-table__heading" aria-hidden="true">
-                      Error
-                    </span>
-                    <div className="text-align-right">
-                      {`${error.cellValue} - `}
-                      <span className="govuk-error-message govuk-inline">{error.errorMessage}</span>
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-        {/* </div> */}
+        <h1 className="govuk-heading-xl govuk-!-margin-bottom-3">Errors found</h1>
+        <p className="govuk-body-l govuk-!-font-weight-bold">Your file has errors. Check the file to fix any errors and re-upload your file.</p>
+        <div className="govuk-form-group--error">
+          <table className="govuk-table responsive-table">
+            <caption className="govuk-table__caption govuk-table__caption--s govuk-border-bottom">{`${uploadErrors?.length} errors found in ${fileName}`}</caption>
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row" role="row">
+                <th scope="col" className="govuk-table__header govuk-!-width-one-third">Cell number</th>
+                <th scope="col" className="govuk-table__header">Error</th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {uploadErrors?.map((error) => {
+                return (
+                  <tr key={error.id} className="govuk-table__row" role="row">
+                    <td className="govuk-table__cell govuk-table__cell--bold">
+                      <span className="responsive-table__heading" aria-hidden="true">
+                        Cell number
+                      </span>
+                      {error.cell}
+                    </td>
+                    <td className="govuk-table__cell">
+                      <span className="responsive-table__heading" aria-hidden="true">
+                        Error
+                      </span>
+                      <div className="text-align-right">
+                        {`${error.cellValue} - `}
+                        <span className="govuk-error-message govuk-inline">{error.errorMessage}</span>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Voyage/__tests__/ErrorsCrewUpload.test.jsx
+++ b/src/pages/Voyage/__tests__/ErrorsCrewUpload.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import ErrorsCrewUpload from '../ErrorsCrewUpload';
+
+describe('Crew upload error tests', () => {
+
+  it('should render the page correctly', async () => {
+    render(<ErrorsCrewUpload />);
+    expect(screen.getByText('Errors found')).toBeInTheDocument();
+    expect(screen.getByText('Your file has errors. Check the file to fix any errors and re-upload your file.')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-upload file'})).toBeInTheDocument();
+  });
+
+  // TODO: Once api is in place, mock it's response to test that errors show correctly as currently the hardcoded errors are always returned in the render
+});


### PR DESCRIPTION
# Ticket

NMSW-291

----

## AC

Given I am on the error page for Crew details upload
I will see a H1 with 'Errors found' and text detailing that there are errors

Given I am on the error page for Crew details upload
I see a (table) with a red sidebar containing information about (mocked) errors 
The table will show a (possible) cell number in one column and a concatenated cell value - error message in a second column

Given there is 1 error
I see one error in the (table)

Given there are 5 errors
When I map over the errors
Then I will see a (table) with 5 errors

Given there are 100 errors
When I map over the errors
Then I will see a table with 100 errors (Need a way to deal with this many errors - this is to demo what lots of errors will look like)

----

## To test

- Run the app
- Sign in
- in the url type `http://localhost:3000/create-voyage/check-crew-details`
- > You should see a page with the title 'Errors found' and a table showing 50 errors (should match the prototype image)
- Go to the code and view the file `ErrorsCrewUpload`
- Comment out the `const errors50 = [.......]`
- Uncomment the const errors5 = [........]
- Change `errors50` to `errors5` on line 73
- Save the file
- Go back to the running app
- > You should now see only 5 errors and the caption should read '5 errors found in (filename)'
- Repeat with `errors1`
- In dev tools swap to mobile view
- > The table should be responsive to accommodate smaller screens

----

## Notes
