### PR TITLE
Add a wait in tests to prevent timing errors

### DIFF
--- a/src/components/__tests__/DisplayFormTests/ErrorPhoneNumberInput.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorPhoneNumberInput.test.jsx
@@ -69,6 +69,7 @@ describe('Display Form', () => {
       </MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    await screen.getByText('There is a problem');
     expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
     expect(screen.getAllByText('Enter your phone value')).toHaveLength(2);
     // Error summary has the error message as a button and correct class

--- a/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
@@ -179,6 +179,7 @@ describe('Display Form', () => {
       </MemoryRouter>
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    await screen.getByText('There is a problem');
 
     expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');
     expect(screen.getAllByText('Enter your text input value')).toHaveLength(2);


### PR DESCRIPTION

----

## Notes

We occasionally had 2 tests failing inexplicably and randomly - they would fail when we'd not touched related code, and if you run the test suite again then they would pass.

Investigating it looks like the `expect` statement that checked for error text to have appeared on the page was running before the errors has been generated.

To try to prevent this we've added waits around the error summary title to wait for it to appear before running the rest of the assertions 