### PR TITLE
NMSW-180 Verify email address - success path

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
   "rules": {
     "eol-last": ["error", "always"],
     "import/prefer-default-export": ["off"],
-    "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignorePattern": "^path " }],
+    "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignoreComments": true, "ignorePattern": "^path " }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "quotes": [ "error",  "single"],
     "react-hooks/exhaustive-deps": "off",

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -2,6 +2,7 @@ import { apiUrl } from './Config';
 
 // Create account/register pages
 export const REGISTER_ACCOUNT_ENDPOINT = `${apiUrl}/registration`;
+export const REGISTER_CHECK_TOKEN_ENDPOINT = `${apiUrl}/check-token`;
 
 // Responses
 export const AXIOS_ERROR = 'Network Error';

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -20,7 +20,7 @@ export const REGISTER_CONFIRMATION_URL = '/create-account/account-created';
 export const REGISTER_EMAIL_URL = '/create-account/email-address';
 export const REGISTER_EMAIL_CHECK_URL = '/create-account/check-your-email';
 export const REGISTER_EMAIL_RESEND_URL = '/create-account/request-new-verification-link';
-export const REGISTER_EMAIL_VERIFIED_URL = '/create-account/email-verified';
+export const REGISTER_EMAIL_VERIFIED_URL = '/activate-account';
 export const REGISTER_DETAILS_URL = '/create-account/your-details';
 export const REGISTER_PASSWORD_URL = '/create-account/your-password';
 

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -30,7 +30,7 @@ const RegisterEmailVerified = () => {
           blurb: 'You can continue creating your account',
           buttonLabel: 'Continue',
           buttonNavigateTo: REGISTER_DETAILS_URL,
-          buttonState: { state: { dataToSubmit: { emailAddress } } },
+          buttonState: { state: { dataToSubmit: { emailAddress, token } } },
         });
       }
     } catch (err) {

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -39,7 +39,7 @@ const RegisterEmailVerified = () => {
     }
   }, [token, emailAddress]);
 
-  // if (Object.entries(pageContent).length === 0) { console.log('loading'); }
+  if (Object.entries(pageContent).length === 0) { setPageContent({ blurb: '...Loading' }); }
   return (
     <>
       <div className="govuk-grid-row">
@@ -50,14 +50,16 @@ const RegisterEmailVerified = () => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <p className="govuk-body">{pageContent.blurb}</p>
-          <button
-            className="govuk-button"
-            data-module="govuk-button"
-            type="button"
-            onClick={() => { navigate(pageContent.buttonNavigateTo, pageContent.buttonState); }}
-          >
-            {pageContent.buttonLabel}
-          </button>
+          {pageContent.buttonLabel && (
+            <button
+              className="govuk-button"
+              data-module="govuk-button"
+              type="button"
+              onClick={() => { navigate(pageContent.buttonNavigateTo, pageContent.buttonState); }}
+            >
+              {pageContent.buttonLabel}
+            </button>
+          )}
         </div>
       </div>
     </>

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -7,9 +7,7 @@ import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
 const RegisterEmailVerified = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [title, setTitle] = useState();
-  const [blurb, setBlurb] = useState();
-  const [button, setButton] = useState({});
+  const [pageContent, setPageContent] = useState({});
   document.title = 'Your email address has been verified';
 
   // sample URL
@@ -21,15 +19,15 @@ const RegisterEmailVerified = () => {
       // const response = await axios.get(REGISTER_CHECK_TOKEN_ENDPOINT, {
       //   headers: { token: searchParams.get('token')}
       // });
-      const response = '204';
+      const response = '209';
 
-      if (response === '204') { // I think may not need the if statement here as 204 is the success response
-        setTitle('Your email address has been verified');
-        setBlurb('You can continue creating your account');
-        setButton({
-          label: 'Continue',
-          navigateTo: REGISTER_DETAILS_URL,
-          state: { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } }
+      if (response === '209') { // I think may not need the if statement here as 204 is the success response
+        setPageContent({
+          title: 'Your email address has been verified',
+          blurb: 'You can continue creating your account',
+          buttonLabel: 'Continue',
+          buttonNavigateTo: REGISTER_DETAILS_URL,
+          buttonState: { 'state': { 'dataToSubmit': { 'emailAddress': searchParams.get('email') } } },
         });
       }
     } catch (err) {
@@ -41,25 +39,26 @@ const RegisterEmailVerified = () => {
 
   useEffect(() => {
     checkTokenIsValid();
-  }, [searchParams]);
+  }, []);
 
+  // if (Object.entries(pageContent).length === 0) { console.log('loading'); }
   return (
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <h1 className="govuk-heading-xl">{title}</h1>
+          <h1 className="govuk-heading-xl">{pageContent.title}</h1>
         </div>
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <p className="govuk-body">{blurb}</p>
+          <p className="govuk-body">{pageContent.blurb}</p>
           <button
             className="govuk-button"
             data-module="govuk-button"
             type="button"
-            onClick={() => { navigate(button.navigateTo, button.state); }}
+            onClick={() => { navigate(pageContent.buttonNavigateTo, pageContent.buttonState); }}
           >
-            Continue
+            {pageContent.buttonLabel}
           </button>
         </div>
       </div>

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -7,17 +7,20 @@ import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
 const RegisterEmailVerified = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const emailAddress = searchParams.get('email');
+  const token = searchParams.get('token');
   const [pageContent, setPageContent] = useState({});
   document.title = 'Your email address has been verified';
 
   // sample URL
   // http://localhost:3000/activate-account?email=jentestemail@email.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImM4OWY0MjlhLTMxOGQtNDhiZC1iODE3LWZkMWJjOTYyMWYyM0BtYWlsc2x1cnAuY29tIiwiZXhwIjoxNjczMzg0NzgyLCJqaXQiOiJiMGJiOWZlNi0yMzhiLTRiNzgtYjA1Zi0wODc3NDAxNTc3YWQifQ.FiUsaU4Mqth4cnQl4a6YZMOVn2OEQ5I6JjI1T2c1WYc
 
-  // make call to /check-token to check token validity
-  const checkTokenIsValid = async () => {
+  useEffect(() => {
     try {
+      // const controller = new AbortController();
       // const response = await axios.get(REGISTER_CHECK_TOKEN_ENDPOINT, {
-      //   headers: { token: searchParams.get('token')}
+      //   headers: { token: searchParams.get('token') },
+      //   signal: controller.signal,
       // });
       const response = '209';
 
@@ -27,19 +30,14 @@ const RegisterEmailVerified = () => {
           blurb: 'You can continue creating your account',
           buttonLabel: 'Continue',
           buttonNavigateTo: REGISTER_DETAILS_URL,
-          buttonState: { 'state': { 'dataToSubmit': { 'emailAddress': searchParams.get('email') } } },
+          buttonState: { state: { dataToSubmit: { emailAddress } } },
         });
       }
     } catch (err) {
       console.log('error', err);
+      // name === 'AbortError' will be if the fetch is aborted with the AbortController
     }
-  };
-  // assume call returns 204 valid response
-  // show user 'email validated, click here to go to your-details' page
-
-  useEffect(() => {
-    checkTokenIsValid();
-  }, []);
+  }, [token, emailAddress]);
 
   // if (Object.entries(pageContent).length === 0) { console.log('loading'); }
   return (

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -1,43 +1,48 @@
-// import axios from 'axios';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-// import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../constants/AppAPIConstants';
+import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../constants/AppAPIConstants';
 import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
+import Auth from '../../utils/Auth';
 
 const RegisterEmailVerified = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const emailAddress = searchParams.get('email');
-  const token = searchParams.get('token');
+  const tokenToCheck = searchParams.get('token');
   const [pageContent, setPageContent] = useState({});
   document.title = 'Your email address has been verified';
 
   // sample URL
-  // http://localhost:3000/activate-account?email=jentestemail@email.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImM4OWY0MjlhLTMxOGQtNDhiZC1iODE3LWZkMWJjOTYyMWYyM0BtYWlsc2x1cnAuY29tIiwiZXhwIjoxNjczMzg0NzgyLCJqaXQiOiJiMGJiOWZlNi0yMzhiLTRiNzgtYjA1Zi0wODc3NDAxNTc3YWQifQ.FiUsaU4Mqth4cnQl4a6YZMOVn2OEQ5I6JjI1T2c1WYc
+  // http://localhost:3000/activate-account?email=jentestingemailsforwork%2B20230113%40gmail.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImplbnRlc3RpbmdlbWFpbHNmb3J3b3JrKzIwMjMwMTEzQGdtYWlsLmNvbSIsImV4cCI6MTY3MzYzMjYzNiwiaml0IjoiNDE4NTliMzQtMzI2ZC00MjUxLTgyNDQtMjgwMTg4YjJiZDU4In0.1bdZ2X7rxMX9wTD2Kwkx7VqktUuE3IzPJzxEVO3hNCw
 
-  useEffect(() => {
+  const fetchData = async () => {
     try {
-      // const controller = new AbortController();
-      // const response = await axios.get(REGISTER_CHECK_TOKEN_ENDPOINT, {
-      //   headers: { token: searchParams.get('token') },
-      //   signal: controller.signal,
-      // });
-      const response = '209';
+      const controller = new AbortController();
+      const response = await axios.post(REGISTER_CHECK_TOKEN_ENDPOINT, {
+        token: tokenToCheck,
+      }, {
+        signal: controller.signal,
+      });
 
-      if (response === '209') { // I think may not need the if statement here as 204 is the success response
+      if (response.status === 204) {
         setPageContent({
           title: 'Your email address has been verified',
           blurb: 'You can continue creating your account',
           buttonLabel: 'Continue',
           buttonNavigateTo: REGISTER_DETAILS_URL,
-          buttonState: { state: { dataToSubmit: { emailAddress, token } } },
+          buttonState: { state: { dataToSubmit: { emailAddress, token: tokenToCheck } } },
         });
       }
     } catch (err) {
       console.log('error', err);
       // name === 'AbortError' will be if the fetch is aborted with the AbortController
     }
-  }, [token, emailAddress]);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [tokenToCheck, emailAddress]);
 
   if (Object.entries(pageContent).length === 0) { setPageContent({ blurb: '...Loading' }); }
   return (

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -1,8 +1,69 @@
+// import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+// import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../constants/AppAPIConstants';
+import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
+
 const RegisterEmailVerified = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [title, setTitle] = useState();
+  const [blurb, setBlurb] = useState();
+  const [button, setButton] = useState({});
   document.title = 'Your email address has been verified';
 
+  // sample URL
+  // http://localhost:3000/activate-account?email=jentestemail@email.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImM4OWY0MjlhLTMxOGQtNDhiZC1iODE3LWZkMWJjOTYyMWYyM0BtYWlsc2x1cnAuY29tIiwiZXhwIjoxNjczMzg0NzgyLCJqaXQiOiJiMGJiOWZlNi0yMzhiLTRiNzgtYjA1Zi0wODc3NDAxNTc3YWQifQ.FiUsaU4Mqth4cnQl4a6YZMOVn2OEQ5I6JjI1T2c1WYc
+
+  // make call to /check-token to check token validity
+  const checkTokenIsValid = async () => {
+    try {
+      // const response = await axios.get(REGISTER_CHECK_TOKEN_ENDPOINT, {
+      //   headers: { token: searchParams.get('token')}
+      // });
+      const response = '204';
+
+      if (response === '204') { // I think may not need the if statement here as 204 is the success response
+        setTitle('Your email address has been verified');
+        setBlurb('You can continue creating your account');
+        setButton({
+          label: 'Continue',
+          navigateTo: REGISTER_DETAILS_URL,
+          state: { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } }
+        });
+      }
+    } catch (err) {
+      console.log('error', err);
+    }
+  };
+  // assume call returns 204 valid response
+  // show user 'email validated, click here to go to your-details' page
+
+  useEffect(() => {
+    checkTokenIsValid();
+  }, [searchParams]);
+
   return (
-    <h1>Verification link clicked</h1>
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-full">
+          <h1 className="govuk-heading-xl">{title}</h1>
+        </div>
+      </div>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-full">
+          <p className="govuk-body">{blurb}</p>
+          <button
+            className="govuk-button"
+            data-module="govuk-button"
+            type="button"
+            onClick={() => { navigate(button.navigateTo, button.state); }}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -1,54 +1,8 @@
-import { useNavigate } from 'react-router-dom';
-import {
-  FIELD_EMAIL,
-  MULTI_PAGE_FORM,
-  VALIDATE_EMAIL_ADDRESS,
-  VALIDATE_REQUIRED,
-} from '../../constants/AppConstants';
-import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
-import DisplayForm from '../../components/DisplayForm';
-
 const RegisterEmailVerified = () => {
-  const navigate = useNavigate();
   document.title = 'Your email address has been verified';
 
-  const formActions = {
-    submit: {
-      label: 'Continue',
-    },
-  };
-  const formFields = [
-    {
-      type: FIELD_EMAIL,
-      fieldName: 'emailAddress',
-      label: 'Enter your email address',
-      validation: [
-        {
-          type: VALIDATE_REQUIRED,
-          message: 'Enter an email address in the correct format, like name@example.com',
-        },
-        {
-          type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter an email address in the correct format, like name@example.com',
-        },
-      ],
-    },
-  ];
-
-  const handleSubmit = async (formData) => {
-    const dataToSubmit = { ...formData.formData };
-    navigate(REGISTER_DETAILS_URL, { state: { dataToSubmit: { emailAddress: dataToSubmit.emailAddress } } });
-  };
-
   return (
-    <DisplayForm
-      formId="formRegisterEmailVerified"
-      fields={formFields}
-      formActions={formActions}
-      formType={MULTI_PAGE_FORM}
-      pageHeading="Your email address has been verified​"
-      handleSubmit={handleSubmit}
-    />
+    <h1>Verification link clicked</h1>
   );
 };
 

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -109,14 +109,14 @@ const RegisterYourDetails = () => {
   };
 
   /*
-   * Without an email address we can't submit the PATCH to update the user account
+   * Without an email address & token we can't submit the PATCH to update the user account
    * So if a user arrives to this page and we do not have an email address in state
    * we need to direct them to a place where they can deal with that
    * TODO: once we have email verification flow journey replace REGISTER_EMAIL_URL_VERIFIED
    * with a more appropriate page
    */
   useEffect(() => {
-    if (!state || !state.dataToSubmit || !state.dataToSubmit.emailAddress) {
+    if (!state || !state.dataToSubmit || !state.dataToSubmit.emailAddress || !state.dataToSubmit.token) {
       navigate(ERROR_VERIFICATION_FAILED_URL);
     }
   }, [state]);

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -88,7 +88,7 @@ const RegisterYourPassword = () => {
       password: dataMerged.requirePassword,
       groupName: dataMerged.companyName,
       groupTypeName: dataMerged.shippingAgent === 'yes' ? 'Shipping Agency' : 'Operator', // these are the only two valid public group types
-      token: 'tbd',
+      token: dataMerged.token,
     };
 
     try {

--- a/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
@@ -8,13 +8,16 @@ import { REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
 import RegisterEmailVerified from '../RegisterEmailVerified';
 
 const mockedUseNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-  return {
-    ...jest.requireActual('react-router-dom'),
-    useSearchParams: () => [new URLSearchParams({ email: 'testemail@email.com', token: '123' })],
-    useNavigate: () => mockedUseNavigate,
-  };
-});
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: () => [new URLSearchParams({ email: 'testemail@email.com', token: '123' })],
+  useNavigate: () => mockedUseNavigate,
+}));
+
+// jest.mock('react-router-dom', () => ({
+//   ...jest.requireActual('react-router-dom'),
+//   useNavigate: () => mockedUseNavigate,
+// }));
 
 describe('Verify email address tests', () => {
   const mockAxios = new MockAdapter(axios);
@@ -33,7 +36,7 @@ describe('Verify email address tests', () => {
     mockAxios
       .onGet(REGISTER_CHECK_TOKEN_ENDPOINT)
       .reply(209, {
-        email: 'testemail@email.com'
+        email: 'testemail@email.com',
       });
 
     render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
@@ -46,7 +49,7 @@ describe('Verify email address tests', () => {
     mockAxios
       .onGet(REGISTER_CHECK_TOKEN_ENDPOINT)
       .reply(209, {
-        email: 'testemail@email.com'
+        email: 'testemail@email.com',
       });
 
     render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
@@ -55,7 +58,7 @@ describe('Verify email address tests', () => {
     expect(nextButton.outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Continue</button>');
     await user.click(nextButton);
     await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } });
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
     });
   });
 });

--- a/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
@@ -1,17 +1,20 @@
-import { render, screen } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../../constants/AppAPIConstants';
-// import { REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
+import { REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
 import RegisterEmailVerified from '../RegisterEmailVerified';
 
 const mockedUseNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedUseNavigate,
-}));
+jest.mock('react-router-dom', () => {
+  return {
+    ...jest.requireActual('react-router-dom'),
+    useSearchParams: () => [new URLSearchParams({ email: 'testemail@email.com', token: '123' })],
+    useNavigate: () => mockedUseNavigate,
+  };
+});
 
 describe('Verify email address tests', () => {
   const mockAxios = new MockAdapter(axios);
@@ -29,30 +32,30 @@ describe('Verify email address tests', () => {
   it('should load the email verified successfully message if token is valid', async () => {
     mockAxios
       .onGet(REGISTER_CHECK_TOKEN_ENDPOINT)
-      .reply(204, {
+      .reply(209, {
         email: 'testemail@email.com'
       });
 
     render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
-    expect(screen.getByRole('heading', {name: 'Your email address has been verified'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Your email address has been verified' })).toBeInTheDocument();
     expect(screen.getByText('You can continue creating your account')).toBeInTheDocument();
   });
 
-  // it('should link user to your details page if token is valid', async () => {
-  //   const user = userEvent.setup();
-  //   // mockAxios
-  //   //   .onGet(CHECK_VERIFY_TOKEN_ENDPOINT)
-  //   //   .reply(200, {
-  //   //     email: 'testemail@email.com'
-  //   //   });
+  it('should link user to your details page if token is valid', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(REGISTER_CHECK_TOKEN_ENDPOINT)
+      .reply(209, {
+        email: 'testemail@email.com'
+      });
 
-  //   render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
-  //   const nextButton = screen.getByRole('button', { name: 'Continue' });
-  //   expect(nextButton).toBeInTheDocument();
-  //   expect(nextButton.outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Continue</button>');
-  //   await user.click(nextButton);
-  //   await waitFor(() => {
-  //     expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } });
-  //   });
-  // });
+    render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
+    const nextButton = screen.getByRole('button', { name: 'Continue' });
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton.outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Continue</button>');
+    await user.click(nextButton);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } });
+    });
+  });
 });

--- a/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
@@ -58,7 +58,7 @@ describe('Verify email address tests', () => {
     expect(nextButton.outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Continue</button>');
     await user.click(nextButton);
     await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } });
     });
   });
 });

--- a/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailVerified.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+// import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../../constants/AppAPIConstants';
+// import { REGISTER_DETAILS_URL } from '../../../constants/AppUrlConstants';
+import RegisterEmailVerified from '../RegisterEmailVerified';
+
+const mockedUseNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUseNavigate,
+}));
+
+describe('Verify email address tests', () => {
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    mockAxios.reset();
+    window.sessionStorage.clear();
+  });
+
+  it('should render the page', () => {
+    render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
+    expect(screen.getByText('Your email address has been verified')).toBeInTheDocument();
+  });
+
+  it('should load the email verified successfully message if token is valid', async () => {
+    mockAxios
+      .onGet(REGISTER_CHECK_TOKEN_ENDPOINT)
+      .reply(204, {
+        email: 'testemail@email.com'
+      });
+
+    render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
+    expect(screen.getByRole('heading', {name: 'Your email address has been verified'})).toBeInTheDocument();
+    expect(screen.getByText('You can continue creating your account')).toBeInTheDocument();
+  });
+
+  // it('should link user to your details page if token is valid', async () => {
+  //   const user = userEvent.setup();
+  //   // mockAxios
+  //   //   .onGet(CHECK_VERIFY_TOKEN_ENDPOINT)
+  //   //   .reply(200, {
+  //   //     email: 'testemail@email.com'
+  //   //   });
+
+  //   render(<MemoryRouter><RegisterEmailVerified /></MemoryRouter>);
+  //   const nextButton = screen.getByRole('button', { name: 'Continue' });
+  //   expect(nextButton).toBeInTheDocument();
+  //   expect(nextButton.outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Continue</button>');
+  //   await user.click(nextButton);
+  //   await waitFor(() => {
+  //     expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_DETAILS_URL, { 'state': { 'dataToSubmit': { 'emailAddress': 'testemail@email.com' } } });
+  //   });
+  // });
+});

--- a/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
@@ -38,8 +38,24 @@ describe('Your details tests', () => {
     });
   });
 
-  it('should redirect user to other page if there is no emailAddress in state', async () => {
+  it('should redirect user to other page if there is an empty dataToSubmit object in state', async () => {
     mockUseLocationState = { state: { dataToSubmit: {} } };
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
+    });
+  });
+
+  it('should redirect user to other page if there is no emailAddress in state', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { toke: '123' } } };
+    render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
+    });
+  });
+
+  it('should redirect user to other page if there is no token in state', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await waitFor(() => {
       expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);


### PR DESCRIPTION
# Ticket

NMSW-180

----

## AC

Given a user clicks their 'verify your email address' link in their email
When the FE receives that request
Then the FE sends a GET request to /check-token endpoint with the token details from the link

Given the FE app has sent a  GET request to /check-token endpoint
When the response is 204
Then the email address verified page is loaded with a continue button

Given the user has been shown the email address verified page
When they click the continue button
Then they are taken to the /your-details page 

Given they are taken to the /your-details page
When they complete the registration form and submit
Then their account is activated

----

## To test

-   // to test this as a user in browser
-   // make new email address
-   // add email to GovNotify
-   // create account using that email
-   // get link from email - that token lasts 8 hours

_let me know if you need to me to make it, I can make for jentestingemailsforwork+<todaysdate>@gmail.com & we can use that url_

- go to /create-account/email-address
- add new email address and submit
- > you should be taken to confirm your email page
- > you should have a verification email
- click the verification email link
- > you should be taken to the email has been verified page
- click continue
- > you should be taken to /your-details page
- complete the your details and password pages and submit
- > you should be taken to the account created page

----

## Notes

Have to test against Dev BE for now as code is on the release branch but release not moved to main yet as other things to continue testing with it before it is merged
