### PR TITLE
NMSW-181 Verify email - account already exists

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -7,4 +7,5 @@ export const REGISTER_CHECK_TOKEN_ENDPOINT = `${apiUrl}/check-token`;
 // Responses
 export const AXIOS_ERROR = 'Network Error';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';
+export const TOKEN_USED_TO_REGISTER = 'Token was already used';
 export const USER_ALREADY_REGISTERED = 'User is already registered';

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { REGISTER_CHECK_TOKEN_ENDPOINT } from '../../constants/AppAPIConstants';
-import { REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
-import Auth from '../../utils/Auth';
+import { REGISTER_CHECK_TOKEN_ENDPOINT, TOKEN_USED_TO_REGISTER } from '../../constants/AppAPIConstants';
+import { ERROR_ACCOUNT_ALREADY_ACTIVE_URL, REGISTER_DETAILS_URL } from '../../constants/AppUrlConstants';
 
 const RegisterEmailVerified = () => {
   const navigate = useNavigate();
@@ -14,7 +13,7 @@ const RegisterEmailVerified = () => {
   document.title = 'Your email address has been verified';
 
   // sample URL
-  // http://localhost:3000/activate-account?email=jentestingemailsforwork%2B20230113%40gmail.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImplbnRlc3RpbmdlbWFpbHNmb3J3b3JrKzIwMjMwMTEzQGdtYWlsLmNvbSIsImV4cCI6MTY3MzYzMjYzNiwiaml0IjoiNDE4NTliMzQtMzI2ZC00MjUxLTgyNDQtMjgwMTg4YjJiZDU4In0.1bdZ2X7rxMX9wTD2Kwkx7VqktUuE3IzPJzxEVO3hNCw
+  // http://localhost:3000/activate-account?email=jentestingemailsforwork%2B202301160900%40gmail.com&token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImplbnRlc3RpbmdlbWFpbHNmb3J3b3JrKzIwMjMwMTE2MDkwMEBnbWFpbC5jb20iLCJleHAiOjE2NzM4NzExNTcsImppdCI6IjcyNDFkNzcyLWYzZWYtNGU3OC1iMDZkLTU3ZWMxM2VkMTE4YiJ9.ZoPD-u3T10B-YEc2I0lD2BsT6KMYSGhie7PMtnycNHc
 
   const fetchData = async () => {
     try {
@@ -35,8 +34,9 @@ const RegisterEmailVerified = () => {
         });
       }
     } catch (err) {
-      console.log('error', err);
-      // name === 'AbortError' will be if the fetch is aborted with the AbortController
+      if (err.response.data.message === TOKEN_USED_TO_REGISTER) {
+        navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress } } });
+      }
     }
   };
 


### PR DESCRIPTION
# Ticket

NMSW-181

----

## AC

Given a user clicks their 'verify your email address' link
When the FE receives that request
Then the FE sends a GET request to /check-token endpoint with the token details from the link

Given the FE app has sent a  GET request to /check-token endpoint
When the response is 401: "Token was already used"
Then we show the user the 'error' page with 'You already have an account' message and sign in link

Given the user is on the error page
When the error reason is 'You already have an account'
And the user clicks the button
Then they're taken to the /sign-in page

----

## To test

- go to /create-account/email-address
- add new email address and submit
- you should be taken to confirm your email page
- > you should have a verification email
- click the verification email link
- > you should be taken to the email has been verified page
- click continue
- > you should be taken to /your-details page
- complete the your details and password pages and submit
- > you should be taken to the account created page
- go back to your email
- click the verification email link again
- > you should be taken to 'you already have an account' page
- click the sign in button
- > you should be taken to the sign in page


----

## Notes
Confirmed with Endi that `401: "Token was already used"` is the indicator that the account has been registered
