### PR TITLE
NMSW-168 Add a details input field

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -212,7 +212,7 @@ Object structure
   type: FIELD_RADIO,
   className: <required>,
   fieldName: <required>,
-  grouped: true,
+  displayType: DISPLAY_GROUPED,
   hint: <optional>
   label: <required>,
   radioOptions: [
@@ -239,7 +239,7 @@ A string that will be used for `name` and to create `id` and other field referen
 
 ### grouped
 Always specify this as `true` as radio buttons are grouped inputs and use a different fieldset/label html structure.
-This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `grouped: true` does not need to be specified within the field object
+This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `displayType: DISPLAY_GROUPED,` does not need to be specified within the field object
 
 ### hint (optional)
 An optional string
@@ -275,7 +275,7 @@ Object structure
   type: FIELD_CONDITIONAL,
   className: <required>,
   fieldName: <required>,
-  grouped: true,
+  displayType: DISPLAY_GROUPED,
   hint: <optional>,
   label: <required>,
   radioOptions: [
@@ -309,7 +309,7 @@ A string that will be used for `name` and to create `id` and other field referen
 
 ### grouped
 Always specify this as `true` as radio buttons are grouped inputs and use a different fieldset/label html structure.
-This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `grouped: true` does not need to be specified within the field object
+This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `displayType: DISPLAY_GROUPED,` does not need to be specified within the field object
 
 ### hint (optional)
 An optional string
@@ -426,7 +426,7 @@ A string that will be used for `name` and to create `id` and other field referen
 
 ### grouped
 Always specify this as `true` as phone number fields are grouped inputs and use a different fieldset/label html structure.
-This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `grouped: true` does not need to be specified within the field object
+This is defined within `src/components/formFields/DetermineFieldType` and at some point we will refactor this so that `displayType: DISPLAY_GROUPED,` does not need to be specified within the field object
 
 ### hint (optional)
 An optional string
@@ -615,7 +615,7 @@ e.g.
   label: 'What is your favourite animal',
   fieldName: 'favAnimal',
   className: 'govuk-radios',
-  grouped: true,
+  displayType: DISPLAY_GROUPED,
   radioOptions: [
     {
       radioField: true,

--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -9,6 +9,11 @@ This app has an in built form creator with reusable components for if you wish t
 - [Form action options](#form-action-options)
 
 ## Field types
+Display types
+Every input can be displayed as a single field, set of grouped fields, or contained within a `<details>` component. By default, inputs are treated as single field unless otherwise specified.
+
+- [Display types](#display-types)
+
 Standard inputs
 - [Autocomplete](#autocomplete)
 - [Radio buttons](#radio-buttons)
@@ -148,6 +153,31 @@ The page you want to redirect the user to if they click cancel
 
 ----
 
+## Display Types
+
+Sometimes an input needs to be contained with the GDS `<details>` tags to allow users control over whether to interact with it or not.
+
+Some inputs must be grouped with a fieldset e.g. radio buttons and checkboxes, conditional fields
+
+To create one, when you define your input (see input options below) you need to include the params:
+- `displayType: <type>`
+- `linkText: <required/optional>`
+
+Parameters
+
+### displayType
+Import and use
+- `FIELD_DETAILS` for detail components
+- `FIELD_GROUPED` for grouped inputs
+- `FIELD_SINGLE` for everything else
+
+### linkText
+This is required for a `FIELD_DETAILS` type as this is the text that will show on the detail summary to be clicked on
+
+It should NOT be used for the other types as it is redundant for them.
+
+----
+
 ## Autocomplete
 
 Requirements
@@ -159,6 +189,7 @@ Object structure
 ```
 {
   type: FIELD_AUTOCOMPLETE,
+  displayType: DISPLAY_SINGLE,
   dataAPIEndpoint: <required>,
   fieldName: <required>,
   hint: <optional>
@@ -211,8 +242,8 @@ Object structure
 {
   type: FIELD_RADIO,
   className: <required>,
-  fieldName: <required>,
   displayType: DISPLAY_GROUPED,
+  fieldName: <required>,
   hint: <optional>
   label: <required>,
   radioOptions: [
@@ -274,8 +305,8 @@ Object structure
 {
   type: FIELD_CONDITIONAL,
   className: <required>,
-  fieldName: <required>,
   displayType: DISPLAY_GROUPED,
+  fieldName: <required>,
   hint: <optional>,
   label: <required>,
   radioOptions: [
@@ -344,6 +375,7 @@ Object structure
 ```
 {
   type: FIELD_TEXT,
+  displayType: DISPLAY_SINGLE,
   fieldName: <required>,
   hint: <optional>,
   label: <required>
@@ -377,6 +409,7 @@ Object structure
 ```
 {
   type: FIELD_EMAIL,
+  displayType: DISPLAY_SINGLE,
   fieldName: <required>,
   hint: <optional>,
   label: <required>
@@ -410,6 +443,7 @@ Object structure
 ```
 {
   type: FIELD_PASSWORD,
+  displayType: DISPLAY_SINGLE,
   fieldName: <required>,
   hint: <optional>,
   label: <required>
@@ -447,6 +481,7 @@ Object structure
 ```
 {
   type: FIELD_PHONE,
+  displayType: DISPLAY_SINGLE,
   fieldName: <required>,
   hint: <optional>,
   label: <required>
@@ -595,6 +630,7 @@ e.g.
 ```
 {
   type: FIELD_TEXT,
+  displayType: DISPLAY_SINGLE,
   label: 'First name',
   fieldName: 'firstName',
   validation: [

--- a/docs/form_creator_example.md
+++ b/docs/form_creator_example.md
@@ -59,7 +59,7 @@ const formFields = [
       label: 'What is your favourite colour',
       fieldName: 'favouriteColour',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           label: 'Red',
@@ -96,7 +96,7 @@ const formFields = [
       label: 'Sample date field',
       hint: 'Enter a date',
       fieldName: 'myDate',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
     },
   ];
 
@@ -143,7 +143,7 @@ const formFields = [
       label: 'What is your favourite colour',
       fieldName: 'favouriteColour',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           label: 'Red',
@@ -180,7 +180,7 @@ const formFields = [
       label: 'Sample date field',
       hint: 'Enter a date',
       fieldName: 'myDate',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       validation: [
         {
           type: VALIDATE_REQUIRED,
@@ -305,7 +305,7 @@ const SecondPage = () => {
       label: 'What is your favourite colour',
       fieldName: 'favouriteColour',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           label: 'Red',
@@ -342,7 +342,7 @@ const SecondPage = () => {
       label: 'Sample date field',
       hint: 'Enter a date',
       fieldName: 'myDate',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       validation: [
         {
           type: VALIDATE_REQUIRED,

--- a/src/components/__tests__/DisplayForm.test.jsx
+++ b/src/components/__tests__/DisplayForm.test.jsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DisplayForm from '../DisplayForm';
 import {
+  DISPLAY_GROUPED,
   FIELD_AUTOCOMPLETE,
   FIELD_CONDITIONAL,
   FIELD_EMAIL,
@@ -122,7 +123,7 @@ describe('Display Form', () => {
       label: 'This is a radio button set',
       fieldName: 'radioButtonSet',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       hint: 'radio hint',
       radioOptions: [
         {
@@ -251,7 +252,7 @@ describe('Display Form', () => {
       label: 'This is a radio button set',
       fieldName: 'radioButtonSet',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       hint: 'radio hint',
       radioOptions: [
         {
@@ -276,7 +277,7 @@ describe('Display Form', () => {
       label: 'This is a radio set with a conditional field',
       fieldName: 'radioWithConditional',
       hint: 'Hint for conditional set',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           radioField: true,

--- a/src/components/__tests__/DisplayFormTests/DisplayLayout.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayLayout.test.jsx
@@ -1,0 +1,170 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import {
+  DISPLAY_DETAILS,
+  DISPLAY_GROUPED,
+  DISPLAY_SINGLE,
+  FIELD_RADIO,
+  FIELD_TEXT,
+  SINGLE_PAGE_FORM,
+} from '../../../constants/AppConstants';
+import DisplayForm from '../../DisplayForm';
+
+describe('Display Form, display layout tests', () => {
+  const handleSubmit = jest.fn();
+  const scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+  const formActions = {
+    submit: {
+      label: 'Submit test button',
+    },
+  };
+  const formFields = [
+    {
+      type: FIELD_TEXT,
+      displayType: DISPLAY_DETAILS,
+      label: 'Text input wrapped in details',
+      hint: 'This is a hint for the details input',
+      fieldName: 'textWithDetails',
+      linkText: 'The details link text',
+    },
+    {
+      type: FIELD_TEXT,
+      displayType: DISPLAY_SINGLE,
+      label: 'Basic text input',
+      hint: 'This is a hint for the basic text input',
+      fieldName: 'textSingle',
+    },
+    {
+      type: FIELD_TEXT,
+      label: 'Text input without a displayType defined',
+      hint: 'This is a hint for the text without display type',
+      fieldName: 'textMissingDisplayType',
+    },
+    {
+      type: FIELD_RADIO,
+      label: 'This is a radio button set',
+      fieldName: 'radioButtonSet',
+      className: 'govuk-radios',
+      displayType: DISPLAY_GROUPED,
+      hint: 'radio hint',
+      radioOptions: [
+        {
+          label: 'Radio one',
+          name: 'radioButtonSet',
+          id: 'radioOne',
+          value: 'radioOne',
+          checked: true,
+        },
+        {
+          label: 'Radio two',
+          name: 'radioButtonSet',
+          id: 'radioTwo',
+          value: 'radioTwo',
+          checked: false,
+        },
+        {
+          label: 'Radio three',
+          name: 'radioButtonSet',
+          id: 'radioThree',
+          value: 'radioThree',
+          checked: false,
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('should render a submit button if exist', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formFields}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+  });
+
+  it('should render a details component with an input', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formFields}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('Text input wrapped in details')).toBeInTheDocument();
+    expect(screen.getByText('This is a hint for the details input').outerHTML).toEqual('<div id="textWithDetails-hint" class="govuk-hint">This is a hint for the details input</div>');
+    expect(screen.getByRole('textbox', { name: 'Text input wrapped in details' })).toBeInTheDocument();
+    expect(screen.getByTestId('details-component').outerHTML).toEqual('<details class="govuk-details" data-module="govuk-details" data-testid="details-component"><summary class="govuk-details__summary"><span class="govuk-details__summary-text">The details link text</span></summary><div class="govuk-details__text"><label class="govuk-label" for="textWithDetails-input">Text input wrapped in details</label><div id="textWithDetails-hint" class="govuk-hint">This is a hint for the details input</div><p id="textWithDetails-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> </p><input class="govuk-input" id="textWithDetails-input" name="textWithDetails" type="text" aria-describedby="textWithDetails-hint" value=""></div></details>');
+  });
+
+  it('should render a grouped input', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formFields}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('This is a radio button set')).toBeInTheDocument();
+    expect(screen.getByText('radio hint').outerHTML).toEqual('<div id="radioButtonSet-hint" class="govuk-hint">radio hint</div>');
+    expect(screen.getByRole('group', { name: 'This is a radio button set' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Radio one')).toBeInTheDocument();
+    expect(screen.getByLabelText('Radio two')).toBeInTheDocument();
+    expect(screen.getByLabelText('Radio three')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio one' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio two' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Radio three' })).toBeInTheDocument();
+  });
+
+  it('should render a single input', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formFields}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('Basic text input')).toBeInTheDocument();
+    expect(screen.getByText('This is a hint for the basic text input').outerHTML).toEqual('<div id="textSingle-hint" class="govuk-hint">This is a hint for the basic text input</div>');
+    expect(screen.getByRole('textbox', { name: 'Basic text input' })).toBeInTheDocument();
+  });
+
+  it('should render a single input if the displayType is missing', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formFields}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('Text input without a displayType defined')).toBeInTheDocument();
+    expect(screen.getByText('This is a hint for the text without display type').outerHTML).toEqual('<div id="textMissingDisplayType-hint" class="govuk-hint">This is a hint for the text without display type</div>');
+    expect(screen.getByRole('textbox', { name: 'Text input without a displayType defined' })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/DisplayFormTests/ErrorClearingErrors.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorClearingErrors.test.jsx
@@ -2,6 +2,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  DISPLAY_GROUPED,
   FIELD_CONDITIONAL,
   FIELD_PHONE,
   FIELD_TEXT,
@@ -40,7 +41,7 @@ describe('Display Form', () => {
       label: 'What is your favourite animal',
       fieldName: 'favAnimal',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           radioField: true,

--- a/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
@@ -2,6 +2,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  DISPLAY_GROUPED,
   FIELD_CONDITIONAL,
   FIELD_RADIO,
   FIELD_TEXT,
@@ -40,7 +41,7 @@ describe('Display Form', () => {
       label: 'What is your favourite animal',
       fieldName: 'favAnimal',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           radioField: true,
@@ -126,7 +127,7 @@ describe('Display Form', () => {
       label: 'This is a radio button set',
       fieldName: 'radioButtonSet',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       hint: 'radio hint',
       radioOptions: [
         {

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -130,7 +130,7 @@ const determineFieldType = ({
 
   return (
     <>
-      {fieldDetails.grouped ? (
+      {fieldDetails.displayType === 'grouped' ? (
         <GroupedInputs
           allErrors={allErrors}
           error={error}

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -21,7 +21,7 @@ const DetailsInput = ({
   error, fieldName, fieldToReturn, hint, label, linkText,
 }) => (
   <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
-    <details className="govuk-details" data-module="govuk-details">
+    <details className="govuk-details" data-module="govuk-details" data-testid="details-component">
       <summary className="govuk-details__summary">
         <span className="govuk-details__summary-text">
           {linkText}

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -7,6 +7,8 @@ import {
   FIELD_PHONE,
   FIELD_TEXT,
   FIELD_RADIO,
+  DISPLAY_SINGLE,
+  DISPLAY_GROUPED,
 } from '../../constants/AppConstants';
 import InputAutocomplete from './InputAutocomplete';
 import InputConditional from './InputConditional';
@@ -53,6 +55,7 @@ const SingleInput = ({
 const determineFieldType = ({
   allErrors, error, fieldDetails, parentHandleChange,
 }) => {
+  const displayType = fieldDetails.displayType ? fieldDetails.displayType : DISPLAY_SINGLE;
   let fieldToReturn;
   switch (fieldDetails.type) {
     case FIELD_AUTOCOMPLETE: fieldToReturn = (
@@ -130,17 +133,19 @@ const determineFieldType = ({
 
   return (
     <>
-      {fieldDetails.displayType === 'grouped' ? (
-        <GroupedInputs
-          allErrors={allErrors}
-          error={error}
-          fieldName={fieldDetails.fieldName}
-          fieldToReturn={fieldToReturn}
-          hint={fieldDetails.hint}
-          label={fieldDetails.label}
-        />
-      )
-        : (
+      {displayType === DISPLAY_GROUPED
+        && (
+          <GroupedInputs
+            allErrors={allErrors}
+            error={error}
+            fieldName={fieldDetails.fieldName}
+            fieldToReturn={fieldToReturn}
+            hint={fieldDetails.hint}
+            label={fieldDetails.label}
+          />
+        )}
+      {displayType === DISPLAY_SINGLE
+        && (
           <SingleInput
             error={error}
             fieldName={fieldDetails.fieldName}

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import {
+  DISPLAY_DETAILS,
+  DISPLAY_GROUPED,
+  DISPLAY_SINGLE,
   FIELD_AUTOCOMPLETE,
   FIELD_CONDITIONAL,
   FIELD_EMAIL,
@@ -7,14 +10,38 @@ import {
   FIELD_PHONE,
   FIELD_TEXT,
   FIELD_RADIO,
-  DISPLAY_SINGLE,
-  DISPLAY_GROUPED,
 } from '../../constants/AppConstants';
 import InputAutocomplete from './InputAutocomplete';
 import InputConditional from './InputConditional';
 import InputPhoneNumber from './InputPhoneNumber';
 import InputRadio from './InputRadio';
 import InputText from './InputText';
+
+const DetailsInput = ({
+  error, fieldName, fieldToReturn, hint, label, linkText,
+}) => (
+  <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
+    <details className="govuk-details" data-module="govuk-details">
+      <summary className="govuk-details__summary">
+        <span className="govuk-details__summary-text">
+          {linkText}
+        </span>
+      </summary>
+      <div className="govuk-details__text">
+        <label className="govuk-label" htmlFor={`${fieldName}-input`}>
+          {label}
+        </label>
+        <div id={`${fieldName}-hint`} className="govuk-hint">
+          {hint}
+        </div>
+        <p id={`${fieldName}-error`} className="govuk-error-message">
+          <span className="govuk-visually-hidden">Error:</span> {error}
+        </p>
+        {fieldToReturn}
+      </div>
+    </details>
+  </div>
+);
 
 const GroupedInputs = ({
   error, fieldName, fieldToReturn, hint, label,
@@ -133,6 +160,18 @@ const determineFieldType = ({
 
   return (
     <>
+      {displayType === DISPLAY_DETAILS
+        && (
+          <DetailsInput
+            allErrors={allErrors}
+            error={error}
+            fieldName={fieldDetails.fieldName}
+            fieldToReturn={fieldToReturn}
+            hint={fieldDetails.hint}
+            label={fieldDetails.label}
+            linkText={fieldDetails.linkText}
+          />
+        )}
       {displayType === DISPLAY_GROUPED
         && (
           <GroupedInputs
@@ -168,11 +207,21 @@ determineFieldType.propTypes = {
       fieldName: PropTypes.string.isRequired,
       hint: PropTypes.string,
       label: PropTypes.string.isRequired,
+      linkText: PropTypes.string,
       type: PropTypes.string.isRequired,
       value: PropTypes.string,
     }),
   ),
   parentHandleChange: PropTypes.func.isRequired,
+};
+
+DetailsInput.propTypes = {
+  error: PropTypes.string,
+  fieldName: PropTypes.string.isRequired,
+  fieldToReturn: PropTypes.object.isRequired,
+  hint: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  linkText: PropTypes.string.isRequired,
 };
 
 GroupedInputs.propTypes = {

--- a/src/components/formFields/__tests__/InputConditonal.test.jsx
+++ b/src/components/formFields/__tests__/InputConditonal.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FIELD_CONDITIONAL } from '../../../constants/AppConstants';
+import { DISPLAY_GROUPED, FIELD_CONDITIONAL } from '../../../constants/AppConstants';
 import InputConditional from '../InputConditional';
 
 /*
@@ -16,7 +16,7 @@ describe('Conditional input field generation', () => {
     className: 'govuk-radios',
     label: 'What is your favourite animal',
     fieldName: 'favAnimal',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     radioOptions: [
       {
         radioField: true,
@@ -62,7 +62,7 @@ describe('Conditional input field generation', () => {
     hint: 'A hint on choosing a colour',
     label: 'What is your favourite colour',
     fieldName: 'favColour',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     radioOptions: [
       {
         radioField: true,
@@ -91,7 +91,7 @@ describe('Conditional input field generation', () => {
     hint: 'A hint on choosing a colour',
     label: 'What is your favourite colour',
     fieldName: 'favColour',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     radioOptions: [
       {
         radioField: true,

--- a/src/components/formFields/__tests__/InputRadio.test.jsx
+++ b/src/components/formFields/__tests__/InputRadio.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { DISPLAY_GROUPED } from '../../../constants/AppConstants';
 import InputRadio from '../InputRadio';
 
 /*
@@ -11,7 +12,7 @@ describe('Radio input field generation', () => {
   const parentHandleChange = jest.fn();
   const fieldDetailsBasic = {
     fieldName: 'simpleFieldName',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     label: 'Basic props field radio label',
     radioOptions: [
       {
@@ -26,7 +27,7 @@ describe('Radio input field generation', () => {
   const fieldDetailsAllProps = {
     className: 'govuk-radios govuk-radios--inline',
     fieldName: 'fullFieldName',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     label: 'Full props field radio label',
     hint: 'The hint text',
     value: 'radioOne',
@@ -50,7 +51,7 @@ describe('Radio input field generation', () => {
   };
   const fieldDetailsWithValueSelected = {
     fieldName: 'simpleFieldName',
-    grouped: true,
+    displayType: DISPLAY_GROUPED,
     label: 'Basic props field radio label',
     radioOptions: [
       {

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -1,6 +1,10 @@
 // Site
 export const SERVICE_NAME = 'National Maritime Single Window';
 
+// Forms: display types
+export const DISPLAY_DETAILS = 'details';
+export const DISPLAY_GROUPED = 'grouped';
+export const DISPLAY_SINGLE = 'single';
 // Forms: identifiers
 export const EXPANDED_DETAILS = 'ExpandedDetails';
 export const MULTI_PAGE_FORM = 'multiPageForm';

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -8,6 +8,7 @@ import {
   VALIDATE_MAX_LENGTH,
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED,
+  DISPLAY_GROUPED,
 } from '../../constants/AppConstants';
 import { ERROR_VERIFICATION_FAILED_URL, REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
@@ -79,8 +80,8 @@ const RegisterYourDetails = () => {
     {
       type: FIELD_RADIO,
       className: 'govuk-radios govuk-radios--inline',
+      displayType: DISPLAY_GROUPED,
       fieldName: 'shippingAgent',
-      grouped: true,
       label: 'Is your company a shipping agent?',
       radioOptions: [
         {

--- a/src/pages/Regulatory/CookiePolicy.jsx
+++ b/src/pages/Regulatory/CookiePolicy.jsx
@@ -6,6 +6,7 @@ import {
   CHECKED_TRUE,
   CHECKED_FALSE,
   SINGLE_PAGE_FORM,
+  DISPLAY_GROUPED,
 } from '../../constants/AppConstants';
 import cookieToFind from '../../utils/cookieToFind';
 import { scrollToElementId } from '../../utils/ScrollToElement';
@@ -32,7 +33,7 @@ const CookiePolicy = ({ setIsCookieBannerShown }) => {
       label: 'Do you want to accept analytics cookies?',
       fieldName: 'cookieSettings',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           label: 'Yes',

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import {
+  DISPLAY_DETAILS,
   DISPLAY_GROUPED,
+  DISPLAY_SINGLE,
   FIELD_AUTOCOMPLETE,
   FIELD_CONDITIONAL,
   FIELD_EMAIL,
@@ -37,7 +39,7 @@ const SecondPage = () => {
   const formFields = [
     {
       type: FIELD_EMAIL,
-      displayType: 'details',
+      displayType: DISPLAY_DETAILS,
       label: 'Email',
       hint: 'Enter your resend email',
       fieldName: 'emailAddress',
@@ -50,6 +52,19 @@ const SecondPage = () => {
     },
     {
       type: FIELD_TEXT,
+      label: 'First name missing display type test',
+      hint: 'Enter your first name',
+      fieldName: 'firstName',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your first name',
+        },
+      ],
+    },
+    {
+      type: FIELD_TEXT,
+      displayType: DISPLAY_SINGLE,
       label: 'First name',
       hint: 'Enter your first name',
       fieldName: 'firstName',

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -55,7 +55,7 @@ const SecondPage = () => {
       type: FIELD_TEXT,
       label: 'First name missing display type test',
       hint: 'Enter your first name',
-      fieldName: 'firstName',
+      fieldName: 'firstNameMissing',
       validation: [
         {
           type: VALIDATE_REQUIRED,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import {
+  DISPLAY_GROUPED,
   FIELD_AUTOCOMPLETE,
   FIELD_CONDITIONAL,
+  FIELD_EMAIL,
   FIELD_TEXT,
   FIELD_RADIO,
   CHECKED_FALSE,
@@ -34,6 +36,19 @@ const SecondPage = () => {
   };
   const formFields = [
     {
+      type: FIELD_EMAIL,
+      displayType: 'details',
+      label: 'Email',
+      hint: 'Enter your resend email',
+      fieldName: 'emailAddress',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your email address',
+        },
+      ],
+    },
+    {
       type: FIELD_TEXT,
       label: 'First name',
       hint: 'Enter your first name',
@@ -50,7 +65,7 @@ const SecondPage = () => {
       label: 'What is your favourite colour',
       fieldName: 'favouriteColour',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           label: 'Red',
@@ -93,7 +108,7 @@ const SecondPage = () => {
       label: 'What is your favourite animal',
       fieldName: 'favAnimal',
       className: 'govuk-radios',
-      grouped: true,
+      displayType: DISPLAY_GROUPED,
       radioOptions: [
         {
           radioField: true,

--- a/src/pages/TempPages/SecondPage.jsx
+++ b/src/pages/TempPages/SecondPage.jsx
@@ -41,6 +41,7 @@ const SecondPage = () => {
       type: FIELD_EMAIL,
       displayType: DISPLAY_DETAILS,
       label: 'Email',
+      linkText: 'Click on this link',
       hint: 'Enter your resend email',
       fieldName: 'emailAddress',
       validation: [
@@ -247,6 +248,7 @@ const SecondPage = () => {
       <h1>Second page</h1>
       <p>Click this button to test going to sign in page with navigation state</p>
       <button onClick={forceSignIn} type="button">Force sign in</button>
+      <hr />
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">
           <DisplayForm


### PR DESCRIPTION
# Ticket

NMSW-168

----

## AC

The ticket requires an email input field contained within a details component. 
This PR creates that in our form creator

----

## To test

- run app & login
- open second page
- > the first form field should be a `<details>` link
- click the link
- > the email address field should be displayed
- submit the form
- > it should error as normal
- complete the form and then submit
- > it should continue to the confirmation page as normal


----

## Notes

If you do not expand the details field and click submit it will still error as the validation is set to be required for this form.

To enable this, I've had to change the ternary of grouped vs single to be an option of grouped, details, or single
To prevent existing things breaking I've also set the default to always be `single` so if no display type is passed in the form will render the field as a `single`  component
