### PR TITLE
NMSW-324 Delete draft are you sure routes and skeleton page

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -28,6 +28,7 @@ import {
   TEMPLATE_PAGE_URL,
   VOYAGE_CREW_UPLOAD_URL,
   VOYAGE_CREW_CONFIRMATION_URL,
+  VOYAGE_DELETE_DRAFT_CHECK_URL,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
   VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL,
   VOYAGE_PASSENGERS_URL,
@@ -61,6 +62,7 @@ import PrivacyNotice from './pages/Regulatory/PrivacyNotice';
 // Voyage pages
 import FileUploadConfirmation from './pages/Voyage/FileUploadConfirmation';
 import VoyageCrew from './pages/Voyage/VoyageCrew';
+import VoyageDeleteDraftCheck from './pages/Voyage/VoyageDeleteDraftCheck';
 import VoyageGeneralDeclaration from './pages/Voyage/VoyageGeneralDeclaration';
 import VoyagePassengers from './pages/Voyage/VoyagePassengers';
 import VoyagePassengerUpload from './pages/Voyage/VoyagePassengerUpload';
@@ -106,6 +108,7 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
           <Route path={YOUR_VOYAGES_URL} element={<YourVoyages />} />
           <Route path={VOYAGE_CREW_UPLOAD_URL} element={<VoyageCrew />} />
           <Route path={VOYAGE_CREW_CONFIRMATION_URL} element={<FileUploadConfirmation />} />
+          <Route path={VOYAGE_DELETE_DRAFT_CHECK_URL} element={<VoyageDeleteDraftCheck />} />
           <Route path={VOYAGE_GENERAL_DECLARATION_UPLOAD_URL} element={<VoyageGeneralDeclaration />} />
           <Route path={VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL} element={<FileUploadConfirmation />} />
           <Route path={VOYAGE_PASSENGERS_URL} element={<VoyagePassengers />} />

--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -209,7 +209,7 @@ const DisplayForm = ({
       </div>
 
       <div className="govuk-grid-row">
-        <form id={formId} className="govuk-grid-column-one-half" autoComplete="off">
+        <form id={formId} className="govuk-grid-column-full" autoComplete="off">
           {
             fieldsWithValues.map((field) => {
               const error = errors?.find((errorField) => errorField.name === field.fieldName);

--- a/src/components/formFields/DetermineFieldType.jsx
+++ b/src/components/formFields/DetermineFieldType.jsx
@@ -38,17 +38,54 @@ const DetailsInput = ({
   }, [error]);
 
   return (
-    <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
-      <details className="govuk-details" data-module="govuk-details" data-testid="details-component" open={isOpen}>
-        <summary className="govuk-details__summary">
-          <span className="govuk-details__summary-text">
-            {linkText}
-          </span>
-        </summary>
-        <div className="govuk-details__text">
-          <label className="govuk-label" htmlFor={`${fieldName}-input`}>
-            {label}
-          </label>
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-half">
+        <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
+          <details className="govuk-details" data-module="govuk-details" data-testid="details-component" open={isOpen}>
+            <summary className="govuk-details__summary">
+              <span className="govuk-details__summary-text">
+                {linkText}
+              </span>
+            </summary>
+            <div className="govuk-details__text">
+              <label className="govuk-label" htmlFor={`${fieldName}-input`}>
+                {label}
+              </label>
+              <div id={`${fieldName}-hint`} className="govuk-hint">
+                {hint}
+              </div>
+              <p id={`${fieldName}-error`} className="govuk-error-message">
+                <span className="govuk-visually-hidden">Error:</span> {error}
+              </p>
+              {fieldToReturn}
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const GroupedInputs = ({
+  error, fieldName, fieldToReturn, hint, label, legendAsH1,
+}) => (
+  <div className="govuk-grid-row">
+    <div className="govuk-grid-column-full">
+      <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
+        <fieldset className="govuk-fieldset">
+          {legendAsH1
+            ? (
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 className="govuk-fieldset__heading">
+                  {label}
+                </h1>
+              </legend>
+            )
+            : (
+              <legend className="govuk-fieldset__legend">
+                {label}
+              </legend>
+            )}
           <div id={`${fieldName}-hint`} className="govuk-hint">
             {hint}
           </div>
@@ -56,55 +93,30 @@ const DetailsInput = ({
             <span className="govuk-visually-hidden">Error:</span> {error}
           </p>
           {fieldToReturn}
-        </div>
-      </details>
-    </div>
-  );
-};
-
-const GroupedInputs = ({
-  error, fieldName, fieldToReturn, hint, label, legend,
-}) => (
-  <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
-    <fieldset className="govuk-fieldset">
-      {legend
-        ? (
-          <legend className="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 className="govuk-fieldset__heading">
-              {label}
-            </h1>
-          </legend>
-        )
-        : (
-          <legend className="govuk-fieldset__legend">
-            {label}
-          </legend>
-        )}
-      <div id={`${fieldName}-hint`} className="govuk-hint">
-        {hint}
+        </fieldset>
       </div>
-      <p id={`${fieldName}-error`} className="govuk-error-message">
-        <span className="govuk-visually-hidden">Error:</span> {error}
-      </p>
-      {fieldToReturn}
-    </fieldset>
+    </div>
   </div>
 );
 
 const SingleInput = ({
   error, fieldName, fieldToReturn, hint, label,
 }) => (
-  <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
-    <label className="govuk-label" htmlFor={`${fieldName}-input`}>
-      {label}
-    </label>
-    <div id={`${fieldName}-hint`} className="govuk-hint">
-      {hint}
+  <div className="govuk-grid-row">
+    <div className="govuk-grid-column-one-half">
+      <div className={error ? 'govuk-form-group govuk-form-group--error' : 'govuk-form-group'}>
+        <label className="govuk-label" htmlFor={`${fieldName}-input`}>
+          {label}
+        </label>
+        <div id={`${fieldName}-hint`} className="govuk-hint">
+          {hint}
+        </div>
+        <p id={`${fieldName}-error`} className="govuk-error-message">
+          <span className="govuk-visually-hidden">Error:</span> {error}
+        </p>
+        {fieldToReturn}
+      </div>
     </div>
-    <p id={`${fieldName}-error`} className="govuk-error-message">
-      <span className="govuk-visually-hidden">Error:</span> {error}
-    </p>
-    {fieldToReturn}
   </div>
 );
 
@@ -210,7 +222,7 @@ const determineFieldType = ({
             fieldToReturn={fieldToReturn}
             hint={fieldDetails.hint}
             label={fieldDetails.label}
-            legend={fieldDetails.labelAsH1}
+            legendAsH1={fieldDetails.labelAsH1}
           />
         )}
       {displayType === DISPLAY_SINGLE
@@ -260,7 +272,7 @@ GroupedInputs.propTypes = {
   fieldToReturn: PropTypes.object.isRequired,
   hint: PropTypes.string,
   label: PropTypes.string.isRequired,
-  legend: PropTypes.bool,
+  legendAsH1: PropTypes.bool,
 };
 
 SingleInput.propTypes = {

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -26,6 +26,7 @@ export const ERROR_CREW_DETAILS_UPLOAD_URL = '/create-voyage/check-crew-details'
 export const VOYAGE_CHECK_YOUR_ANSWERS = '/your-voyages'; // TODO: replace this
 export const VOYAGE_CREW_UPLOAD_URL = '/report-voyage/upload-crew-details';
 export const VOYAGE_CREW_CONFIRMATION_URL = '/report-voyage/crew-details-uploaded';
+export const VOYAGE_DELETE_DRAFT_CHECK_URL = '/report-voyage/confirm-delete-draft';
 export const VOYAGE_GENERAL_DECLARATION_UPLOAD_URL = '/report-voyage/upload-general-declaration';
 export const VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL = '/report-voyage/general-declaration-uploaded';
 export const VOYAGE_PASSENGERS_URL = '/report-voyage/passenger-details';

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -1,7 +1,10 @@
+import { useLocation } from 'react-router-dom';
 import { SERVICE_NAME } from '../../constants/AppConstants';
 
 const YourVoyages = () => {
+  const { state } = useLocation();
   document.title = SERVICE_NAME;
+  console.log(state?.confirmationBanner);
   return (
     <>
       <h1 className="govuk-heading-xl govuk-!-margin-bottom-4">Your voyages</h1>

--- a/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
+++ b/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
@@ -1,7 +1,62 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { DISPLAY_GROUPED, FIELD_RADIO, SINGLE_PAGE_FORM } from '../../constants/AppConstants';
+import { VOYAGE_TASK_LIST_URL, YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
+import DisplayForm from '../../components/DisplayForm';
+
 const VoyageDeleteDraftCheck = () => {
-  console.log('delete draft are you sure');
+  const { state } = useLocation();
+  const navigate = useNavigate();
+
+  const formActions = {
+    submit: {
+      className: 'govuk-button',
+      dataModule: 'govuk-button',
+      dataTestid: 'submit-button',
+      label: 'Confirm',
+      type: 'button',
+    },
+  };
+  const formFields = [
+    {
+      type: FIELD_RADIO,
+      label: 'Are you sure you want to delete the draft?',
+      labelAsH1: true,
+      fieldName: 'deleteDraft',
+      className: 'govuk-radios--inline',
+      displayType: DISPLAY_GROUPED,
+      radioOptions: [
+        {
+          label: 'Yes',
+          name: 'deleteDraft',
+          id: 'yes',
+          value: 'deleteDraftYes',
+        },
+        {
+          label: 'No',
+          name: 'deleteDraft',
+          id: 'no',
+          value: 'deleteDraftNo',
+        },
+      ],
+    },
+  ];
+
+  const handleSubmit = (formData) => {
+    if (formData?.formData?.deleteDraft === 'deleteDraftYes') {
+      navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${state?.shipName} deleted.` } } });
+    } else if (formData?.formData?.deleteDraft === 'deleteDraftNo') {
+      navigate(VOYAGE_TASK_LIST_URL);
+    }
+  };
+
   return (
-    <h1>Are you sure</h1>
+    <DisplayForm
+      formId="voyagePassengers"
+      fields={formFields}
+      formActions={formActions}
+      formType={SINGLE_PAGE_FORM}
+      handleSubmit={handleSubmit}
+    />
   );
 };
 

--- a/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
+++ b/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
@@ -1,0 +1,8 @@
+const VoyageDeleteDraftCheck = () => {
+  console.log('delete draft are you sure');
+  return (
+    <h1>Are you sure</h1>
+  );
+};
+
+export default VoyageDeleteDraftCheck;

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import {
   VOYAGE_CHECK_YOUR_ANSWERS,
   VOYAGE_CREW_UPLOAD_URL,
+  VOYAGE_DELETE_DRAFT_CHECK_URL,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
   VOYAGE_PASSENGERS_URL,
   VOYAGE_SUPPORTING_DOCS_UPLOAD_URL,
@@ -31,14 +32,6 @@ const VoyageTaskList = () => {
   const classOptional = 'govuk-tag govuk-tag--blue app-task-list__tag';
   const classNotStarted = 'govuk-tag govuk-tag--grey app-task-list__tag';
   const classCannotStartYet = 'govuk-tag govuk-tag--grey app-task-list__tag';
-
-  const handleDelete = () => {
-    /* TODO: this will direct to an are you sure you want to delete page
-     * which will then return to your voyages
-     * with a confirmation banner
-     */
-    navigate('/');
-  };
 
   return (
     <>
@@ -107,7 +100,7 @@ const VoyageTaskList = () => {
             type="button"
             className="govuk-button govuk-button--warning"
             data-module="govuk-button"
-            onClick={() => handleDelete()}
+            onClick={() => navigate(VOYAGE_DELETE_DRAFT_CHECK_URL, { state: { shipName } })}
           >
             Delete draft
           </button>

--- a/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { YOUR_VOYAGES_URL, VOYAGE_TASK_LIST_URL } from '../../../constants/AppUrlConstants';
+import VoyageDeleteDraftCheck from '../VoyageDeleteDraftCheck';
+
+let mockUseLocationState = { state: {} };
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => mockUseLocationState),
+}));
+
+describe('Voyage delete draft check are you sure page', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockUseLocationState.state = {};
+  });
+
+  it('should render the page', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    render(<VoyageDeleteDraftCheck />);
+    expect(screen.getByRole('heading', { name: 'Are you sure you want to delete the draft?' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Yes' }).outerHTML).toEqual('<input class="govuk-radios__input" id="deleteDraft-input[0]" name="deleteDraft" type="radio" value="deleteDraftYes">');
+    expect(screen.getByRole('radio', { name: 'No' }).outerHTML).toEqual('<input class="govuk-radios__input" id="deleteDraft-input[1]" name="deleteDraft" type="radio" value="deleteDraftNo">');
+    expect(screen.getByRole('button', { name: 'Confirm' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Confirm</button>');
+  });
+
+  it('should go to the your voyages details page, with details for confirmation banner, if user selects YES', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    render(<VoyageDeleteDraftCheck />);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: 'Report for My ship name deleted.' } } });
+  });
+
+  it('should go to the task details page if user selects NO', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    render(<VoyageDeleteDraftCheck />);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'No' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(VOYAGE_TASK_LIST_URL);
+  });
+});


### PR DESCRIPTION
# Ticket

NMSW-324

----

## AC

prototype: /mvp-2/delete-draft

Page | URL | Link type | Link name | Link route | Next page
-- | -- | -- | -- | -- | --
Are you sure delete draft | /report-voyage/confirm-delete-draft | primary button | Confirm | /your-voyages | Yes: Your voyages with confirmation banner
Are you sure delete draft | /report-voyage/confirm-delete-draft | primary button | Confirm | /report-voyage | No: Draft task list



----

## To test

- run tests, all should pass
- run app
- go to `/report-voyage`
- click `delete`
- > you should be taken to `/report-voyage/confirm-delete-draft`
- select no
- click confirm
- > you should be returned to `your-voyage`
- click `delete`
- select `yes`
- click `confirm`
- > you should be taken to `your-voyages`
- > there should be a console log of the ship name

----

## Notes

- the ship name is passed into this page in state as part of this PR
- the ship name is also passed on to the /your-voyages page in state as part of this PR
- the ship name is currently hard coded on the /report-voyage page
- the ship name is NOT displayed in a confirmation banner on /your-pages for this PR, that will be done in a future ticket, it is just console logged for now
