### PR TITLE
Add cucumber report

### DIFF
--- a/.cypress-cucumber-preprocessorrc.json
+++ b/.cypress-cucumber-preprocessorrc.json
@@ -1,0 +1,10 @@
+{
+  "json": {
+    "enabled": true,
+    "output": "reports/cucumber-report.json"
+  },
+  "html": {
+    "enabled": true,
+    "output": "reports/cucumber-report.html"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ docker run -d --name nmswui -p 8080:8080 nmsw-ui .
 ### Run Cypress tests
 **Run all the tests on local environment - replace below command with actual mailslurp API key** *(It executes tests headless mode on Electron Browser)*
 ```sh
-npm run cypress:run:local --env MAIL_API_KEY=<API_KEY> .
+npm run cypress:run:local -- --env MAIL_API_KEY=<API_KEY> .
 ```
 **Run tests on cypress runner on local environment - replace below command with actual mailslurp API key**
 ```sh
-npm run cypress:open:local --env MAIL_API_KEY=<API_KEY> .
+npm run cypress:open:local -- --env MAIL_API_KEY=<API_KEY> .
 ```
 **Run all the tests on development environment - replace below command with actual mailslurp API key** *(It executes tests headless mode on Electron Browser)*
 ```sh
-npm run cypress:run:dev --env MAIL_API_KEY=<API_KEY> .
+npm run cypress:run:dev -- --env MAIL_API_KEY=<API_KEY> .
 ```
 **Run tests on cypress runner on a specific browser on development environment - replace below command with actual mailslurp API key**
 ```sh
-npm run cypress:open:dev --env MAIL_API_KEY=<API_KEY> .
+npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY> .
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ docker run -d --name nmswui -p 8080:8080 nmsw-ui .
 ----
 
 ### Run Cypress tests
+**Run all the tests on local environment - replace below command with actual mailslurp API key** *(It executes tests headless mode on Electron Browser)*
 ```sh
-npx cypress open
+npm run cypress:run:local --env MAIL_API_KEY=<API_KEY> .
+```
+**Run tests on cypress runner on local environment - replace below command with actual mailslurp API key**
+```sh
+npm run cypress:open:local --env MAIL_API_KEY=<API_KEY> .
+```
+**Run all the tests on development environment - replace below command with actual mailslurp API key** *(It executes tests headless mode on Electron Browser)*
+```sh
+npm run cypress:run:dev --env MAIL_API_KEY=<API_KEY> .
+```
+**Run tests on cypress runner on a specific browser on development environment - replace below command with actual mailslurp API key**
+```sh
+npm run cypress:open:dev --env MAIL_API_KEY=<API_KEY> .
 ```

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -37,6 +37,7 @@ async function setupNodeEvents(on, config) {
 
 module.exports = defineConfig({
   e2e: {
+    video: false,
     specPattern: '**/*.feature',
     step_definitions: 'cypress/support/step_definitions/',
     watchForFileChanges: false,


### PR DESCRIPTION
Configured test to  generate basic html report
Modified scripts to run tests with mailslurp
## To test

```
npm run cypress:open:dev --env MAIL_API_KEY=<API_KEY>
```
and select registration.feature