### PR TITLE
NMSW-375 Add webpack bundling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,25 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  entry: ['./src/index.js', './src/assets/main.scss'],
+  entry: {
+    main: path.resolve(__dirname, 'src/index.js'),
+    css: path.resolve(__dirname, 'src/assets/main.scss'),
+    Templates: path.resolve(__dirname, 'src/pages/NavPages/Templates.jsx'), // templates page rarely change so can be served from cache most of the time
+  },
   output: {
+    filename: '[contenthash:8].bundle.js',
+    chunkFilename: '[contenthash].bundle.js',
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.[contenthash].js',
     publicPath: '/',
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+  performance: {
+    maxEntrypointSize: 512000,
+    maxAssetSize: 512000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Ticket

NMSW-375

----

## AC

Improve build bundle sizes

----

## To test

- delete your dist folder (if you have one)
 run npm run build
- in package.json change start to be `"start": "webpack serve --mode production",` (so it runs the production mode)
- run npm start

----

## Notes

1 - increase size from 244 to 512
2 - add webpack standard chunking
3 - bundle Templates component separately as it's large and rarely changes
