### PR TITLE
NMSW-356 Disable submit or show loading spinner when processing

### DIFF
--- a/src/components/DisplayForm.jsx
+++ b/src/components/DisplayForm.jsx
@@ -17,7 +17,7 @@ import { scrollToTop } from '../utils/ScrollToElement';
 import Validator from '../utils/Validator';
 
 const DisplayForm = ({
-  fields, formId, formActions, formType, pageHeading, handleSubmit, children, removeApiErrors,
+  fields, formId, formActions, formType, isLoading, pageHeading, handleSubmit, children, removeApiErrors,
 }) => {
   const fieldsRef = useRef(null);
   const navigate = useNavigate();
@@ -242,10 +242,11 @@ const DisplayForm = ({
           <div className="govuk-button-group">
             <button
               type="button"
-              className="govuk-button"
+              className={isLoading ? 'govuk-button disabled' : 'govuk-button'}
               data-module="govuk-button"
               data-testid="submit-button"
               onClick={(e) => handleValidation(e, { formData })}
+              disabled={isLoading}
             >
               {formActions.submit.label}
             </button>
@@ -291,6 +292,7 @@ DisplayForm.propTypes = {
     }),
   }),
   formType: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool,
   pageHeading: PropTypes.string,
   handleSubmit: PropTypes.func.isRequired,
   removeApiErrors: PropTypes.func,

--- a/src/components/__tests__/DisplayFormTests/DisplayActionButtons.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayActionButtons.test.jsx
@@ -1,0 +1,120 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DisplayForm from '../../DisplayForm';
+import {
+  FIELD_TEXT,
+  SINGLE_PAGE_FORM,
+  VALIDATE_REQUIRED,
+} from '../../../constants/AppConstants';
+import { YOUR_VOYAGES_URL } from '../../../constants/AppUrlConstants';
+
+/*
+ * These tests check that we can pass a variety of
+ * form field objects, and form action objects
+ * to the display component
+ * and it will return HTML that will display a full form
+ * including labels, hints, inputs, buttons based on what we
+ * pass in
+ * It does NOT test a specific form structure or wording
+ * (that is done on the page that hold the specific form)
+ */
+
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUseNavigate,
+}));
+
+describe('Display Form action buttons', () => {
+  const handleSubmit = jest.fn();
+  const scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+  const formActions = {
+    submit: {
+      label: 'Submit test button',
+    },
+    cancel: {
+      label: 'Cancel test button',
+      redirectURL: YOUR_VOYAGES_URL,
+    },
+  };
+  const formActionsSubmitOnly = {
+    submit: {
+      label: 'Submit test button',
+    },
+  };
+  const formRequiredTextInput = [
+    {
+      type: FIELD_TEXT,
+      label: 'Text input',
+      hint: 'This is a hint for a text input',
+      fieldName: 'testField',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your text input value',
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  // ACTION BUTTONS
+  it('should render a submit and cancel button if both exist', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
+  });
+
+  it('should render only a submit button if there is no cancel button', () => {
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('should call handleSubmit function if submit button is clicked and there are no errors', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText('Text input'), 'Hello');
+    expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/DisplayFormTests/DisplayActionButtons.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayActionButtons.test.jsx
@@ -50,6 +50,7 @@ describe('Display Form action buttons', () => {
       type: FIELD_TEXT,
       label: 'Text input',
       hint: 'This is a hint for a text input',
+      isLoading: false,
       fieldName: 'testField',
       validation: [
         {
@@ -116,5 +117,62 @@ describe('Display Form action buttons', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1);
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
     expect(handleSubmit).toHaveBeenCalled();
+  });
+
+  it('should disable the submit button when isLoading is true', () => {
+    // Note: isLoading state is set by the container page so in this test we just test the correct behaviour when the state is true
+    const isLoading = true;
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          isLoading={isLoading}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button disabled" data-module="govuk-button" data-testid="submit-button" disabled="">Submit test button</button>');
+    expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
+  });
+
+  it('should NOT disable the submit button when isLoading is false', () => {
+    // Note: isLoading state is set by the container page so in this test we just test the correct behaviour when the state is true
+    const isLoading = false;
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          isLoading={isLoading}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
+  });
+
+  it('should NOT disable the submit button when isLoading is undefined', () => {
+    // Note: isLoading state is set by the container page so in this test we just test the correct behaviour when the state is true
+    const isLoading = undefined;
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formRequiredTextInput}
+          formActions={formActions}
+          formType={SINGLE_PAGE_FORM}
+          isLoading={isLoading}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
+    expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
   });
 });

--- a/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
@@ -16,7 +16,6 @@ import {
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
-import { YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
 
 /*
  * These tests check that we can pass a variety of
@@ -36,19 +35,10 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockedUseNavigate,
 }));
 
-describe('Display Form', () => {
+describe('Display Form inputs', () => {
   const handleSubmit = jest.fn();
   const scrollIntoViewMock = jest.fn();
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-  const formActions = {
-    submit: {
-      label: 'Submit test button',
-    },
-    cancel: {
-      label: 'Cancel test button',
-      redirectURL: YOUR_VOYAGES_URL,
-    },
-  };
   const formActionsSubmitOnly = {
     submit: {
       label: 'Submit test button',
@@ -279,60 +269,6 @@ describe('Display Form', () => {
 
   beforeEach(() => {
     window.sessionStorage.clear();
-  });
-
-  // ACTION BUTTONS
-  it('should render a submit and cancel button if both exist', () => {
-    render(
-      <MemoryRouter>
-        <DisplayForm
-          formId="testForm"
-          fields={formRequiredTextInput}
-          formActions={formActions}
-          formType={SINGLE_PAGE_FORM}
-          handleSubmit={handleSubmit}
-        />
-      </MemoryRouter>,
-    );
-    expect((screen.getByTestId('submit-button')).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
-    expect((screen.getByTestId('cancel-button')).outerHTML).toEqual('<button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-testid="cancel-button">Cancel test button</button>');
-  });
-
-  it('should render only a submit button if there is no cancel button', () => {
-    render(
-      <MemoryRouter>
-        <DisplayForm
-          formId="testForm"
-          fields={formRequiredTextInput}
-          formActions={formActionsSubmitOnly}
-          formType={SINGLE_PAGE_FORM}
-          handleSubmit={handleSubmit}
-        />
-      </MemoryRouter>,
-    );
-    expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
-    expect(screen.getAllByRole('button')).toHaveLength(1);
-  });
-
-  it('should call handleSubmit function if submit button is clicked and there are no errors', async () => {
-    const user = userEvent.setup();
-    render(
-      <MemoryRouter>
-        <DisplayForm
-          formId="testForm"
-          fields={formRequiredTextInput}
-          formActions={formActionsSubmitOnly}
-          formType={SINGLE_PAGE_FORM}
-          handleSubmit={handleSubmit}
-        />
-      </MemoryRouter>,
-    );
-
-    await user.type(screen.getByLabelText('Text input'), 'Hello');
-    expect(screen.getByTestId('submit-button').outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Submit test button</button>');
-    expect(screen.getAllByRole('button')).toHaveLength(1);
-    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
-    expect(handleSubmit).toHaveBeenCalled();
   });
 
   // INPUTS

--- a/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
@@ -1,7 +1,7 @@
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import DisplayForm from '../DisplayForm';
+import DisplayForm from '../../DisplayForm';
 import {
   DISPLAY_GROUPED,
   FIELD_AUTOCOMPLETE,
@@ -15,7 +15,7 @@ import {
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_PHONE_NUMBER,
   VALIDATE_REQUIRED,
-} from '../../constants/AppConstants';
+} from '../../../constants/AppConstants';
 
 /*
  * These tests check that we can pass a variety of

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
@@ -21,6 +22,7 @@ import {
   REGISTER_EMAIL_CHECK_URL,
 } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+import LoadingSpinner from '../../components/LoadingSpinner';
 import Auth from '../../utils/Auth';
 
 const SupportingText = () => (
@@ -32,6 +34,7 @@ const SupportingText = () => (
 
 const RegisterEmailAddress = () => {
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
   document.title = 'What is your email address';
 
   const formActions = {
@@ -101,6 +104,7 @@ const RegisterEmailAddress = () => {
   };
 
   const handleSubmit = async (formData) => {
+    const timer = setTimeout(() => setIsLoading(true), 750);
     const dataToSubmit = {
       email: formData.formData.emailAddress,
     };
@@ -119,9 +123,13 @@ const RegisterEmailAddress = () => {
         // 500 errors will fall into this bucket
         navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_EMAIL_URL } });
       }
+    } finally {
+      setIsLoading(false);
+      clearTimeout(timer);
     }
   };
 
+  if (isLoading) { return (<LoadingSpinner />); }
   return (
     <DisplayForm
       formId="formRegisterEmailAddress"
@@ -130,6 +138,7 @@ const RegisterEmailAddress = () => {
       formType={SINGLE_PAGE_FORM}
       pageHeading="What is your email address"
       handleSubmit={handleSubmit}
+      isLoading={isLoading}
     >
       <SupportingText />
     </DisplayForm>

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -136,9 +136,9 @@ const RegisterEmailAddress = () => {
       fields={formFields}
       formActions={formActions}
       formType={SINGLE_PAGE_FORM}
+      isLoading={isLoading}
       pageHeading="What is your email address"
       handleSubmit={handleSubmit}
-      isLoading={isLoading}
     >
       <SupportingText />
     </DisplayForm>

--- a/src/pages/Register/RegisterEmailResend.jsx
+++ b/src/pages/Register/RegisterEmailResend.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
@@ -29,6 +30,7 @@ const SupportingText = () => (
 const RegisterEmailResend = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
   document.title = 'Resend verification email';
 
   const formActions = {
@@ -74,10 +76,13 @@ const RegisterEmailResend = () => {
         // 500 errors will fall into this bucket
         navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_EMAIL_URL } });
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
   const handleSubmit = async (formData) => {
+    setIsLoading(true);
     try {
       const controller = new AbortController();
       const response = await axios.post(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT, {
@@ -88,15 +93,18 @@ const RegisterEmailResend = () => {
 
       if (response.status === 204) {
         navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
+        setIsLoading(false);
       }
     } catch (err) {
       if (err?.response?.data?.message === USER_ALREADY_VERIFIED) {
         navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: formData.formData.emailAddress } } });
+        setIsLoading(false);
       } else if (err?.response?.data?.message === USER_NOT_REGISTERED) {
         registerNewEmail(formData.formData.emailAddress);
       } else {
         // 500 errors will fall into this bucket
         navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_EMAIL_URL } });
+        setIsLoading(false);
       }
     }
   };
@@ -107,6 +115,7 @@ const RegisterEmailResend = () => {
       fields={formFields}
       formActions={formActions}
       formType={SINGLE_PAGE_FORM}
+      isLoading={isLoading}
       pageHeading="Request a new verification link"
       handleSubmit={handleSubmit}
     >

--- a/src/pages/Register/RegisterEmailVerified.jsx
+++ b/src/pages/Register/RegisterEmailVerified.jsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import LoadingSpinner from '../../components/LoadingSpinner';
 import { REGISTER_CHECK_TOKEN_ENDPOINT, TOKEN_INVALID, TOKEN_USED_TO_REGISTER } from '../../constants/AppAPIConstants';
 import {
   ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
@@ -64,7 +65,7 @@ const RegisterEmailVerified = () => {
     fetchData();
   }, [tokenToCheck, emailAddress]);
 
-  if (Object.entries(pageContent).length === 0) { setPageContent({ blurb: '...Loading' }); }
+  if (Object.entries(pageContent).length === 0) { return (<LoadingSpinner />); }
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { REGISTER_ACCOUNT_ENDPOINT, TOKEN_INVALID } from '../../constants/AppAPIConstants';
@@ -27,6 +28,7 @@ const SupportingText = () => (
 const RegisterYourPassword = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
+  const [isLoading, setIsLoading] = useState(false);
   document.title = 'Create a password';
 
   const formActions = {
@@ -78,6 +80,7 @@ const RegisterYourPassword = () => {
   ];
 
   const handleSubmit = async (formData) => {
+    setIsLoading(true);
     // combine data from previous page of form
     const dataMerged = { ...state?.dataToSubmit, ...formData.formData };
     const dataToSubmit = {
@@ -111,6 +114,8 @@ const RegisterYourPassword = () => {
       } else {
         navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REGISTER_PASSWORD_URL } });
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -120,6 +125,7 @@ const RegisterYourPassword = () => {
       fields={formFields}
       formActions={formActions}
       formType={MULTI_PAGE_FORM}
+      isLoading={isLoading}
       pageHeading="Create a password"
       handleSubmit={handleSubmit}
     >


### PR DESCRIPTION
# Ticket

NMSW-356

----

## AC

Given a submit button has been clicked
And there are no errors (aka form is submitting)
Then the submit button should become disabled

_When a component is waiting on an API call response
Then a loading spinner should show_

The scenario we currently have to test this is the verify email scenario
And the loading spinner only shows when the site is slow

----

## To test
- in dev tools, network tab, set your speed to slow 3G
- run app
- go to `/create-account/email-address`
- click `send confirmation email` button
- > page should show errors
- > `send confirmation email` button should remain enabled
- enter valid email addresses
- click `send confirmation email` button
- > you should see the button change to disabled state before the submit completes and the next page loads
- get your link to verify your email address
- paste the link into the address bar where you have slow 3G loading
- > you should see a loading spinner on the page before the page content loads


----

## Notes
