### PR TITLE
Webpack: revert optimisation changes from PR166

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,25 +5,11 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  entry: {
-    main: path.resolve(__dirname, 'src/index.js'),
-    css: path.resolve(__dirname, 'src/assets/main.scss'),
-    Templates: path.resolve(__dirname, 'src/pages/NavPages/Templates.jsx'), // templates page rarely change so can be served from cache most of the time
-  },
+  entry: ['./src/index.js', './src/assets/main.scss'],
   output: {
-    filename: '[contenthash:8].bundle.js',
-    chunkFilename: '[contenthash].bundle.js',
     path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.[contenthash].js',
     publicPath: '/',
-  },
-  optimization: {
-    splitChunks: {
-      chunks: 'all',
-    },
-  },
-  performance: {
-    maxEntrypointSize: 512000,
-    maxAssetSize: 512000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Revert https://github.com/UKHomeOffice/nmsw-ui/pull/166 changes as they've caused FOUC (flash of unstyled content) issues and we need to find a new fix