### PR TITLE
NMSW-257 Sign out

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -4,7 +4,7 @@ import { apiUrl } from './Config';
 export const REGISTER_ACCOUNT_ENDPOINT = `${apiUrl}/registration`;
 export const REGISTER_CHECK_TOKEN_ENDPOINT = `${apiUrl}/check-token`;
 export const REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT = `${apiUrl}/resend-verification-email`;
-export const SIGN_IN = `${apiUrl}/sign-in`;
+export const SIGN_IN_ENDPOINT = `${apiUrl}/sign-in`;
 
 // Responses
 export const TOKEN_INVALID = 'Token is invalid or it has expired';

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -5,6 +5,7 @@ export const REGISTER_ACCOUNT_ENDPOINT = `${apiUrl}/registration`;
 export const REGISTER_CHECK_TOKEN_ENDPOINT = `${apiUrl}/check-token`;
 export const REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT = `${apiUrl}/resend-verification-email`;
 export const SIGN_IN_ENDPOINT = `${apiUrl}/sign-in`;
+export const SIGN_OUT_ENDPOINT = `${apiUrl}/sign-out`;
 
 // Responses
 export const TOKEN_INVALID = 'Token is invalid or it has expired';

--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   Link, NavLink, useLocation, useNavigate,
 } from 'react-router-dom';
+import axios from 'axios';
 import { SERVICE_NAME } from '../constants/AppConstants';
 import {
   YOUR_VOYAGES_PAGE_NAME,
@@ -11,6 +12,7 @@ import {
   TEMPLATE_PAGE_NAME,
   SIGN_IN_URL,
 } from '../constants/AppUrlConstants';
+import { SIGN_OUT_ENDPOINT } from '../constants/AppAPIConstants';
 import useUserIsPermitted from '../hooks/useUserIsPermitted';
 import Auth from '../utils/Auth';
 
@@ -61,6 +63,21 @@ const Nav = () => {
 
   const removeFormData = () => {
     sessionStorage.removeItem('formData');
+  };
+
+  const handleSignOut = async () => {
+    try {
+      const response = await axios.post(SIGN_OUT_ENDPOINT, {}, {
+        headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+      });
+      if (response.status === 200) {
+        Auth.logout();
+        navigate(SIGN_IN_URL);
+      }
+    } catch (err) {
+      Auth.logout();
+      navigate(SIGN_IN_URL);
+    }
   };
 
   useEffect(() => {
@@ -138,7 +155,7 @@ const Nav = () => {
                 </li>
               ))}
               <li className="govuk-header__navigation-item">
-                <NavLink to={YOUR_VOYAGES_URL} className="govuk-header__link" onClick={() => { Auth.logout(); navigate(SIGN_IN_URL); }}>Sign out</NavLink>
+                <NavLink to={YOUR_VOYAGES_URL} className="govuk-header__link" onClick={handleSignOut}>Sign out</NavLink>
                 {/* Link tag cannot be used as we do not have a signout route */}
               </li>
             </ul>

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -16,7 +16,7 @@ import {
   REGISTER_EMAIL_RESEND_URL,
 } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
-import { SIGN_IN, USER_NOT_VERIFIED, USER_SIGN_IN_DETAILS_INVALID } from '../../constants/AppAPIConstants';
+import { SIGN_IN_ENDPOINT, USER_NOT_VERIFIED, USER_SIGN_IN_DETAILS_INVALID } from '../../constants/AppAPIConstants';
 import Auth from '../../utils/Auth';
 import { scrollToTop } from '../../utils/ScrollToElement';
 
@@ -75,7 +75,7 @@ const SignIn = () => {
 
   const handleSubmit = async ({ formData }) => {
     try {
-      const response = await axios.post(SIGN_IN, formData);
+      const response = await axios.post(SIGN_IN_ENDPOINT, formData);
       if (response.data.token) { Auth.storeToken(response.data.token); }
       if (state?.redirectURL) {
         navigate(state.redirectURL);

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import SignIn from './SignIn';
-import { SIGN_IN, USER_NOT_VERIFIED, USER_SIGN_IN_DETAILS_INVALID } from '../../constants/AppAPIConstants';
+import { SIGN_IN_ENDPOINT, USER_NOT_VERIFIED, USER_SIGN_IN_DETAILS_INVALID } from '../../constants/AppAPIConstants';
 import {
   MESSAGE_URL, REGISTER_EMAIL_RESEND_URL, SIGN_IN_URL, YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
@@ -151,7 +151,7 @@ describe('Sign in tests', () => {
     const user = userEvent.setup();
 
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(200, {
         token: '123',
       });
@@ -168,7 +168,7 @@ describe('Sign in tests', () => {
     const user = userEvent.setup();
 
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(200, {
         token: '123',
       });
@@ -190,7 +190,7 @@ describe('Sign in tests', () => {
     window.sessionStorage.setItem('formData', JSON.stringify({ testField: 'Hello Test Field', radioButtonSet: 'radioOne' }));
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(200, {
         token: '123',
       });
@@ -208,7 +208,7 @@ describe('Sign in tests', () => {
     const user = userEvent.setup();
 
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(401, {
         message: USER_SIGN_IN_DETAILS_INVALID,
       });
@@ -225,7 +225,7 @@ describe('Sign in tests', () => {
     const user = userEvent.setup();
 
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(401, {
         message: USER_NOT_VERIFIED,
       });
@@ -241,7 +241,7 @@ describe('Sign in tests', () => {
   it('should redirect to error page if 500 response received', async () => {
     const user = userEvent.setup();
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(500);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
@@ -258,7 +258,7 @@ describe('Sign in tests', () => {
     const user = userEvent.setup();
 
     mockAxios
-      .onPost(SIGN_IN)
+      .onPost(SIGN_IN_ENDPOINT)
       .reply(401, {
         message: USER_SIGN_IN_DETAILS_INVALID,
       });


### PR DESCRIPTION
# Ticket

NMSW-257

----

## AC

As a signed in user
I want to sign out
So my session finishes
 
Given a user has an active authentication token
Then there is a sign out option on the nav bar

Given a user clicks on sign out
Then their session data is cleared (including their auth token)
And a POST is made to /sign-out to blacklist the token
And they are taken to the landing page

----

## To test

- sign in
- > you should have a sign out option in the nav
- open dev tools, network tab
- click sign out
- > you should be taken to the sign in page
- > you should have a POST request to the /sign-out endpoint
- open dev tools and check the session
- > there should be no session data for NMSW

----

## Notes
