### PR TITLE
NMSW-392 Require a number in phone number fields

### DIFF
--- a/src/components/__tests__/DisplayFormTests/ErrorSpecialRules.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorSpecialRules.test.jsx
@@ -237,6 +237,26 @@ describe('Display Form', () => {
     expect(screen.getAllByText('Enter a telephone number in the correct format')).toHaveLength(2);
   });
 
+  it('should return an error if a phone number has no numbers in it', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <DisplayForm
+          formId="testForm"
+          fields={formPhonePatterns}
+          formActions={formActionsSubmitOnly}
+          formType={SINGLE_PAGE_FORM}
+          handleSubmit={handleSubmit}
+        />
+      </MemoryRouter>,
+    );
+    await user.type(screen.getByLabelText('Telephone number'), '()++-- ..)');
+    await user.click(screen.getByRole('button', { name: 'Submit test button' }));
+
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
+    expect(screen.getAllByText('Enter a telephone number in the correct format')).toHaveLength(2);
+  });
+
   it('should NOT return an error if a phone number has characters that ARE in the defined accepted numsymbol list', async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/formFields/__tests__/InputText.test.jsx
+++ b/src/components/formFields/__tests__/InputText.test.jsx
@@ -1,5 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { FIELD_EMAIL, FIELD_PASSWORD, FIELD_TEXT } from '../../../constants/AppConstants';
+import {
+  FIELD_EMAIL,
+  FIELD_PASSWORD,
+  FIELD_PHONE,
+  FIELD_TEXT,
+} from '../../../constants/AppConstants';
 import InputText from '../InputText';
 
 /*
@@ -81,6 +86,18 @@ describe('Text input field generation', () => {
     );
 
     expect(screen.getByTestId('passwordField')).toHaveAttribute('type', 'password');
+  });
+
+  it('should render the input with type of tel if phone passed', () => {
+    render(
+      <InputText
+        fieldDetails={fieldDetailsAllProps}
+        handleChange={parentHandleChange}
+        type={FIELD_PHONE}
+      />,
+    );
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' })).toHaveAttribute('type', 'tel');
   });
 
   it('should render the default value in the input text field when one is provided', () => {

--- a/src/utils/Validator.jsx
+++ b/src/utils/Validator.jsx
@@ -53,7 +53,9 @@ const validateField = ({ type, value, condition }) => {
       }
       break;
     case VALIDATE_PHONE_NUMBER:
-      if (value && !/^[+(\s.\-/\d)]{0,}$/i.test(value)) {
+      if (value && (value.replace(/[()+-. ]/g, '') === '')) { // value has no numbers
+        response = 'error';
+      } else if (value && !/^[+(\s.\-/\d)]{0,}$/i.test(value)) { // value has characters we don't allow e.g. letters
         response = 'error';
       }
       break;


### PR DESCRIPTION
# Ticket

NMSW-392

----

## AC

Fields with phone number validation currently allow you to enter only valid symbols and no numbers.
A number should be required

----

## To test

- log in
- go to `your details`
- go to `change your details`
- enter just symbols e.g. `()+`
- click submit
- > you should get an invalid format error
- enter letters
- click submit
- > you should see an error
- enter just numbers
- click submit
- > you should not see an error
- enter numbers and allowed symbols
- click submit
- > you should not see an error

----

## Notes

Added a test to check input display with type tel as well