### PR TITLE
NMSW-408 Cypress: Add body with registered email address to the DELETE user call

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -89,6 +89,9 @@ Cypress.Commands.add('removeTestUser', () => {
             url: `${apiServer}/user`,
             auth: {
               'bearer': token
+            },
+            body: {
+              email: regEmail,
             }
           }
       )


### PR DESCRIPTION
# Ticket

NMSW-408

----

## AC

The test user should be deleted after each registration test runs

----

## To test

Run Cypress registration tests

----

## Notes

Discovered endpoint now needs the Bearer token, and it's associated email address in the body of the request
Updated and tests should now pass
