### PR TITLE
NMSW-401 Add case for expired token to the create voyage API call

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -11,6 +11,7 @@ export const SIGN_OUT_ENDPOINT = `${apiUrl}/sign-out`;
 export const CREATE_VOYAGE_ENDPOINT = `${apiUrl}/user/declaration`;
 
 // Responses
+export const TOKEN_EXPIRED = 'Token has expired';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';
 export const TOKEN_USED_TO_REGISTER = 'Token was already used';
 export const USER_ALREADY_REGISTERED = 'User is already registered';

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -56,6 +56,7 @@ const YourVoyages = () => {
       if (err?.response?.status === 422) {
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
       } else if (err?.response?.message === TOKEN_EXPIRED) {
+        Auth.removeToken();
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
       } else {
         setIsError(true);

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -55,7 +55,7 @@ const YourVoyages = () => {
       // 422 missing segments = missing bearer token for this endpoint
       if (err?.response?.status === 422) {
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
-      } else if (err?.response?.message === TOKEN_EXPIRED) {
+      } else if (err?.response?.data?.msg === TOKEN_EXPIRED) {
         Auth.removeToken();
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
       } else {

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { CREATE_VOYAGE_ENDPOINT } from '../../constants/AppAPIConstants';
+import { CREATE_VOYAGE_ENDPOINT, TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
@@ -54,6 +54,8 @@ const YourVoyages = () => {
     } catch (err) {
       // 422 missing segments = missing bearer token for this endpoint
       if (err?.response?.status === 422) {
+        navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+      } else if (err?.response?.message === TOKEN_EXPIRED) {
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
       } else {
         setIsError(true);

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { CREATE_VOYAGE_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { CREATE_VOYAGE_ENDPOINT, TOKEN_EXPIRED } from '../../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
@@ -81,6 +81,21 @@ describe('Your voyages page tests', () => {
     user.click(screen.getByRole('button', { name: 'Report a voyage' }));
     await waitFor(() => {
       expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+    });
+  });
+
+  it('should redirect to sign in if Report a voyage button click returns a 401 token expired', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPost(CREATE_VOYAGE_ENDPOINT)
+      .reply(401, { msg: TOKEN_EXPIRED });
+
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    await screen.findByRole('button', { name: 'Report a voyage' });
+    user.click(screen.getByRole('button', { name: 'Report a voyage' }));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+      expect(sessionStorage.getItem('token')).toBe(null);
     });
   });
 

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -11,6 +11,10 @@ class Auth {
     sessionStorage.clear();
   }
 
+  static removeToken() {
+    sessionStorage.removeItem('token');
+  }
+
   static isAuthorized() {
     return this.retrieveToken();
   }

--- a/src/utils/__tests__/Auth.test.js
+++ b/src/utils/__tests__/Auth.test.js
@@ -27,6 +27,14 @@ describe('Auth.js', () => {
     expect(sessionStorage.getItem('token')).toBe(null);
   });
 
+  it('should only clear token from session storage', () => {
+    sessionStorage.setItem('token', testToken);
+    sessionStorage.setItem('formData', 'John Doe');
+    Auth.removeToken();
+    expect(sessionStorage.getItem('token')).toBe(null);
+    expect(sessionStorage.getItem('formData')).toBe('John Doe');
+  });
+
   describe('isAuthorised', () => {
     it('should be truthy when a token is in session storage', () => {
       sessionStorage.setItem('token', testToken);


### PR DESCRIPTION
# Ticket

NMSW-401

----

## AC

Given my token has expired
When I click on report a voyage
Then I am directed to the sign in page

----

## To test

- Run the app
- Sign in
- Wait for token to expire (Devops can reduce token expiry time for testing)
- Click on report a voyage
- It should redirect you to the sign in page
- You should not see the token in session storage

----

## Notes
