### PR TITLE
NMSW-268 Pass state in and out of sign in page on redirects

### DIFF
--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -14,6 +14,7 @@ export const REGISTER_DETAILS_URL = '/create-account/your-details';
 export const REGISTER_PASSWORD_URL = '/create-account/your-password';
 export const SIGN_IN_PAGE_NAME = 'Sign in';
 export const SIGN_IN_URL = '/sign-in';
+export const LOGGED_IN_LANDING = '/your-voyages';
 
 // Regulatory pages
 export const ACCESSIBILITY_URL = '/accessibility-statement';

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -12,7 +12,7 @@ import {
   MESSAGE_URL,
   REGISTER_ACCOUNT_URL,
   SIGN_IN_URL,
-  YOUR_VOYAGES_URL,
+  LOGGED_IN_LANDING,
   REGISTER_EMAIL_RESEND_URL,
 } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
@@ -80,7 +80,7 @@ const SignIn = () => {
       if (state?.redirectURL) {
         navigate(state.redirectURL, { state });
       } else {
-        navigate(YOUR_VOYAGES_URL);
+        navigate(LOGGED_IN_LANDING);
       }
     } catch (err) {
       if (err?.response?.data?.message === USER_SIGN_IN_DETAILS_INVALID) {

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -78,7 +78,7 @@ const SignIn = () => {
       const response = await axios.post(SIGN_IN_ENDPOINT, formData);
       if (response.data.token) { Auth.storeToken(response.data.token); }
       if (state?.redirectURL) {
-        navigate(state.redirectURL);
+        navigate(state.redirectURL, { state });
       } else {
         navigate(YOUR_VOYAGES_URL);
       }

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -273,4 +273,24 @@ describe('Sign in tests', () => {
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
     expect(screen.queryByText('Email and password combination is invalid')).not.toBeInTheDocument();
   });
+
+  it('should redirect to redirectURL on successful sign in if one in state, and pass the state through', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState.state = {
+      redirectURL: '/thisurl',
+      otherState: 'another piece of state',
+    };
+    mockAxios
+      .onPost(SIGN_IN_ENDPOINT)
+      .reply(200, {
+        token: '123',
+      });
+
+    render(<MemoryRouter><SignIn /></MemoryRouter>);
+
+    await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
+    await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith('/thisurl', { state: { redirectURL: '/thisurl', otherState: 'another piece of state' } });
+  });
 });

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -4,9 +4,16 @@ import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import SignIn from './SignIn';
-import { SIGN_IN_ENDPOINT, USER_NOT_VERIFIED, USER_SIGN_IN_DETAILS_INVALID } from '../../constants/AppAPIConstants';
 import {
-  MESSAGE_URL, REGISTER_EMAIL_RESEND_URL, SIGN_IN_URL, YOUR_VOYAGES_URL,
+  SIGN_IN_ENDPOINT,
+  USER_NOT_VERIFIED,
+  USER_SIGN_IN_DETAILS_INVALID,
+} from '../../constants/AppAPIConstants';
+import {
+  MESSAGE_URL,
+  REGISTER_EMAIL_RESEND_URL,
+  SIGN_IN_URL,
+  LOGGED_IN_LANDING,
 } from '../../constants/AppUrlConstants';
 
 const mockUseLocationState = { state: {} };
@@ -161,7 +168,7 @@ describe('Sign in tests', () => {
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
     await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
     await user.click(screen.getByTestId('submit-button'));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(YOUR_VOYAGES_URL);
+    expect(mockedUseNavigate).toHaveBeenCalledWith(LOGGED_IN_LANDING);
   });
 
   it('should store token in session storage if sign in is successful', async () => {

--- a/src/pages/Voyage/VoyageGeneralDeclaration.jsx
+++ b/src/pages/Voyage/VoyageGeneralDeclaration.jsx
@@ -1,7 +1,9 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { DownloadFile } from '../../utils/DownloadFile';
 import {
+  SIGN_IN_URL,
   VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL,
+  VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
 import Message from '../../components/Message';
@@ -15,7 +17,13 @@ const VoyageUploadGeneralDeclaration = () => {
     console.log('Gen Dec', state?.declarationId);
     // this will be refactored once we have the upload file component
     // for now it just takes the declaration ID and passes it to the next page
-    navigate(VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL, { state: { fileType: 'General Declaration', declarationId: state?.declarationId } });
+
+    // for testing the sign in flow returning declaration ID, adding a redirect to sign in if no token
+    if (!sessionStorage.getItem('token')) {
+      navigate(SIGN_IN_URL, { state: { redirectURL: VOYAGE_GENERAL_DECLARATION_UPLOAD_URL, fileType: 'General Declaration', declarationId: state?.declarationId } });
+    } else {
+      navigate(VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL, { state: { fileType: 'General Declaration', declarationId: state?.declarationId } });
+    }
   };
 
   if (!state?.declarationId) {

--- a/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import userEvent from '@testing-library/user-event';
-import { VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL, YOUR_VOYAGES_URL } from '../../../constants/AppUrlConstants';
+import { YOUR_VOYAGES_URL } from '../../../constants/AppUrlConstants';
 import VoyageGeneralDeclaration from '../VoyageGeneralDeclaration';
 
 const mockUseLocationState = { state: {} };
@@ -34,14 +33,5 @@ describe('Voyage general declaration page', () => {
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
-  });
-
-  it('should go to the confirmation of upload on save and continue', async () => {
-    mockUseLocationState.state = { fileType: 'FAL Name', declarationId: '123' };
-    const user = userEvent.setup();
-    render(<MemoryRouter><VoyageGeneralDeclaration /></MemoryRouter>);
-    expect(screen.getByRole('button', { name: 'Save and continue' })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Save and continue' }));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL, { state: { fileType: 'General Declaration', declarationId: '123' } });
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-268

----

## AC

In preparation for NMSW-268's file uploads for declarations
We need to be able to redirect a user into sign in and back to the voyage page, persisting their declaration id

----

## To test

- login
- start a declaration
- delete your token
- click submit button
- > you should be taken to sign in page
- sign in
- > you should be returned to the general declaration upload page

----

## Notes
