### PR TITLE
NMSW-268 Pass state back out of Generic Message if exists

### DIFF
--- a/src/pages/Message/GenericMessage.jsx
+++ b/src/pages/Message/GenericMessage.jsx
@@ -22,7 +22,7 @@ const GenericMessage = () => {
           </button>
         )}
         {!state.button && (
-          <Link to={state?.redirectURL || LANDING_URL}>Click here to continue</Link>
+          <Link to={state?.redirectURL || LANDING_URL} state={state}>Click here to continue</Link>
         )}
       </div>
     </div>

--- a/src/pages/Message/__tests__/GenericMessage.test.jsx
+++ b/src/pages/Message/__tests__/GenericMessage.test.jsx
@@ -40,7 +40,7 @@ describe('Error page tests', () => {
 
     await waitFor(() => {
       expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, {
-        preventScrollReset: undefined, relative: undefined, replace: false, state: undefined,
+        preventScrollReset: undefined, relative: undefined, replace: false, state: { redirectURL: SIGN_IN_URL },
       }); // params on Link generated links by default
     });
   });
@@ -54,7 +54,7 @@ describe('Error page tests', () => {
 
     await waitFor(() => {
       expect(mockedUseNavigate).toHaveBeenCalledWith(LANDING_URL, {
-        preventScrollReset: undefined, relative: undefined, replace: true, state: undefined,
+        preventScrollReset: undefined, relative: undefined, replace: true, state: {},
       }); // params on Link generated links by default
     });
   });


### PR DESCRIPTION
# Ticket

NMSW-268

----

## AC

Given I have passed state into the Generic Message page
When I click the 'next' link
That state should be passed on to the next page

----

## To test

Review and run unit tests as this does not have a UI enabled use case yet (coming in next story)

----

## Notes
