### PR TITLE
NMSW-387 Flash of cookie banner on page load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import { NO_BACK_LINKS, TOP_LEVEL_PAGES } from './constants/AppUrlConstants';
 const App = () => {
   const cookiePreference = cookieToFind('cookiePreference');
   const [isCookieBannerShown, setIsCookieBannerShown] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const topLevelPage = TOP_LEVEL_PAGES.includes(pathname);
@@ -24,6 +25,7 @@ const App = () => {
     if (cookiePreference !== null) {
       setIsCookieBannerShown(false);
     }
+    setIsLoading(false);
   }, [cookiePreference]);
 
   useEffect(() => {
@@ -32,6 +34,8 @@ const App = () => {
       sessionStorage.removeItem('formData');
     }
   }, [pathname]);
+
+  if (isLoading) { return null; }
 
   return (
     <>


### PR DESCRIPTION
# Ticket

NMSW-387

----

## AC

ISSUE
On initial page load, there is a flash of the cookie banner before the main page loads
 
EXPECTED BEHAVIOUR
Cookie banner should not flash
Cookie banner should only load if no cookie preference is found in browser cookies

----

## To test

- Run app
- In the code go to app
- Add `debugger` to the top of the App function
- Return to the app
- Click the arrow a couple of times
- > You should not see a flash of the cookie banner in the steps before the content loads
- Make sure the app works on page refresh AND when the network is set to slow 3G

----

## Notes
