### PR TITLE
Remove unneeded linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,6 @@
     "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" } ],
     "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignoreComments": true, "ignorePattern": "^path " }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "quotes": [ "error",  "single"],
     "react-hooks/exhaustive-deps": "off",
     "react/function-component-definition": [2, {
         "namedComponents": "arrow-function",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,8 +39,7 @@
     }],
     "react/jsx-one-expression-per-line":  "off",
     "react/forbid-prop-types": "off",
-    "react/require-default-props": "off",
-    "no-console": ["warn"]
+    "react/require-default-props": "off"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
   ],
   "rules": {
     "eol-last": ["error", "always"],
-    "import/prefer-default-export": ["off"],
     "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" } ],
     "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignoreComments": true, "ignorePattern": "^path " }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,8 @@
     "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignoreComments": true, "ignorePattern": "^path " }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "react-hooks/exhaustive-deps": "off",
+
+
     "react/function-component-definition": [2, {
         "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"
@@ -40,7 +42,7 @@
     "react/jsx-one-expression-per-line":  "off",
     "react/forbid-prop-types": "off",
     "react/require-default-props": "off",
-    "semi": ["error", "always"],
+    // "semi": ["error", "always"],
     "no-console": ["warn"]
   },
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,12 +37,10 @@
         "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"
     }],
-    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-no-useless-fragment": [2, { "allowExpressions": true }],
     "react/jsx-one-expression-per-line":  "off",
     "react/forbid-prop-types": "off",
     "react/require-default-props": "off",
-    // "semi": ["error", "always"],
     "no-console": ["warn"]
   },
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,8 +31,6 @@
     "max-len": ["error", { "code": 250, "ignoreStrings": true, "ignoreComments": true, "ignorePattern": "^path " }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "react-hooks/exhaustive-deps": "off",
-
-
     "react/function-component-definition": [2, {
         "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,6 @@
         "namedComponents": "arrow-function",
         "unnamedComponents": "arrow-function"
     }],
-    "react/jsx-no-useless-fragment": [2, { "allowExpressions": true }],
     "react/jsx-one-expression-per-line":  "off",
     "react/forbid-prop-types": "off",
     "react/require-default-props": "off",

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -12,7 +12,6 @@ import {
   COOKIE_URL,
   ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
   ERROR_CREW_DETAILS_UPLOAD_URL,
-  ERROR_VERIFICATION_FAILED_URL,
   FORM_CONFIRMATION_URL,
   LANDING_URL,
   MESSAGE_URL,
@@ -52,7 +51,6 @@ import LoadingSpinner from './components/LoadingSpinner';
 const GenericMessage = lazy(() => import('./pages/Message/GenericMessage'));
 // Register/Sign in pages
 const AccountAlreadyActive = lazy(() => import('./pages/Message/AccountAlreadyActive'));
-const VerificationLinkFailed = lazy(() => import('./pages/Message/VerificationLinkFailed'));
 const RegisterConfirmation = lazy(() => import('./pages/Register/RegisterConfirmation'));
 const RegisterEmailAddress = lazy(() => import('./pages/Register/RegisterEmailAddress'));
 const RegisterEmailCheck = lazy(() => import('./pages/Register/RegisterEmailCheck'));
@@ -98,7 +96,6 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
           <Route path={MESSAGE_URL} element={<GenericMessage />} />
 
           <Route path={ERROR_ACCOUNT_ALREADY_ACTIVE_URL} element={<AccountAlreadyActive />} />
-          <Route path={ERROR_VERIFICATION_FAILED_URL} element={<VerificationLinkFailed />} />
           <Route path={REGISTER_CONFIRMATION_URL} element={<RegisterConfirmation />} />
           <Route path={REGISTER_ACCOUNT_URL} element={<RegisterEmailAddress />} />
           <Route path={REGISTER_EMAIL_URL} element={<RegisterEmailAddress />} />

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -54,7 +54,6 @@ export const CHANGE_YOUR_PASSWORD_PAGE_URL = '/change-your-password';
 // Error/message pages
 export const MESSAGE_URL = '/message';
 export const ERROR_ACCOUNT_ALREADY_ACTIVE_URL = '/create-account/account-already-exists';
-export const ERROR_VERIFICATION_FAILED_URL = '/create-account/verification-failed';
 
 // Top level pages - we use this to know to clear form session data
 export const TOP_LEVEL_PAGES = [
@@ -70,11 +69,11 @@ export const TOP_LEVEL_PAGES = [
 // Pages without back links
 export const NO_BACK_LINKS = [
   ...TOP_LEVEL_PAGES,
-  ERROR_VERIFICATION_FAILED_URL,
   FORM_CONFIRMATION_URL,
   GENERIC_CONFIRMATION_URL,
   MESSAGE_URL,
   REGISTER_CONFIRMATION_URL,
+  REGISTER_DETAILS_URL,
   REGISTER_EMAIL_CHECK_URL,
   REGISTER_EMAIL_VERIFIED_URL,
   SIGN_IN_URL,

--- a/src/constants/Config.js
+++ b/src/constants/Config.js
@@ -1,4 +1,5 @@
 const apiVersion = 'v1';
 const apiBaseUrl = process.env.NMSW_DATA_API_BASE_URL || 'http://localhost:5000';
 
+// eslint-disable-next-line import/prefer-default-export
 export const apiUrl = `${apiBaseUrl}/${apiVersion}`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-filename-extension */
 /* istanbul ignore file */
 /* above leaves this file out of the jest test coverage check as we can't test index.js */
 import React from 'react';

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   FIELD_RADIO,
@@ -10,8 +9,9 @@ import {
   VALIDATE_REQUIRED,
   DISPLAY_GROUPED,
 } from '../../constants/AppConstants';
-import { ERROR_VERIFICATION_FAILED_URL, REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
+import { REGISTER_EMAIL_RESEND_URL, REGISTER_PASSWORD_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
+import Message from '../../components/Message';
 import { MergePhoneNumberFields } from '../../utils/FormatPhoneNumber';
 
 const RegisterYourDetails = () => {
@@ -136,14 +136,20 @@ const RegisterYourDetails = () => {
    * Without an email address & token we can't submit the PATCH to update the user account
    * So if a user arrives to this page and we do not have an email address in state
    * we need to direct them to a place where they can deal with that
-   * TODO: once we have email verification flow journey replace REGISTER_EMAIL_URL_VERIFIED
-   * with a more appropriate page
    */
-  useEffect(() => {
-    if (!state || !state.dataToSubmit || !state.dataToSubmit.emailAddress || !state.dataToSubmit.token) {
-      navigate(ERROR_VERIFICATION_FAILED_URL);
-    }
-  }, [state]);
+  if (!state?.dataToSubmit?.emailAddress || !state?.dataToSubmit?.token) {
+    const buttonProps = {
+      buttonLabel: 'Resend confirmation email',
+      buttonNavigateTo: REGISTER_EMAIL_RESEND_URL,
+    };
+    return (
+      <Message
+        button={buttonProps}
+        title="Try again"
+        message="The verification link did not work. Resend the email to try again."
+      />
+    );
+  }
 
   return (
     <DisplayForm

--- a/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
@@ -1,7 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { ERROR_VERIFICATION_FAILED_URL } from '../../../constants/AppUrlConstants';
 import RegisterYourDetails from '../RegisterYourDetails';
 
 let mockUseLocationState = {};
@@ -22,64 +21,73 @@ describe('Register your details tests', () => {
     window.sessionStorage.clear();
   });
 
-  it('should redirect user to other page if there is no state', async () => {
+  it('should show try again message if there is no state', async () => {
     mockUseLocationState = {};
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
-    });
+    expect(screen.getByRole('heading', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByText('The verification link did not work. Resend the email to try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Resend confirmation email</button>');
   });
 
-  it('should redirect user to other page if there is no dataToSubmit object in state', async () => {
+  it('should show try again message if there is no dataToSubmit object in state', async () => {
     mockUseLocationState = { state: {} };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
-    });
+    expect(screen.getByRole('heading', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByText('The verification link did not work. Resend the email to try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Resend confirmation email</button>');
   });
 
-  it('should redirect user to other page if there is an empty dataToSubmit object in state', async () => {
+  it('should show try again message if there is an empty dataToSubmit object in state', async () => {
     mockUseLocationState = { state: { dataToSubmit: {} } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
-    });
+    expect(screen.getByRole('heading', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByText('The verification link did not work. Resend the email to try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Resend confirmation email</button>');
   });
 
-  it('should redirect user to other page if there is no emailAddress in state', async () => {
+  it('should show try again message if there is no emailAddress in state', async () => {
     mockUseLocationState = { state: { dataToSubmit: { toke: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
-    });
+    expect(screen.getByRole('heading', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByText('The verification link did not work. Resend the email to try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Resend confirmation email</button>');
   });
 
-  it('should redirect user to other page if there is no token in state', async () => {
+  it('should show try again message if there is no token in state', async () => {
     mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_VERIFICATION_FAILED_URL);
-    });
+    expect(screen.getByRole('heading', { name: 'Try again' })).toBeInTheDocument();
+    expect(screen.getByText('The verification link did not work. Resend the email to try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Resend confirmation email</button>');
   });
 
   it('should render h1', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByText('Your details')).toBeInTheDocument();
   });
 
   it('should render a full name question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByLabelText('Full name')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Full name' }).outerHTML).toEqual('<input class="govuk-input" id="fullName-input" name="fullName" type="text" value="">');
   });
 
   it('should render a company name question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByLabelText('Your company name')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Your company name' }).outerHTML).toEqual('<input class="govuk-input" id="companyName-input" name="companyName" type="text" value="">');
   });
 
   it('should render an international dialling code question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByLabelText('International dialling code')).toBeInTheDocument();
     expect(screen.getByText('For example, 44 for UK')).toBeInTheDocument();
@@ -87,6 +95,7 @@ describe('Register your details tests', () => {
   });
 
   it('should render a telephone number question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByLabelText('Telephone number')).toBeInTheDocument();
     expect(screen.getByText('For example, 7123123123')).toBeInTheDocument();
@@ -94,12 +103,14 @@ describe('Register your details tests', () => {
   });
 
   it('should render a country question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByLabelText('Country')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Country' }).outerHTML).toEqual('<input class="govuk-input" id="country-input" name="country" type="text" value="">');
   });
 
   it('should render a shipping agent question', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByText('Is your company a shipping agent?')).toBeInTheDocument();
     expect(screen.getByText('Yes')).toBeInTheDocument();
@@ -109,11 +120,13 @@ describe('Register your details tests', () => {
   });
 
   it('should render a continue button', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     expect(screen.getByRole('button', { name: 'Continue' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Continue</button>');
   });
 
   it('should NOT call the handleSubmit function on button click if there ARE errors', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
@@ -121,6 +134,7 @@ describe('Register your details tests', () => {
   });
 
   it('should display the Error Summary if there are errors', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
@@ -128,6 +142,7 @@ describe('Register your details tests', () => {
   });
 
   it('should display the required error messages if required fields are null', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
@@ -141,6 +156,7 @@ describe('Register your details tests', () => {
   });
 
   it('should display the error messages if fields are formatted incorrectly', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await user.type(screen.getByLabelText('International dialling code'), 'abc');
@@ -154,6 +170,7 @@ describe('Register your details tests', () => {
   });
 
   it('should NOT display error messagess if fields are valid', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);
     await user.type(screen.getByLabelText('Full name'), 'Joe Bloggs');
@@ -174,6 +191,7 @@ describe('Register your details tests', () => {
   });
 
   it('should NOT clear form session data on submit', async () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com', token: '123' } } };
     const user = userEvent.setup();
     const expectedStoredData = '{"fullName":"Joe Bloggs","companyName":"Joe Bloggs Company","diallingCode":"44","telephoneNumber":"12345","country":"AUS","shippingAgent":"yes"}';
     render(<MemoryRouter><RegisterYourDetails /></MemoryRouter>);

--- a/src/utils/DownloadFile.js
+++ b/src/utils/DownloadFile.js
@@ -1,4 +1,5 @@
-export const DownloadFile = (file, fileName) => {
+// eslint-disable-next-line import/prefer-default-export
+export const { DownloadFile } = (file, fileName) => {
   fetch(file, {
     method: 'GET',
     headers: {
@@ -20,3 +21,10 @@ export const DownloadFile = (file, fileName) => {
       URL.revokeObjectURL(url);
     });
 };
+
+/* NOTE on disabling the linting rule here:
+ * mocking the download file function for RTL/Jest
+ * testing has proved to be quite difficult
+ * when we use export default here and then import
+ * as a component on the other end
+ */

--- a/src/utils/ScrollToTopOnNewPage.jsx
+++ b/src/utils/ScrollToTopOnNewPage.jsx
@@ -9,6 +9,7 @@ const ScrollToTopOnNewPage = ({ children }) => {
     document.activeElement.blur(); // deselect the link so it doesn't remain in the focus state when page loads
   }, [location.pathname]);
 
+  // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;
 };
 


### PR DESCRIPTION
# Ticket



----

## AC

While doing a review of linting noticed we have some unneeded rules

----

## To test

- run tests
- run cypress tests
- go to `/create-account/your-details`
- > should redirect you to the Try again message
- go through create account process and click validate on your link
- > should should the Your details page

----

## Notes

- refactored a useEffect so it is not needed and the associated file can be removed : discovered when investigating `"react-hooks/exhaustive-deps": "off",` rule. There is more refactoring to be done so we can reset this back to the 'on' state
- removed some rules that are part of the AirBnB styles by default, we don't need to respecify them here
- We have two special cases where `"import/prefer-default-export": ["off"],` needs to apply, so have removed this rule as a general rule and overridden those two cases in their files (DownloadFile -- see comments on file it's causing us trouble with mocking for testing, and config file where we expect to be adding more config for this app)
- The only place we allow jsx in a .js file is index.js so removed `"react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],` and overridden in index.js
- `"react/jsx-no-useless-fragment": [2, { "allowExpressions": true }],` was in place for one file - ScrollToTopOnNewPage which takes {children} with no other jsx, so removed rule and we override on that file only