### PR TITLE
NMSW-268 File upload for General Declaration FAL 1

### DIFF
--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -57,7 +57,7 @@ const FileUploadForm = ({
         });
 
         if (response.status === 200) {
-          navigate(urlSuccessPage, { state: { declarationId } });
+          navigate(urlSuccessPage, { state: { declarationId, fileName: selectedFile?.file?.name } });
         }
       } catch (err) {
         if (err?.response?.status === 401 || err?.response?.status === 422) {

--- a/src/components/__tests__/FileUploadForm.test.jsx
+++ b/src/components/__tests__/FileUploadForm.test.jsx
@@ -198,6 +198,6 @@ describe('File upload tests', () => {
     await user.upload(input, file);
     expect(input.files[0]).toStrictEqual(file);
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
-    expect(mockedUseNavigate).toHaveBeenCalledWith('/success-page', { state: { declarationId: '123' } });
+    expect(mockedUseNavigate).toHaveBeenCalledWith('/success-page', { state: { declarationId: '123', fileName: 'image.png' } });
   });
 });

--- a/src/pages/Voyage/FileUploadConfirmation.jsx
+++ b/src/pages/Voyage/FileUploadConfirmation.jsx
@@ -7,7 +7,7 @@ const FileUploadConfirmation = () => {
   const navigate = useNavigate();
   document.title = 'No errors found';
 
-  if (!state?.declarationId || !state?.fileType) {
+  if (!state?.declarationId || !state?.fileName) {
     return (
       <Message title="Something has gone wrong" redirectURL={YOUR_VOYAGES_URL} />
     );
@@ -30,7 +30,7 @@ const FileUploadConfirmation = () => {
             </div>
             <div className="govuk-notification-banner__content">
               <h3 className="govuk-notification-banner__heading">
-                {`${state?.fileType ? state?.fileType : ''} uploaded`}
+                {`${state?.fileName ? state?.fileName : ''} uploaded`}
               </h3>
             </div>
           </div>

--- a/src/pages/Voyage/VoyageGeneralDeclaration.jsx
+++ b/src/pages/Voyage/VoyageGeneralDeclaration.jsx
@@ -1,30 +1,25 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { DownloadFile } from '../../utils/DownloadFile';
 import {
-  SIGN_IN_URL,
+  API_URL,
+  ENDPOINT_DECLARATION_PATH,
+  ENDPOINT_FILE_UPLOAD_GENERAL_DECLARATION_PATH,
+} from '../../constants/AppAPIConstants';
+import {
   VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
+import FileUploadForm from '../../components/FileUploadForm';
 import Message from '../../components/Message';
+
+const SupportingText = () => (
+  <p className="govuk-body" data-testid="paragraph">You must use the new excel spreadsheet version of the <button className="govuk-button--text" type="button" onClick={() => DownloadFile('/assets/files/NMSW-FAL-1.xlsx', 'FAL1.xlsx')}>FAL 1 general declaration</button>.</p>
+);
 
 const VoyageUploadGeneralDeclaration = () => {
   const { state } = useLocation();
-  const navigate = useNavigate();
   document.title = 'Upload the General Declaration (FAL 1)';
-
-  const handleSubmit = async () => {
-    console.log('Gen Dec', state?.declarationId);
-    // this will be refactored once we have the upload file component
-    // for now it just takes the declaration ID and passes it to the next page
-
-    // for testing the sign in flow returning declaration ID, adding a redirect to sign in if no token
-    if (!sessionStorage.getItem('token')) {
-      navigate(SIGN_IN_URL, { state: { redirectURL: VOYAGE_GENERAL_DECLARATION_UPLOAD_URL, fileType: 'General Declaration', declarationId: state?.declarationId } });
-    } else {
-      navigate(VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL, { state: { fileType: 'General Declaration', declarationId: state?.declarationId } });
-    }
-  };
 
   if (!state?.declarationId) {
     return (
@@ -33,26 +28,19 @@ const VoyageUploadGeneralDeclaration = () => {
   }
 
   return (
-    <>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
-          <h1 className="govuk-heading-xl">Upload the General Declaration (FAL 1)</h1>
-          <p className="govuk-body" data-testid="paragraph">You must use the new excel spreadsheet version of the <button className="govuk-button--text" type="button" onClick={() => DownloadFile('/assets/files/NMSW-FAL-1.xlsx', 'FAL1.xlsx')}>FAL 1 general declaration</button>.</p>
-        </div>
-      </div>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <button
-            type="button"
-            className="govuk-button"
-            data-module="govuk-button"
-            onClick={handleSubmit}
-          >
-            Save and continue
-          </button>
-        </div>
-      </div>
-    </>
+    <FileUploadForm
+      declarationId={state?.declarationId}
+      endpoint={`${API_URL}${ENDPOINT_DECLARATION_PATH}/${state?.declarationId}${ENDPOINT_FILE_UPLOAD_GENERAL_DECLARATION_PATH}`}
+      fileNameRequired="FAL 1 - General Declaration"
+      fileTypesAllowed="csv or xlsx"
+      formId="uploadGeneralDeclaration"
+      pageHeading="Upload the General Declaration (FAL 1)"
+      submitButtonLabel="Check for errors"
+      urlSuccessPage={VOYAGE_GENERAL_DECLARATION_CONFIRMATION_URL}
+      urlThisPage={VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}
+    >
+      <SupportingText />
+    </FileUploadForm>
   );
 };
 

--- a/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
+++ b/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
@@ -20,7 +20,7 @@ describe('File upload success confirmation page', () => {
   });
 
   it('should render the page with state', async () => {
-    mockUseLocationState.state = { fileType: 'FAL Name', declarationId: '123' };
+    mockUseLocationState.state = { fileName: 'FAL Name', declarationId: '123' };
     render(<MemoryRouter><FileUploadConfirmation /></MemoryRouter>);
     expect(screen.getByRole('heading', { name: 'No errors found' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Success' }).outerHTML).toEqual('<h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>');
@@ -38,7 +38,7 @@ describe('File upload success confirmation page', () => {
 
   it('should go to the voyage task list page on button click', async () => {
     const user = userEvent.setup();
-    mockUseLocationState.state = { fileType: 'FAL Name', declarationId: '123' };
+    mockUseLocationState.state = { fileName: 'FAL Name', declarationId: '123' };
     render(<MemoryRouter><FileUploadConfirmation /></MemoryRouter>);
     expect(screen.getByRole('button', { name: 'Save and continue' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Save and continue' }));

--- a/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import { YOUR_VOYAGES_URL } from '../../../constants/AppUrlConstants';
 import VoyageGeneralDeclaration from '../VoyageGeneralDeclaration';
 
@@ -13,7 +16,10 @@ jest.mock('react-router', () => ({
 }));
 
 describe('Voyage general declaration page', () => {
+  const mockAxios = new MockAdapter(axios);
+
   beforeEach(() => {
+    mockAxios.reset();
     window.sessionStorage.clear();
     mockUseLocationState.state = {};
   });
@@ -24,7 +30,7 @@ describe('Voyage general declaration page', () => {
     expect(screen.getByRole('heading', { name: 'Upload the General Declaration (FAL 1)' })).toBeInTheDocument();
     expect(screen.getByTestId('paragraph').outerHTML).toEqual('<p class="govuk-body" data-testid="paragraph">You must use the new excel spreadsheet version of the <button class="govuk-button--text" type="button">FAL 1 general declaration</button>.</p>');
     expect(screen.getByRole('button', { name: 'FAL 1 general declaration' }).outerHTML).toEqual('<button class="govuk-button--text" type="button">FAL 1 general declaration</button>');
-    expect(screen.getByRole('button', { name: 'Save and continue' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button">Save and continue</button>');
+    expect(screen.getByRole('button', { name: 'Check for errors' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button">Check for errors</button>');
   });
 
   it('should show error message if no declaration ID in state', async () => {
@@ -34,4 +40,22 @@ describe('Voyage general declaration page', () => {
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
+
+  it('should show error if no file is selected and submit clicked', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState.state = { fileType: 'FAL Name', declarationId: '123' };
+    render(<MemoryRouter><VoyageGeneralDeclaration /></MemoryRouter>);
+    expect(screen.getByRole('heading', { name: 'Upload the General Declaration (FAL 1)' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Check for errors' }));
+    expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select a FAL 1 - General Declaration' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a FAL 1 - General Declaration')).toHaveLength(2);
+  });
+
+  /*
+   * Note: API responses of 400 Missing file, 400 Invalid file type,
+   * 401, 422, 500, and other non specified errors are
+   * tested within the FileUploadForm.test.jsx test suite as they are
+   * generic for any file upload
+  */
 });


### PR DESCRIPTION
# Ticket

NMSW-268

----

## AC

Given a user has not uploaded a file
When they click check for errors
Then a form field styled error is shown

Given a user has uploaded a file
When a user clicks check for errors
Then the FE sends a POST to the /declaration/{declarationId}/upload-fal1 endpoint

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
When the response is a 200
Then the FE shows the no errors found page

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
And the file is not of type .csv or .xlsx
When they click check for errors
Then a form field styled 'invalid type' error is shown

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
And the file is missing from the payload
Then a form field styled 'no file' error is shown

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
And the endpoint is missing a declaration id
Then the something went wrong page is shown
And the link on that page returns the user to the `Your voyages` page

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
And their token has expired/become invalid
Then the sign in page is shown
When they sign in
Then they are returned to the `upload General Declaration FAL 1` page

Given the FE has sent a POST to the /declaration/{declarationId}/upload-fal1 endpoint
And the API returns a 500 error
Then the something went wrong page is shown
And the link on that page returns the user to the  `General Declaration FAL 1` page


----

## To test

ERROR SCENARIOS:

- Log in
- Click on `Report a voyage` button
- > Upload general declaration FAL 1 page should display as per prototype
- Click on `FAL 1 general declaration` link
- > template should download
- Click on `Check for errors`
- > Error of “Select a FAL 1 - General Declaration” should be shown
- Upload an image file
- Click on `Check for errors`
- > Error of “The selected file must be a csv or xlsx” should be shown
- Upload a large file (over 4MB)
- Click on `Check for errors`
- > Error of “The file must be smaller than 4MB” should be shown
- Click on `The file must be smaller than 4MB` link in the `Error summary panel`
- > You should be scrolled to the Upload a file question
- Upload a new file
- > The error message should clear
- Delete your auth token
- Click on `Check for errors`
- > You should be redirected to sign in
- Sign in
- > You should directed back to the Upload general declaration FAL 1 page

 

For dev testing 404

- In `FileUploadForm` change the endpoint to `/declaration//upload-fal1`
- Upload a file
- Click `Check for errors`
- > You should be taken to something went wrong page
- Click link
- You should be taken to Your voyages page

 

SUCCESS SCENARIO:

Due to an issue with dev ClamAV you will need to run the backend locally to test the success scenario.

- run backend locally
- remember to update the logging so your token will log in your terminal
- register an email address (can do in Postman)
- get your token from the terminal
- complete your registration with that token
- in the browser sign in
- Upload the FAL 1 template file with all fields correctly filled in
- Click `Check for errors`
- > You should be taken to the confirmation of upload page with a success message
- Click `Save and continue`
- > You should be taken to the task details page

----

## Notes

Waiting on a fix to BE which currently returns a 500 error in what we expect to be a success