### PR TITLE
NMSW-394 Update error messages

### DIFF
--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -318,7 +318,7 @@ It should NOT be used for the other types as it is redundant for them.
   validation: [
     {
       type: VALIDATE_REQUIRED,
-      message: 'Select is your company a shipping agent',
+      message: 'Select yes if your company is a shipping agent',
     },
   ],
 },

--- a/docs/form_creator.md
+++ b/docs/form_creator.md
@@ -288,7 +288,7 @@ It should NOT be used for the other types as it is redundant for them.
     },
     {
       type: VALIDATE_EMAIL_ADDRESS,
-      message: 'Enter an email address in the correct format, like name@example.com',
+      message: 'Enter a real email address',
     },
   ],
 },

--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -101,7 +101,7 @@ const FileUploadForm = ({
     setIsLoading(true);
 
     if (Object.entries(selectedFile).length < 1) {
-      handleErrors({ errType: FILE_ERROR, errMessage: `Select a ${fileNameRequired}` });
+      handleErrors({ errType: FILE_ERROR, errMessage: 'Select a file' });
     } else if (selectedFile?.file.size > MAX_FILE_SIZE) {
       handleErrors({ errType: FILE_ERROR, errMessage: `The file must be smaller than ${MAX_FILE_SIZE_DISPLAY}MB` });
     } else {
@@ -125,9 +125,9 @@ const FileUploadForm = ({
         switch (err?.response?.status) {
           case 400:
             if (err?.response?.data?.message === FILE_MISSING) {
-              handleErrors({ errType: FILE_ERROR, errMessage: `Select a ${fileNameRequired}` });
+              handleErrors({ errType: FILE_ERROR, errMessage: 'Select a file' });
             } else if (err?.response?.data?.message?.startsWith(FILE_TYPE_INVALID_PREFIX)) {
-              handleErrors({ errType: FILE_ERROR, errMessage: `The selected file must be a ${fileTypesAllowed}` });
+              handleErrors({ errType: FILE_ERROR, errMessage: `The file must be a ${fileTypesAllowed}` });
             } else {
               handleErrors({ errType: FIELD_ERROR, errData: err?.response?.data });
             }

--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -89,20 +89,20 @@ const MultiFileUploadForm = ({
     const remainingFilesAvailable = MAX_FILES - filesAddedForUpload.length;
 
     if (filesAddedForUpload.length === MAX_FILES) {
-      setMaxFilesError(`You've selected too many files. You can add ${remainingFilesAvailable} more files.`);
-      setErrors([`You've selected too many files. You can add ${remainingFilesAvailable} more files.`]);
+      setMaxFilesError(`You've selected too many files: you can add up to ${remainingFilesAvailable} more files`);
+      setErrors([`You've selected too many files: you can add up to ${remainingFilesAvailable} more files`]);
     } else if (filesAddedForUpload.length > 0 && (filesAddedForUpload.length + fileList.length > MAX_FILES)) {
-      setMaxFilesError(`You've selected too many files. You can only add ${remainingFilesAvailable} more files.`);
-      setErrors([`You've selected too many files. You can only add ${remainingFilesAvailable} more files.`]);
+      setMaxFilesError(`You've selected too many files: you can add up to ${remainingFilesAvailable} more files`);
+      setErrors([`You've selected too many files: you can add up to ${remainingFilesAvailable} more files`]);
     } else if (fileList.length > MAX_FILES) {
-      setMaxFilesError(`You've selected too many files. You can only add ${MAX_FILES}.`);
-      setErrors([`You've selected too many files. You can only add ${MAX_FILES}.`]);
+      setMaxFilesError(`You've selected too many files: you can only add ${MAX_FILES}`);
+      setErrors([`You've selected too many files: you can only add ${MAX_FILES}`]);
     } else {
       const newFilesForUpload = filesUserAdded.reduce((results, fileToCheck) => {
         if (fileCurrentlyInState.findIndex((existingFile) => existingFile.file.name === fileToCheck.name) === -1) {
           results.push({ file: fileToCheck, status: FILE_STATUS_PENDING });
         } else {
-          errorList.push(`A file name ${fileToCheck.name} already exists in your list`);
+          errorList.push(`A file called ${fileToCheck.name} already exists in your list`);
         }
         setErrors(errorList);
         return results;

--- a/src/components/__tests__/DisplayFormTests/DefaultValuesAndSessionData.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DefaultValuesAndSessionData.test.jsx
@@ -68,7 +68,7 @@ describe('Display Form default values and session data', () => {
         },
         {
           type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter your email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
       ],
     },

--- a/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/DisplayFormInputs.test.jsx
@@ -164,7 +164,7 @@ describe('Display Form inputs', () => {
         },
         {
           type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter your email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
       ],
     },

--- a/src/components/__tests__/DisplayFormTests/ErrorSpecialRules.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorSpecialRules.test.jsx
@@ -82,7 +82,7 @@ describe('Display Form', () => {
         },
         {
           type: VALIDATE_PHONE_NUMBER,
-          message: 'Enter a telephone number in the correct format',
+          message: 'Telephone number must be in the correct format',
         },
       ],
     },
@@ -237,7 +237,7 @@ describe('Display Form', () => {
 
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a telephone number in the correct format')).toHaveLength(2);
+    expect(screen.getAllByText('Telephone number must be in the correct format')).toHaveLength(2);
   });
 
   it('should return an error if a phone number has no numbers in it', async () => {
@@ -258,7 +258,7 @@ describe('Display Form', () => {
 
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a telephone number in the correct format')).toHaveLength(2);
+    expect(screen.getAllByText('Telephone number must be in the correct format')).toHaveLength(2);
   });
 
   it('should NOT return an error if a phone number has characters that ARE in the defined accepted numsymbol list', async () => {
@@ -278,7 +278,7 @@ describe('Display Form', () => {
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
 
     expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter a telephone number in the correct format')).not.toBeInTheDocument();
+    expect(screen.queryByText('Telephone number must be in the correct format')).not.toBeInTheDocument();
   });
 
   it('should return the error for the first failing validation rule if there are multiple rules', async () => {

--- a/src/components/__tests__/FileUploadForm.test.jsx
+++ b/src/components/__tests__/FileUploadForm.test.jsx
@@ -112,8 +112,8 @@ describe('File upload tests', () => {
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Select a File name from props for error display' })).toBeInTheDocument();
-    expect(screen.getAllByText('Select a File name from props for error display')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Select a file' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
@@ -133,8 +133,8 @@ describe('File upload tests', () => {
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Select a File name from props for error display' })).toBeInTheDocument();
-    expect(screen.getAllByText('Select a File name from props for error display')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Select a file' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
@@ -152,8 +152,8 @@ describe('File upload tests', () => {
     expect(input.files[0]).toStrictEqual(file);
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'The selected file must be a File types from props for error display' })).toBeInTheDocument();
-    expect(screen.getAllByText('The selected file must be a File types from props for error display')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'The file must be a File types from props for error display' })).toBeInTheDocument();
+    expect(screen.getAllByText('The file must be a File types from props for error display')).toHaveLength(2);
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
@@ -176,7 +176,7 @@ describe('File upload tests', () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
-    await user.click(screen.getByRole('button', { name: 'Select a File name from props for error display' }));
+    await user.click(screen.getByRole('button', { name: 'Select a file' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
@@ -185,10 +185,10 @@ describe('File upload tests', () => {
     const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
     renderPage();
     await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
-    expect(screen.getAllByText('Select a File name from props for error display')).toHaveLength(2);
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
     const input = screen.getByLabelText('Title from props');
     await user.upload(input, file);
-    expect(screen.queryByText('Select a File name from props for error display')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select a file')).not.toBeInTheDocument();
   });
 
   it('should redirect user to sign in with this page and declaration id if missing bearer token', async () => {

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -139,7 +139,7 @@ describe('Multi file upload tests', () => {
 
     const input = screen.getByTestId('multiFileUploadInput');
     await user.upload(input, files);
-    expect(screen.getAllByText("You've selected too many files. You can only add 7.")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can only add 7")).toHaveLength(2);
   });
 
   it('should only allow a max of seven files be added for upload - more than 7 selected over multiple adds', async () => {
@@ -165,7 +165,7 @@ describe('Multi file upload tests', () => {
 
     await user.upload(input, additionalFiles);
     expect(screen.getAllByText('Pending')).toHaveLength(2); // it does not let user add the extra files, remains at 2
-    expect(screen.getAllByText("You've selected too many files. You can only add 5 more files.")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can add up to 5 more files")).toHaveLength(2);
   });
 
   it('should only allow a max of seven files be added for upload - 7 added and tries to add more', async () => {
@@ -190,7 +190,7 @@ describe('Multi file upload tests', () => {
 
     await user.upload(input, additionalFiles);
     expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
-    expect(screen.getAllByText("You've selected too many files. You can add 0 more files.")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
   });
 
   it('should not repeat error messages when too many files selected for upload - 7 added and tries to add more', async () => {
@@ -219,11 +219,11 @@ describe('Multi file upload tests', () => {
 
     await user.upload(input, additionalFiles);
     expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
-    expect(screen.getAllByText("You've selected too many files. You can add 0 more files.")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
 
     await user.upload(input, additionalFilesTwo); // repeat and expect to still only have the 2 instance of error on screen
     expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
-    expect(screen.getAllByText("You've selected too many files. You can add 0 more files.")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
   });
 
   it('should remove a pre-uploaded file from the list if its delete button is clicked', async () => {
@@ -292,8 +292,8 @@ describe('Multi file upload tests', () => {
     expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(5);
     expect(screen.getAllByText('Pending')).toHaveLength(5);
 
-    expect(screen.getByText('A file name template2.xlsx already exists in your list')).toBeInTheDocument();
-    expect(screen.getByText('A file name template4.xlsx already exists in your list')).toBeInTheDocument();
+    expect(screen.getByText('A file called template2.xlsx already exists in your list')).toBeInTheDocument();
+    expect(screen.getByText('A file called template4.xlsx already exists in your list')).toBeInTheDocument();
   });
 
   it('should load the next page on submit button click', async () => {

--- a/src/constants/ErrorMappingFal5.js
+++ b/src/constants/ErrorMappingFal5.js
@@ -22,20 +22,20 @@ const ErrorMappingFal5 = {
   E: { // rank or rating
     order: 'e',
     'none is not an allowed value': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
-    'Value must be 35 characters or less': 'Enter the rank, rating or job title in 35 characters or less',
-    'Value must use English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
+    'ensure this value has at most 35 characters': 'Enter the rank, rating or job title in 35 characters or less',
+    'Enter the value using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
   },
   F: { // surname
     order: 'f',
     'none is not an allowed value': 'Enter family name or surname as it appears in the travel document',
-    'Value must be 35 characters or less': 'Enter family name or surname in 35 characters or less',
-    'Value must use English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
+    'ensure this value has at most 35 characters': 'Enter family name or surname in 35 characters or less',
+    'Enter the value using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
   },
   G: { // forenames
     order: 'g',
     'none is not an allowed value': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
-    'Value must be 35 characters or less': 'Enter all forenames or given names in 35 characters or less',
-    'Value must use English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
+    'ensure this value has at most 35 characters': 'Enter all forenames or given names in 35 characters or less',
+    'Enter the value using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
   },
   H: { // gender
     order: 'h',
@@ -47,8 +47,8 @@ const ErrorMappingFal5 = {
   },
   J: { // place of birth
     order: 'j',
-    'Value must be 35 characters or less': 'Enter the place of birth in 35 characters or less',
-    'Value must use English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
+    'ensure this value has at most 35 characters': 'Enter the place of birth in 35 characters or less',
+    'Enter the value using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
   },
   K: { // nationality
     order: 'k',

--- a/src/pages/NavPages/YourDetails/ChangeYourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/ChangeYourDetails.jsx
@@ -79,7 +79,7 @@ const ChangeYourDetails = () => {
         },
         {
           type: VALIDATE_PHONE_NUMBER,
-          message: 'Enter a telephone number in the correct format',
+          message: 'Telephone number must be in the correct format',
         },
       ],
     },

--- a/src/pages/NavPages/YourDetails/ChangeYourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/ChangeYourDetails.jsx
@@ -63,7 +63,7 @@ const ChangeYourDetails = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter an international dialling code',
+          message: 'Select an international dialling code',
         },
       ],
     },
@@ -94,7 +94,7 @@ const ChangeYourDetails = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter country',
+          message: 'Select a country',
         },
       ],
     },

--- a/src/pages/NavPages/YourDetails/ChangeYourPassword.jsx
+++ b/src/pages/NavPages/YourDetails/ChangeYourPassword.jsx
@@ -60,12 +60,12 @@ const ChangeYourPassword = () => {
         },
         {
           type: VALIDATE_MIN_LENGTH,
-          message: 'Passwords must be at least 10 characters long',
+          message: 'Password must be at least 10 characters long',
           condition: 10,
         },
         {
           type: VALIDATE_NO_SPACES,
-          message: 'Enter a password that does not contain spaces',
+          message: 'Password must not contain spaces',
         },
       ],
     },
@@ -76,7 +76,7 @@ const ChangeYourPassword = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Confirm a new password',
+          message: 'Confirm your new password',
         },
         {
           type: VALIDATE_FIELD_MATCH_CASE_SENSITIVE,

--- a/src/pages/NavPages/YourDetails/__tests__/ChangeYourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/ChangeYourDetails.test.jsx
@@ -137,9 +137,9 @@ describe('Change your details tests', () => {
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
     expect(screen.getAllByText('Enter your full name')).toHaveLength(2);
     expect(screen.getAllByText('Enter your company name')).toHaveLength(2);
-    expect(screen.getAllByText('Enter an international dialling code')).toHaveLength(2);
+    expect(screen.getAllByText('Select an international dialling code')).toHaveLength(2);
     expect(screen.getAllByText('Enter a telephone number')).toHaveLength(2);
-    expect(screen.getAllByText('Enter country')).toHaveLength(2);
+    expect(screen.getAllByText('Select a country')).toHaveLength(2);
   });
 
   it('should NOT display error messagess if fields are valid', async () => {
@@ -156,9 +156,9 @@ describe('Change your details tests', () => {
     expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter your full name')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter your company name')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter an international dialling code')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select an international dialling code')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter a telephone number')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter country')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select a country')).not.toBeInTheDocument();
   });
 
   it('should take user to a confirmation page is there are no errors', async () => {

--- a/src/pages/NavPages/YourDetails/__tests__/ChangeYourPassword.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/ChangeYourPassword.test.jsx
@@ -72,7 +72,7 @@ describe('Change your password tests', () => {
     expect(screen.getAllByText('Enter a password')).toHaveLength(2);
     // This text is also in the 'hint' text so occurs 3 times
     expect(screen.getAllByText('Enter a new password')).toHaveLength(3);
-    expect(screen.getAllByText('Confirm a new password')).toHaveLength(2);
+    expect(screen.getAllByText('Confirm your new password')).toHaveLength(2);
   });
 
   it('should display error message if fields are formatted incorrectly', async () => {
@@ -94,7 +94,7 @@ describe('Change your password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Passwords must be at least 10 characters long')).toHaveLength(2);
+    expect(screen.getAllByText('Password must be at least 10 characters long')).toHaveLength(2);
   });
 
   it('should display error message if password contains spaces', async () => {
@@ -104,7 +104,7 @@ describe('Change your password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+    expect(screen.getAllByText('Password must not contain spaces')).toHaveLength(2);
   });
 
   it('should NOT display error messagess if fields are valid', async () => {
@@ -116,10 +116,10 @@ describe('Change your password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter a password')).not.toBeInTheDocument();
-    expect(screen.queryByText('Confirm a new password')).not.toBeInTheDocument();
+    expect(screen.queryByText('Confirm your new password')).not.toBeInTheDocument();
     expect(screen.queryByText('Passwords must match')).not.toBeInTheDocument();
-    expect(screen.queryByText('Passwords must be at least 10 characters long')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Password must be at least 10 characters long')).not.toBeInTheDocument();
+    expect(screen.queryByText('Password must not contain spaces')).not.toBeInTheDocument();
   });
 
   it('should take user to a confirmation page is there are no errors', async () => {

--- a/src/pages/Register/RegisterEmailAddress.jsx
+++ b/src/pages/Register/RegisterEmailAddress.jsx
@@ -48,11 +48,11 @@ const RegisterEmailAddress = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter an email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
         {
           type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter an email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
       ],
     },
@@ -67,7 +67,7 @@ const RegisterEmailAddress = () => {
         },
         {
           type: VALIDATE_FIELD_MATCH,
-          message: 'Your email addresses must match',
+          message: 'Email addresses must match',
           condition: 'emailAddress',
         },
       ],

--- a/src/pages/Register/RegisterEmailResend.jsx
+++ b/src/pages/Register/RegisterEmailResend.jsx
@@ -53,7 +53,7 @@ const RegisterEmailResend = () => {
         },
         {
           type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter an email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
       ],
     },

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -64,7 +64,7 @@ const RegisterYourDetails = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter an international dialling code',
+          message: 'Select an international dialling code',
         },
       ],
     },
@@ -95,7 +95,7 @@ const RegisterYourDetails = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Enter country',
+          message: 'Select a country',
         },
       ],
     },
@@ -120,7 +120,7 @@ const RegisterYourDetails = () => {
       validation: [
         {
           type: VALIDATE_REQUIRED,
-          message: 'Select is your company a shipping agent',
+          message: 'Select yes if your company is a shipping agent',
         },
       ],
     },

--- a/src/pages/Register/RegisterYourDetails.jsx
+++ b/src/pages/Register/RegisterYourDetails.jsx
@@ -80,7 +80,7 @@ const RegisterYourDetails = () => {
         },
         {
           type: VALIDATE_PHONE_NUMBER,
-          message: 'Enter a telephone number in the correct format',
+          message: 'Telephone number must be in the correct format',
         },
       ],
     },

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -57,12 +57,12 @@ const RegisterYourPassword = () => {
         },
         {
           type: VALIDATE_MIN_LENGTH,
-          message: 'Passwords must be at least 10 characters long',
+          message: 'Password must be at least 10 characters long',
           condition: 10,
         },
         {
           type: VALIDATE_NO_SPACES,
-          message: 'Enter a password that does not contain spaces',
+          message: 'Password must not contain spaces',
         },
       ],
     },

--- a/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailAddress.test.jsx
@@ -54,14 +54,14 @@ describe('Register email address tests', () => {
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should scroll to email field and set focus on email input if user clicks on email required error link', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.click(screen.getByTestId('submit-button'));
-    await user.click(screen.getByRole('button', { name: 'Enter an email address in the correct format, like name@example.com' }));
+    await user.click(screen.getByRole('button', { name: 'Enter a real email address' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getAllByRole('textbox', { name: /email/i })[0]).toHaveFocus();
   });
@@ -71,7 +71,7 @@ describe('Register email address tests', () => {
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail');
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should display the email invalid error if the email address has no .xx', async () => {
@@ -79,7 +79,7 @@ describe('Register email address tests', () => {
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should scroll to email field and set focus on email input if user clicks on email invalid format error link', async () => {
@@ -87,7 +87,7 @@ describe('Register email address tests', () => {
     render(<MemoryRouter><RegisterEmailAddress /></MemoryRouter>);
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    await user.click(screen.getByRole('button', { name: 'Enter an email address in the correct format, like name@example.com' }));
+    await user.click(screen.getByRole('button', { name: 'Enter a real email address' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getAllByRole('textbox', { name: /email/i })[0]).toHaveFocus();
   });
@@ -116,7 +116,7 @@ describe('Register email address tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo.com');
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Your email addresses must match')).toHaveLength(2);
+    expect(screen.getAllByText('Email addresses must match')).toHaveLength(2);
   });
 
   it('should scroll to repeat email field and set focus on repeat email input if user clicks on emails dont match error link', async () => {
@@ -125,7 +125,7 @@ describe('Register email address tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo.com');
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    await user.click(screen.getByRole('button', { name: 'Your email addresses must match' }));
+    await user.click(screen.getByRole('button', { name: 'Email addresses must match' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getAllByRole('textbox', { name: /email/i })[1]).toHaveFocus();
   });
@@ -137,8 +137,8 @@ describe('Register email address tests', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[1], 'testEMAIL@email.COM');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.queryByText('Enter your email address')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter your email address in the correct format, like name@example.com')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enter a real email address')).not.toBeInTheDocument();
     expect(screen.queryByText('Confirm your email address')).not.toBeInTheDocument();
-    expect(screen.queryByText('Your email addresses must match')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email addresses must match')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Register/__tests__/RegisterEmailResend.test.jsx
+++ b/src/pages/Register/__tests__/RegisterEmailResend.test.jsx
@@ -92,7 +92,7 @@ describe('Resend registration email verification email', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail');
     await user.click(screen.getByRole('button', { name: 'Request a new link' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
-    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should display the email invalid error if the email address has no .xx', async () => {
@@ -101,7 +101,7 @@ describe('Resend registration email verification email', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
     await user.click(screen.getByRole('button', { name: 'Request a new link' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
-    expect(screen.getAllByText('Enter an email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should scroll to email field and set focus on email input if user clicks on email invalid format error link', async () => {
@@ -110,7 +110,7 @@ describe('Resend registration email verification email', () => {
     await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
     await user.click(screen.getByRole('button', { name: 'Request a new link' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
-    await user.click(screen.getByRole('button', { name: 'Enter an email address in the correct format, like name@example.com' }));
+    await user.click(screen.getByRole('button', { name: 'Enter a real email address' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getAllByRole('textbox', { name: /email/i })[0]).toHaveFocus();
   });

--- a/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourDetails.test.jsx
@@ -153,9 +153,9 @@ describe('Register your details tests', () => {
     expect(screen.getAllByText('Enter your full name')).toHaveLength(2);
     expect(screen.getAllByText('Enter your company name')).toHaveLength(2);
     expect(screen.getAllByText('Enter a telephone number')).toHaveLength(2);
-    expect(screen.getAllByText('Enter an international dialling code')).toHaveLength(2);
-    expect(screen.getAllByText('Enter country')).toHaveLength(2);
-    expect(screen.getAllByText('Select is your company a shipping agent')).toHaveLength(2);
+    expect(screen.getAllByText('Select an international dialling code')).toHaveLength(2);
+    expect(screen.getAllByText('Select a country')).toHaveLength(2);
+    expect(screen.getAllByText('Select yes if your company is a shipping agent')).toHaveLength(2);
   });
 
   it('should display the error messages if fields are formatted incorrectly', async () => {
@@ -168,7 +168,7 @@ describe('Register your details tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a telephone number in the correct format')).toHaveLength(2);
+    expect(screen.getAllByText('Telephone number must be in the correct format')).toHaveLength(2);
   });
 
   it('should NOT display error messagess if fields are valid', async () => {
@@ -188,11 +188,11 @@ describe('Register your details tests', () => {
     expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter your full name')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter your company name')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter an international dialling code')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select an international dialling code')).not.toBeInTheDocument();
     expect(screen.queryByText('Enter a telephone number')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter a telephone number in the correct format')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter country')).not.toBeInTheDocument();
-    expect(screen.queryByText('Select is your company a shipping agent')).not.toBeInTheDocument();
+    expect(screen.queryByText('Telephone number must be in the correct format')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select a country')).not.toBeInTheDocument();
+    expect(screen.queryByText('Select yes if your company is a shipping agent')).not.toBeInTheDocument();
   });
 
   it('should NOT clear form session data on submit', async () => {

--- a/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
+++ b/src/pages/Register/__tests__/RegisterYourPassword.test.jsx
@@ -112,7 +112,7 @@ describe('Register password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Passwords must be at least 10 characters long')).toHaveLength(2);
+    expect(screen.getAllByText('Password must be at least 10 characters long')).toHaveLength(2);
   });
 
   it('should display the error messages if password values do not match', async () => {
@@ -144,7 +144,7 @@ describe('Register password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+    expect(screen.getAllByText('Password must not contain spaces')).toHaveLength(2);
   });
 
   it('should display the error messages if password value has spaces at the start', async () => {
@@ -154,7 +154,7 @@ describe('Register password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+    expect(screen.getAllByText('Password must not contain spaces')).toHaveLength(2);
   });
 
   it('should display the error messages if password value has spaces at the end', async () => {
@@ -164,7 +164,7 @@ describe('Register password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Enter a password that does not contain spaces')).toHaveLength(2);
+    expect(screen.getAllByText('Password must not contain spaces')).toHaveLength(2);
   });
 
   it('should display the required error messages if password value is only spaces', async () => {
@@ -175,7 +175,7 @@ describe('Register password tests', () => {
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
     expect(screen.getAllByText('Enter a password')).toHaveLength(2);
-    expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Password must not contain spaces')).not.toBeInTheDocument();
   });
 
   it('should display the min length error message if password has spaces and is fewer than 10 characters', async () => {
@@ -185,8 +185,8 @@ describe('Register password tests', () => {
     await user.click(screen.getByTestId('submit-button'));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem')).toBeInTheDocument();
-    expect(screen.getAllByText('Passwords must be at least 10 characters long')).toHaveLength(2);
-    expect(screen.queryByText('Enter a password that does not contain spaces')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Password must be at least 10 characters long')).toHaveLength(2);
+    expect(screen.queryByText('Password must not contain spaces')).not.toBeInTheDocument();
   });
 
   it('should NOT display error messagess if fields are valid', async () => {

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -61,7 +61,7 @@ const SignIn = () => {
         },
         {
           type: VALIDATE_EMAIL_ADDRESS,
-          message: 'Enter your email address in the correct format, like name@example.com',
+          message: 'Enter a real email address',
         },
       ],
     },

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -105,7 +105,7 @@ describe('Sign in tests', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail');
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter your email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should display the email invalid error if the email address has no .xx', async () => {
@@ -113,7 +113,7 @@ describe('Sign in tests', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    expect(screen.getAllByText('Enter your email address in the correct format, like name@example.com')).toHaveLength(2);
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
   });
 
   it('should scroll to email field and set focus on email input if user clicks on email invalid format error link', async () => {
@@ -121,8 +121,8 @@ describe('Sign in tests', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@boo');
     await user.click(screen.getByTestId('submit-button'));
-    await screen.findByRole('button', { name: 'Enter your email address in the correct format, like name@example.com' });
-    await user.click(screen.getByRole('button', { name: 'Enter your email address in the correct format, like name@example.com' }));
+    await screen.findByRole('button', { name: 'Enter a real email address' });
+    await user.click(screen.getByRole('button', { name: 'Enter a real email address' }));
     expect(scrollIntoViewMock).toHaveBeenCalled();
     expect(screen.getByRole('textbox', { name: /email/i })).toHaveFocus();
   });
@@ -133,7 +133,7 @@ describe('Sign in tests', () => {
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
     await user.click(screen.getByTestId('submit-button'));
     expect(screen.queryByText('Enter your email address')).not.toBeInTheDocument();
-    expect(screen.queryByText('Enter your email address in the correct format, like name@example.com')).not.toBeInTheDocument();
+    expect(screen.queryByText('Enter a real email address')).not.toBeInTheDocument();
   });
 
   it('should display the password required error if there is no password', async () => {

--- a/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
+++ b/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
@@ -1,5 +1,10 @@
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { DISPLAY_GROUPED, FIELD_RADIO, SINGLE_PAGE_FORM } from '../../constants/AppConstants';
+import {
+  DISPLAY_GROUPED,
+  FIELD_RADIO,
+  SINGLE_PAGE_FORM,
+  VALIDATE_REQUIRED,
+} from '../../constants/AppConstants';
 import { VOYAGE_TASK_LIST_URL, YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/DisplayForm';
 import Message from '../../components/Message';
@@ -38,7 +43,14 @@ const VoyageDeleteDraftCheck = () => {
           value: 'deleteDraftNo',
         },
       ],
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select yes if you want to delete your draft report',
+        },
+      ],
     },
+
   ];
 
   const handleSubmit = (formData) => {

--- a/src/pages/Voyage/__tests__/VoyageCrew.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrew.test.jsx
@@ -55,7 +55,7 @@ describe('Voyage crew page', () => {
     expect(screen.getByRole('heading', { name: `Upload the ${CREW_DETAILS_TEMPLATE_NAME}` })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Check for errors' }));
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: `Select a ${CREW_DETAILS_TEMPLATE_NAME}` })).toBeInTheDocument();
-    expect(screen.getAllByText(`Select a ${CREW_DETAILS_TEMPLATE_NAME}`)).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Select a file' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
   });
 });

--- a/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
@@ -140,12 +140,12 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
         C5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
-        F6: 'Value must be 35 characters or less',
+        F6: 'ensure this value has at most 35 characters',
         K5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
         D13: 'ensure this value has at most 35 characters',
-        G9: 'Value must be 35 characters or less',
-        E5: 'Value must be 35 characters or less',
-        J10: 'Value must be 35 characters or less',
+        G9: 'ensure this value has at most 35 characters',
+        E5: 'ensure this value has at most 35 characters',
+        J10: 'ensure this value has at most 35 characters',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -204,11 +204,11 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
         A5: 'Enter travel document as P, I, O or as Passport, ID card, Other',
-        E12: 'Value must use English letters instead of special characters not recognised',
+        E12: 'Enter the value using English letters instead of special characters not recognised',
         D8: 'Number of the travel document must be only numbers',
-        G9: 'Value must use English letters instead of special characters not recognised',
-        F6: 'Value must use English letters instead of special characters not recognised',
-        J22: 'Value must use English letters instead of special characters not recognised',
+        G9: 'Enter the value using English letters instead of special characters not recognised',
+        F6: 'Enter the value using English letters instead of special characters not recognised',
+        J22: 'Enter the value using English letters instead of special characters not recognised',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');

--- a/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
@@ -63,8 +63,8 @@ describe('Voyage general declaration page', () => {
     await user.click(screen.getByRole('button', { name: 'Check for errors' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: `Select a ${GENERAL_DECLARATION_TEMPLATE_NAME}` })).toBeInTheDocument();
-    expect(screen.getAllByText(`Select a ${GENERAL_DECLARATION_TEMPLATE_NAME}`)).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Select a file' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
   });
 
   /*

--- a/src/pages/Voyage/__tests__/VoyagePassengerUpload.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyagePassengerUpload.test.jsx
@@ -56,7 +56,7 @@ describe('Voyage passenger page', () => {
     await user.click(screen.getByRole('button', { name: 'Check for errors' }));
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: `Select a ${PASSENGER_DETAILS_TEMPLATE_NAME}` })).toBeInTheDocument();
-    expect(screen.getAllByText(`Select a ${PASSENGER_DETAILS_TEMPLATE_NAME}`)).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Select a file' })).toBeInTheDocument();
+    expect(screen.getAllByText('Select a file')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
# Ticket

NMSW-394

----

## AC

UCD has reviewed all error messages and need to update app & tests to match. We're switching to 'harsher' validation error messages. So 'Enter a password that does not contain spaces' is changing to 'Password must not contain spaces'. This is in order to align more closely with COP and E@B error messages.

----

## To test

- Open spreadsheet attached to the ticket and scroll down to the current NMSW error messages
- Run app
- Compare the error messages marked as 'incorrect' on the spread sheet to the error messages on the app
- > The error messages in the app should match the new error messages in the table on the spreadsheet
- Check FAL 5 error messages for invalid and max characters (see note below)

----

## Notes

- **I have had to make changes to the FAL 5 error mapping due to a BE refactor - will need to check FAL 5 errors for invalid characters and max characters**