### PR TITLE
NMSW-502 Allow 8 file to be added in supporting documents

### DIFF
--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -11,7 +11,7 @@ const FILE_STATUS_PENDING = 'Pending';
 const FILE_STATUS_IN_PROGRESS = 'in progress';
 const FILE_STATUS_ERROR = 'Error';
 const FILE_STATUS_SUCCESS = 'Success';
-const MAX_FILES = 7;
+const MAX_FILES = 8;
 
 const FileStatusInProgress = ({ fileName }) => (
   <div className="govuk-!-margin-bottom-5 multi-file-upload--filelist-filename">

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -122,7 +122,7 @@ describe('Multi file upload tests', () => {
     expect(screen.getAllByText('Pending')).toHaveLength(4);
   });
 
-  it('should only allow a max of seven files be selected for upload - more than 7 selected for add', async () => {
+  it('should only allow a max of eight files be selected for upload - more than 8 selected for add', async () => {
     const user = userEvent.setup();
     const files = [
       new File(['template1'], 'template1.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
@@ -133,16 +133,17 @@ describe('Multi file upload tests', () => {
       new File(['template6'], 'template6.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template7'], 'template7.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template9'], 'template9.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
 
     renderPage();
 
     const input = screen.getByTestId('multiFileUploadInput');
     await user.upload(input, files);
-    expect(screen.getAllByText("You've selected too many files: you can only add 7")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can only add 8")).toHaveLength(2);
   });
 
-  it('should only allow a max of seven files be added for upload - more than 7 selected over multiple adds', async () => {
+  it('should only allow a max of eight files be added for upload - more than 8 selected over multiple adds', async () => {
     const user = userEvent.setup();
     const files = [
       new File(['template1'], 'template1.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
@@ -155,6 +156,7 @@ describe('Multi file upload tests', () => {
       new File(['template6'], 'template6.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template7'], 'template7.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template9'], 'template9.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
 
     renderPage();
@@ -165,10 +167,10 @@ describe('Multi file upload tests', () => {
 
     await user.upload(input, additionalFiles);
     expect(screen.getAllByText('Pending')).toHaveLength(2); // it does not let user add the extra files, remains at 2
-    expect(screen.getAllByText("You've selected too many files: you can add up to 5 more files")).toHaveLength(2);
+    expect(screen.getAllByText("You've selected too many files: you can add up to 6 more files")).toHaveLength(2);
   });
 
-  it('should only allow a max of seven files be added for upload - 7 added and tries to add more', async () => {
+  it('should only allow a max of eight files be added for upload - 8 added and tries to add more', async () => {
     const user = userEvent.setup();
     const files = [
       new File(['template1'], 'template1.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
@@ -178,22 +180,23 @@ describe('Multi file upload tests', () => {
       new File(['template5'], 'template5.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template6'], 'template6.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template7'], 'template7.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
-    const additionalFiles = [new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+    const additionalFiles = [new File(['template9'], 'template9.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
 
     renderPage();
 
     const input = screen.getByTestId('multiFileUploadInput');
     await user.upload(input, files);
-    expect(screen.getAllByText('Pending')).toHaveLength(7);
+    expect(screen.getAllByText('Pending')).toHaveLength(8);
 
     await user.upload(input, additionalFiles);
-    expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
+    expect(screen.getAllByText('Pending')).toHaveLength(8); // it does not let user add the extra files, remains at 2
     expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
   });
 
-  it('should not repeat error messages when too many files selected for upload - 7 added and tries to add more', async () => {
+  it('should not repeat error messages when too many files selected for upload - 8 added and tries to add more', async () => {
     const user = userEvent.setup();
     const files = [
       new File(['template1'], 'template1.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
@@ -203,26 +206,27 @@ describe('Multi file upload tests', () => {
       new File(['template5'], 'template5.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template6'], 'template6.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
       new File(['template7'], 'template7.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
     const additionalFiles = [
-      new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template9'], 'template9.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
     const additionalFilesTwo = [
-      new File(['template8'], 'template8.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+      new File(['template9'], 'template9.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
     ];
 
     renderPage();
 
     const input = screen.getByTestId('multiFileUploadInput');
     await user.upload(input, files);
-    expect(screen.getAllByText('Pending')).toHaveLength(7);
+    expect(screen.getAllByText('Pending')).toHaveLength(8);
 
     await user.upload(input, additionalFiles);
-    expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
+    expect(screen.getAllByText('Pending')).toHaveLength(8); // it does not let user add the extra files, remains at 2
     expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
 
     await user.upload(input, additionalFilesTwo); // repeat and expect to still only have the 2 instance of error on screen
-    expect(screen.getAllByText('Pending')).toHaveLength(7); // it does not let user add the extra files, remains at 2
+    expect(screen.getAllByText('Pending')).toHaveLength(8); // it does not let user add the extra files, remains at 2
     expect(screen.getAllByText("You've selected too many files: you can add up to 0 more files")).toHaveLength(2);
   });
 


### PR DESCRIPTION
# Ticket

NMSW-502

----

## AC

We send FAL5&6 as one file, and FAL1 as one files - so can allow user to upload up to 8 more files.

----

## To test

- Run app
- Sign in
- Click Report a voyage
- Upload a good FAL 1
- Get the the task list page
- Click on supporting documents 
- Select 8 files
- > All 8 files should show in the list
- try to add a 9th file
- You should get max file error
- Refresh the page to clear the errors
- Try to add 9 files
- > You should get max file error
- Refresh the page to clear the errors
- Add a file
- Then try to add another 8 files
- You should get a max file error

----

## Notes
