### PR TITLE
NMSW-470 Redirect protected pages to sign in when no auth token

### DIFF
--- a/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
+++ b/src/pages/Voyage/VoyageDeleteDraftCheck.jsx
@@ -51,7 +51,6 @@ const VoyageDeleteDraftCheck = () => {
         },
       ],
     },
-
   ];
 
   const handleSubmit = (formData) => {
@@ -62,7 +61,7 @@ const VoyageDeleteDraftCheck = () => {
     }
   };
 
-  if (!declarationId || !state?.shipName) {
+  if (!declarationId) {
     return (
       <Message title="Something has gone wrong" redirectURL={YOUR_VOYAGES_URL} />
     );

--- a/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
@@ -41,14 +41,6 @@ describe('Voyage delete draft check are you sure page', () => {
     expect(screen.getByRole('button', { name: 'Confirm' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button" data-testid="submit-button">Confirm</button>');
   });
 
-  it('should render an error if no state', async () => {
-    mockUseLocationState.state = {};
-    renderPage();
-    await screen.findByRole('heading', { name: 'Something has gone wrong' });
-    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
-  });
-
   it('should render an error if no declarationId in params', async () => {
     mockUseLocationState = { state: { shipName: 'My ship name' } };
     render(

--- a/src/utils/ProtectedRoutes.jsx
+++ b/src/utils/ProtectedRoutes.jsx
@@ -1,10 +1,14 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { LANDING_URL } from '../constants/AppUrlConstants';
+import { SIGN_IN_URL } from '../constants/AppUrlConstants';
 
-const ProtectedRoutes = ({ isPermittedToView }) => (
-  isPermittedToView ? <Outlet /> : <Navigate to={LANDING_URL} replace />
-);
+const ProtectedRoutes = ({ isPermittedToView }) => {
+  const location = useLocation();
+
+  return (
+    isPermittedToView ? <Outlet /> : <Navigate to={SIGN_IN_URL} state={{ redirectURL: location }} replace />
+  );
+};
 
 export default ProtectedRoutes;
 


### PR DESCRIPTION
# Ticket

NMSW-470

----

## AC

Given a user tries to access a protected url
When the user is not signed in
Then they will be directed to the sign in page
When they sign in successfully
Then they will be redirected back to the protected url they tried to access

Given a request is made to a declaration endpoint
When the response indicates the declaration does not belong to the signed in user (404 declaration does not exist)
Then a message of 'declaration does not exist' is shown

----

## To test

This impacts all logged in pages, and the entire report voyage journey.
The key scenarios are listed in the Jira ticket.

To check the code changed in this ticket specifically you can

- start a report
- add a bad general declaration file
- click check for errors
- > you should see the error page
- delete your auth token
- click re-upload file
- > you should be taken to the sign in page
- sign in
- > you should be returned to the upload general declaration page
- add a good file
- click check for errors
- > you should be taken to the success page
- delete your auth token
- click save and continue
- > you should be taken to sign in
- sign in
- > you should be taken to task details page
- delete your token
- click on check your answers
- > you should be taken to sign in
- sign in
- > you should be taken to check your answers


----

## Notes
