### PR TITLE
NMSW-355 Display FAL 6 field level errors

### DIFF
--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -3,7 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../constants/AppConstants';
-import { FILE_MISSING, FILE_TYPE_INVALID_PREFIX } from '../constants/AppAPIConstants';
+import {
+  FILE_MISSING,
+  FILE_TYPE_INVALID_PREFIX,
+  FAL6_IS_EMPTY,
+} from '../constants/AppAPIConstants';
 import {
   FILE_UPLOAD_FIELD_ERRORS_URL,
   LOGGED_IN_LANDING,
@@ -128,6 +132,8 @@ const FileUploadForm = ({
               handleErrors({ errType: FILE_ERROR, errMessage: 'Select a file' });
             } else if (err?.response?.data?.message?.startsWith(FILE_TYPE_INVALID_PREFIX)) {
               handleErrors({ errType: FILE_ERROR, errMessage: `The file must be a ${fileTypesAllowed}` });
+            } else if (err?.response?.data?.message === FAL6_IS_EMPTY) {
+              handleErrors({ errType: FILE_ERROR, errMessage: 'Template is empty' });
             } else {
               handleErrors({ errType: FIELD_ERROR, errData: err?.response?.data });
             }

--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -6,6 +6,7 @@ import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY
 import {
   FILE_MISSING,
   FILE_TYPE_INVALID_PREFIX,
+  FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
 } from '../constants/AppAPIConstants';
 import {
@@ -132,7 +133,7 @@ const FileUploadForm = ({
               handleErrors({ errType: FILE_ERROR, errMessage: 'Select a file' });
             } else if (err?.response?.data?.message?.startsWith(FILE_TYPE_INVALID_PREFIX)) {
               handleErrors({ errType: FILE_ERROR, errMessage: `The file must be a ${fileTypesAllowed}` });
-            } else if (err?.response?.data?.message === FAL6_IS_EMPTY) {
+            } else if ((err?.response?.data?.message === FAL5_IS_EMPTY) || (err?.response?.data?.message === FAL6_IS_EMPTY)) {
               handleErrors({ errType: FILE_ERROR, errMessage: 'Template is empty' });
             } else {
               handleErrors({ errType: FIELD_ERROR, errData: err?.response?.data });

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -20,6 +20,7 @@ export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 // Responses
 export const FILE_MISSING = 'No file provided';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';
+export const FAL6_IS_EMPTY = 'No data rows found in file.';
 export const TOKEN_EXPIRED = 'Token has expired';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';
 export const TOKEN_USED_TO_REGISTER = 'Token was already used';

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -20,6 +20,7 @@ export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 // Responses
 export const FILE_MISSING = 'No file provided';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';
+export const FAL5_IS_EMPTY = 'File has no crew data';
 export const FAL6_IS_EMPTY = 'No data rows found in file.';
 export const TOKEN_EXPIRED = 'Token has expired';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';

--- a/src/constants/ErrorMappingFal5.js
+++ b/src/constants/ErrorMappingFal5.js
@@ -1,44 +1,47 @@
 const ErrorMappingFal5 = {
   A: { // travel document type
     order: 'a',
-    'none is not an allowed value': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
+    'field required': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
+    'travel document type must be 8 characters or less': 'Enter travel document as P, I, O or as Passport, ID card, Other',
     'Enter travel document as P, I, O or as Passport, ID card, Other': 'Enter travel document as P, I, O or as Passport, ID card, Other',
   },
   B: { // other travel doument type
     order: 'b',
     "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document": "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document",
+    'travel document nature must be 35 characters or less': 'Enter the type of travel document in 35 characters or less',
   },
   C: { // travel document issuing country
     order: 'c',
-    'none is not an allowed value': 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
-    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+    'field required': 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
+    'ensure this value has at most 3 characters': 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
   },
   D: { // travel document number
     order: 'd',
-    'none is not an allowed value': 'Enter the number of the travel document',
+    'field required': 'Enter the number of the travel document',
     'Number of the travel document must be only numbers': 'Enter the number of the travel document using only numbers',
-    'ensure this value has at most 35 characters': 'Enter the number of the travel document in 35 characters or less',
+    'travel document number must be 35 characters or less': 'Enter the number of the travel document in 35 characters or less',
   },
   E: { // rank or rating
     order: 'e',
-    'none is not an allowed value': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
+    'field required': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
     'ensure this value has at most 35 characters': 'Enter the rank, rating or job title in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
+    'Enter the rank or rating using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
   },
   F: { // surname
     order: 'f',
-    'none is not an allowed value': 'Enter family name or surname as it appears in the travel document',
-    'ensure this value has at most 35 characters': 'Enter family name or surname in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
+    'field required': 'Enter family name or surname as it appears in the travel document',
+    'surname must be 35 characters or less': 'Enter family name or surname in 35 characters or less',
+    'Enter the surname using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
   },
   G: { // forenames
     order: 'g',
-    'none is not an allowed value': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
-    'ensure this value has at most 35 characters': 'Enter all forenames or given names in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
+    'field required': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
+    'forenames must be 35 characters or less': 'Enter all forenames or given names in 35 characters or less',
+    'Enter the forenames using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
   },
   H: { // gender
     order: 'h',
+    'field required': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
     'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
   },
   I: { // date of birth
@@ -47,12 +50,12 @@ const ErrorMappingFal5 = {
   },
   J: { // place of birth
     order: 'j',
-    'ensure this value has at most 35 characters': 'Enter the place of birth in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
+    'place of birth must be 35 characters or less': 'Enter the place of birth in 35 characters or less',
+    'Enter the place of birth using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
   },
   K: { // nationality
     order: 'k',
-    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+    'ensure this value has at most 3 characters': 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
   },
   L: { // travel document expiry
     order: 'l',

--- a/src/constants/ErrorMappingFal6.js
+++ b/src/constants/ErrorMappingFal6.js
@@ -1,0 +1,81 @@
+const ErrorMappingFal6 = {
+  A: { // travel document type
+    order: 'a',
+    'field required': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
+    'Enter travel document as P, I, O or as Passport, ID card, Other': 'Enter travel document as P, I, O or as Passport, ID card, Other',
+  },
+  B: { // other travel doument type
+    order: 'b',
+    "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document": "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document",
+  },
+  C: { // travel document issuing country
+    order: 'c',
+    'field required': 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
+    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+  },
+  D: { // travel document number
+    order: 'd',
+    'field required': 'Enter the number of the travel document',
+    'Number of the travel document must be only numbers': 'Enter the number of the travel document using only numbers',
+    'travel document number must be 35 characters or less': 'Enter the number of the travel document in 35 characters or less',
+  },
+  E: { // surname
+    order: 'e',
+    'field required': 'Enter family name or surname as it appears in the travel document',
+    'surname must be 35 characters or less': 'Enter family name or surname in 35 characters or less',
+    'Enter the surname using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
+  },
+  F: { // forenames
+    order: 'f',
+    'field required': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
+    'forenames must be 35 characters or less': 'Enter all forenames or given names in 35 characters or less',
+    'Enter the forenames using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
+  },
+  G: { // gender
+    order: 'g',
+    'field required': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+    'ensure this value has at most 6 characters': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+    'Enter M for male, F for female, or X for gender neutral if this is in the travel document': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+  },
+  H: { // date of birth
+    order: 'h',
+    'Date must be in the dd/mm/yyyy format, for example, 22/02/2002': 'Enter the date of birth in the dd/mm/yyyy format, for example, 12/02/2022',
+  },
+  I: { // place of birth
+    order: 'i',
+    'place of birth must be 35 characters or less': 'Enter the place of birth in 35 characters or less',
+    'Enter the place of birth using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
+  },
+  J: { // nationality
+    order: 'j',
+    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+  },
+  K: { // travel document expiry
+    order: 'k',
+    'Date must be in the dd/mm/yyyy format, for example, 22/02/2002': 'Enter the travel document expiry date in the dd/mm/yyyy format, for example, 12/02/2022',
+  },
+  L: { // cabin number
+    order: 'l',
+    'Enter the cabin using only letters and numbers': 'Enter the cabin number using letters and numbers only and omit any other characters',
+    'cabin must be 35 characters or less': 'Enter the cabin number in 35 characters or less',
+  },
+  M: { // port of embarkation
+    order: 'm',
+    'field required': 'Enter the name of the port or the LOCODE for the port; for example, Southampton, GBSOU or GB SOU',
+    'port of embarkation must be 35 characters or less': 'Enter the name of the port in 35 characters or less',
+    'Enter the port of embarkation using only letters and numbers': 'Enter the name of the port using English letters instead of special characters not recognised',
+  },
+  N: { // port of disembarkation
+    order: 'n',
+    'field required': 'Enter the name of the port or the LOCODE for the port; for example, Southampton, GBSOU or GB SOU',
+    'port of disembarkation must be 35 characters or less': 'Enter the name of the port in 35 characters or less',
+    'Enter the port of disembarkation using only letters and numbers': 'Enter the name of the port using English letters instead of special characters not recognised',
+  },
+  O: { // transit
+    order: 'o',
+    'field required': 'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK',
+    'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK': 'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK',
+  },
+};
+
+export default ErrorMappingFal6;

--- a/src/pages/Voyage/VoyagePassengerUpload.jsx
+++ b/src/pages/Voyage/VoyagePassengerUpload.jsx
@@ -9,6 +9,7 @@ import {
   VOYAGE_PASSENGER_UPLOAD_URL,
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
+import ErrorMappingFal6 from '../../constants/ErrorMappingFal6';
 
 const VoyagePassengerUpload = () => {
   const [searchParams] = useSearchParams();
@@ -24,7 +25,7 @@ const VoyagePassengerUpload = () => {
   return (
     <FileUploadForm
       endpoint={`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}${ENDPOINT_FILE_UPLOAD_PASSENGER_DETAILS_PATH}`}
-      // errorMessageMapFile={}
+      errorMessageMapFile={ErrorMappingFal6}
       fileNameRequired={PASSENGER_DETAILS_TEMPLATE_NAME}
       fileTypesAllowed="csv or xlsx"
       formId="uploadPassengerDetails"

--- a/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
@@ -47,13 +47,13 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        F5: 'none is not an allowed value',
-        A5: 'none is not an allowed value',
-        C5: 'none is not an allowed value',
-        H5: 'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document',
-        D5: 'none is not an allowed value',
-        E5: 'none is not an allowed value',
-        G5: 'none is not an allowed value',
+        F5: 'field required',
+        A5: 'field required',
+        C5: 'field required',
+        H5: 'field required',
+        D5: 'field required',
+        E5: 'field required',
+        G5: 'field required',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -139,13 +139,14 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        C5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
-        F6: 'ensure this value has at most 35 characters',
-        K5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
-        D13: 'ensure this value has at most 35 characters',
-        G9: 'ensure this value has at most 35 characters',
+        C5: 'ensure this value has at most 3 characters',
+        F6: 'surname must be 35 characters or less',
+        K5: 'ensure this value has at most 3 characters',
+        B24: 'travel document nature must be 35 characters or less',
+        D13: 'travel document number must be 35 characters or less',
+        G9: 'forenames must be 35 characters or less',
         E5: 'ensure this value has at most 35 characters',
-        J10: 'ensure this value has at most 35 characters',
+        J10: 'place of birth must be 35 characters or less',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -155,6 +156,11 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
       state: {
         errorList: [
+          {
+            cell: 'B24',
+            message: 'Enter the type of travel document in 35 characters or less',
+            order: 'b',
+          },
           {
             cell: 'C5',
             message: 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
@@ -204,11 +210,12 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
         A5: 'Enter travel document as P, I, O or as Passport, ID card, Other',
-        E12: 'Enter the value using English letters instead of special characters not recognised',
+        E12: 'Enter the rank or rating using English letters instead of special characters not recognised',
         D8: 'Number of the travel document must be only numbers',
-        G9: 'Enter the value using English letters instead of special characters not recognised',
-        F6: 'Enter the value using English letters instead of special characters not recognised',
-        J22: 'Enter the value using English letters instead of special characters not recognised',
+        H12: 'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document',
+        G9: 'Enter forenames using English letters instead of special characters not recognised',
+        F6: 'Enter the surname using English letters instead of special characters not recognised',
+        J22: 'Enter the place of birth using English letters instead of special characters not recognised',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -242,6 +249,11 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
             cell: 'G9',
             message: 'Enter forenames using English letters instead of special characters not recognised',
             order: 'g',
+          },
+          {
+            cell: 'H12',
+            message: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+            order: 'h',
           },
           {
             cell: 'J22',

--- a/src/pages/Voyage/__tests__/VoyagePassengersErrorMapping.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyagePassengersErrorMapping.test.jsx
@@ -1,0 +1,345 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { FILE_UPLOAD_FIELD_ERRORS_URL } from '../../../constants/AppUrlConstants';
+import ErrorMappingFal6 from '../../../constants/ErrorMappingFal6';
+import FileUploadForm from '../../../components/FileUploadForm';
+
+const mockedUseNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+}));
+
+const renderPage = () => {
+  render(
+    <MemoryRouter>
+      <FileUploadForm
+        endpoint="/specific-endpoint-path-for-filetype"
+        errorMessageMapFile={ErrorMappingFal6}
+        fileNameRequired="File name from props for error display"
+        fileTypesAllowed="File types from props for error display"
+        formId="uploadFile"
+        pageHeading="Title from props"
+        submitButtonLabel="Submit text from props"
+        urlSuccessPage="/success-page/123"
+        urlThisPage="/this-page/123"
+      />
+    </MemoryRouter>,
+  );
+};
+
+describe('Error mapping for Passenger details (FAL 6) tests', () => {
+  const mockAxios = new MockAdapter(axios);
+  const scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+  beforeEach(() => {
+    mockAxios.reset();
+    window.sessionStorage.clear();
+  });
+
+  it('should map the mandatory fields missing Passenger details (FAL 6), in the specified order', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        F5: 'field required',
+        A5: 'field required',
+        C5: 'field required',
+        G5: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+        D5: 'field required',
+        E5: 'field required',
+        M5: 'field required',
+        O5: 'field required',
+        N5: 'field required',
+      });
+    renderPage();
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
+      state: {
+        errorList: [
+          {
+            cell: 'A5',
+            message: 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
+            order: 'a',
+          },
+          {
+            cell: 'C5',
+            message: 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
+            order: 'c',
+          },
+          {
+            cell: 'D5',
+            message: 'Enter the number of the travel document',
+            order: 'd',
+          },
+          {
+            cell: 'E5',
+            message: 'Enter family name or surname as it appears in the travel document',
+            order: 'e',
+          },
+          {
+            cell: 'F5',
+            message: 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
+            order: 'f',
+          },
+          {
+            cell: 'G5',
+            message: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+            order: 'g',
+          },
+          {
+            cell: 'M5',
+            message: 'Enter the name of the port or the LOCODE for the port; for example, Southampton, GBSOU or GB SOU',
+            order: 'm',
+          },
+          {
+            cell: 'N5',
+            message: 'Enter the name of the port or the LOCODE for the port; for example, Southampton, GBSOU or GB SOU',
+            order: 'n',
+          },
+          {
+            cell: 'O5',
+            message: 'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK',
+            order: 'o',
+          },
+        ],
+        fileName: 'template.xlsx',
+        returnURL: '/this-page/123',
+      },
+    });
+  });
+
+  it('should map correctly if there is an error for other document type field', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        B5: "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document",
+      });
+    renderPage();
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
+      state: {
+        errorList: [
+          {
+            cell: 'B5',
+            message: "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document",
+            order: 'b',
+          },
+        ],
+        fileName: 'template.xlsx',
+        returnURL: '/this-page/123',
+      },
+    });
+  });
+
+  it('should map the too many characters Passenger details (FAL 6), in the specified order', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        C5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+        F6: 'forenames must be 35 characters or less',
+        J20: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+        D13: 'travel document number must be 35 characters or less',
+        L97: 'cabin must be 35 characters or less',
+        E28: 'surname must be 35 characters or less',
+        I123: 'place of birth must be 35 characters or less',
+        G45: 'ensure this value has at most 6 characters',
+        M7: 'port of embarkation must be 35 characters or less',
+        N55: 'port of disembarkation must be 35 characters or less',
+      });
+    renderPage();
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
+      state: {
+        errorList: [
+          {
+            cell: 'C5',
+            message: 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+            order: 'c',
+          },
+          {
+            cell: 'D13',
+            message: 'Enter the number of the travel document in 35 characters or less',
+            order: 'd',
+          },
+          {
+            cell: 'E28',
+            message: 'Enter family name or surname in 35 characters or less',
+            order: 'e',
+          },
+          {
+            cell: 'F6',
+            message: 'Enter all forenames or given names in 35 characters or less',
+            order: 'f',
+          },
+          {
+            cell: 'G45',
+            message: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+            order: 'g',
+          },
+          {
+            cell: 'I123',
+            message: 'Enter the place of birth in 35 characters or less',
+            order: 'i',
+          },
+          {
+            cell: 'J20',
+            message: 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+            order: 'j',
+          },
+          {
+            cell: 'L97',
+            message: 'Enter the cabin number in 35 characters or less',
+            order: 'l',
+          },
+          {
+            cell: 'M7',
+            message: 'Enter the name of the port in 35 characters or less',
+            order: 'm',
+          },
+          {
+            cell: 'N55',
+            message: 'Enter the name of the port in 35 characters or less',
+            order: 'n',
+          },
+        ],
+        fileName: 'template.xlsx',
+        returnURL: '/this-page/123',
+      },
+    });
+  });
+
+  it('should map the invalid characters and incorrect values Crew Details (FAL 5) errors, in the specified order', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        A5: 'Enter travel document as P, I, O or as Passport, ID card, Other',
+        D8: 'Number of the travel document must be only numbers',
+        E45: 'Enter the surname using English letters instead of special characters not recognised',
+        F87: 'Enter the forenames using English letters instead of special characters not recognised',
+        G54: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+        I9: 'Enter the place of birth using English letters instead of special characters not recognised',
+        L16: 'Enter the cabin using only letters and numbers',
+        M23: 'Enter the port of embarkation using only letters and numbers',
+        N54: 'Enter the port of disembarkation using only letters and numbers',
+        O12: 'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK',
+      });
+    renderPage();
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
+      state: {
+        errorList: [
+          {
+            cell: 'A5',
+            message: 'Enter travel document as P, I, O or as Passport, ID card, Other',
+            order: 'a',
+          },
+          {
+            cell: 'D8',
+            message: 'Enter the number of the travel document using only numbers',
+            order: 'd',
+          },
+          {
+            cell: 'E45',
+            message: 'Enter family name or surname using English letters instead of special characters not recognised',
+            order: 'e',
+          },
+          {
+            cell: 'F87',
+            message: 'Enter forenames using English letters instead of special characters not recognised',
+            order: 'f',
+          },
+          {
+            cell: 'G54',
+            message: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+            order: 'g',
+          },
+          {
+            cell: 'I9',
+            message: 'Enter place of birth using English letters instead of special characters not recognised',
+            order: 'i',
+          },
+          {
+            cell: 'L16',
+            message: 'Enter the cabin number using letters and numbers only and omit any other characters',
+            order: 'l',
+          },
+          {
+            cell: 'M23',
+            message: 'Enter the name of the port using English letters instead of special characters not recognised',
+            order: 'm',
+          },
+          {
+            cell: 'N54',
+            message: 'Enter the name of the port using English letters instead of special characters not recognised',
+            order: 'n',
+          },
+          {
+            cell: 'O12',
+            message: 'Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK',
+            order: 'o',
+          },
+        ],
+        fileName: 'template.xlsx',
+        returnURL: '/this-page/123',
+      },
+    });
+  });
+
+  it('should map the dates in the wrong format for Passenger details (FAL 6) errors, in the specified order', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        K8: 'Date must be in the dd/mm/yyyy format, for example, 22/02/2002',
+        H6: 'Date must be in the dd/mm/yyyy format, for example, 22/02/2002',
+      });
+    renderPage();
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
+      state: {
+        errorList: [
+          {
+            cell: 'H6',
+            message: 'Enter the date of birth in the dd/mm/yyyy format, for example, 12/02/2022',
+            order: 'h',
+          },
+          {
+            cell: 'K8',
+            message: 'Enter the travel document expiry date in the dd/mm/yyyy format, for example, 12/02/2022',
+            order: 'k',
+          },
+        ],
+        fileName: 'template.xlsx',
+        returnURL: '/this-page/123',
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Ticket

NMSW-355

----

## AC

Given the fileupload FAL 6 endpoint has returned error messages
When those errors are displayed
The cell reference and error message text should match the table below:

<div class="table-wrap">


Cell | Field | Rule | Error Message
-- | -- | -- | --
A5-99+ | travelDocument | required | Enter P, I or O, or you may enter the full  word: P - Passport, I - ID card - for a national ID card, or O - Other -  for any other document
A5-99+ | travelDocument | wrong value | Enter travel document as P, I, O or as Passport, ID card, Other
B5-99+ | otherTDtype | require value when 'O' or 'Other' was entered in col A | You entered 'Other' as the travel document  type. You must enter the type of travel document, for example SID for  Seafarer's Identity Document
C5-99+ | travelDocumentIssuingCountry | required | Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD
C5-99+ | travelDocumentIssuingCountry | must be 3 letters | Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD
D5-99+ | travelDocumentNumber | required | Enter the number of the travel document
D5-99+ | travelDocumentNumber | only numbers | Enter the number of the travel document using only numbers
D5-99+ | travelDocumentNumber | max characters | Enter the number of the travel document in 35 characters or less
E5-99+ | familyName | required | Enter family name or surname as it appears in the travel document
E5-99+ | familyName | max characters | Enter family name or surname in 35 characters or less
E5-99+ | familyName | invalid characters | Enter family name or surname using English letters instead of special characters not recognised
F5-99+ | givenName | required | Enter all forenames or given names as they  appear in the travel document - if the crew member has no forename  recorded enter UNKNOWN
F5-99+ | givenName | max characters | Enter all forenames or given names in 35 characters or less
F5-99+ | givenName | invalid characters | Enter forenames using English letters instead of special characters not recognised
G5-99+ | gender | required | Enter M for male, F for female, or X for gender neutral if this is in the travel document
G5-99+ | gender | wrong value | Enter M for male, F for female, or X for gender neutral if this is in the travel document
H5-99+ | dateOfBirth | invalid format | Enter the date of birth in the dd/mm/yyyy format, for example, 12/02/2022
I5-99+ | placeOfBirth | max characters | Enter the place of birth in 35 characters or less
I5-99+ | placeOfBirth | invalid characters | Enter place of birth using English letters instead of special characters not recognised
J5-99+ | nationality | must be 3 letters | Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD
K5-99+ | travelDocumentExpiry | invalid format | Enter the travel document expiry date in the dd/mm/yyyy format, for example, 12/02/2022
L5-99+ | cabinNumber | only numbers | Enter the cabin number using letters and numbers only and omit any other characters
L5-99+ | cabinNumber | max characters | Enter the cabin number in 35 characters or less
M5-99+ | portOfEmbarkation | required | Enter the name of the port or the LOCODE for the port; for example, Southampton, GBSOU or GB SOU
M5-99+ | portOfEmbarkation | max characters | Enter the name of the port in 35 characters or less
M5-99+ | portOfEmbarkation | invalid characters | Enter the name of the port using English letters instead of special characters not recognised
N5-99+ | portOfDisembarkation | required | Enter the name of the port or the LOCODE for the port; for example, Tunis, TNTUN or TN TUN; Stockholm, SESTO or SE STO
N5-99+ | portOfDisembarkation | max characters | Enter the name of the port in 35 characters or less
N5-99+ | portOfDisembarkation | invalid characters | Enter the name of the port using English letters instead of special characters not recognised
O5-99+ | transit | required | Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK
O5-99+ | transit | wrong value | Enter Yes or Y if this passenger is in transit and No or N if this passenger is disembarking or embarking in the UK

</div></body></html>

----

## To test

To Test:
- Log in
- Click on Report a voyage button
- Upload a general declaration FAL 6
- Go through the process until you see the task list
- Click on "Any passenger details (FAL 6)" link
- Select 'yes' and continue
- Upload the 'Passenger details FAL 6 - blank.xlsx' file attached to the ticket
- > You should be see an error of 'Template is empty' in the error summary
- Upload the 'Passenger details FAL 6 - maxCharacters.xlsx' file attached to the ticket
- > You should be taken to the errors found page and be shown errors relating to max characters
- Click re-upload file
- Upload the 'Passenger details FAL 6 - invalidCharacters.xlsx' file attached to the ticket
- > You should be taken to the errors found page and be shown errors relating to characters
- Click re-upload file
- Upload the 'Passenger details FAL 6 - invalidDates.xlsx' file attached to the ticket
- > You should be taken to the errors found page and be shown errors relating to dates
- Click re-upload file
- Upload the 'Passenger details FAL 6 - missingOtherTD.xlsx' file attached to the ticket
- > You should be taken to the errors found page and be shown errors relating to missing the other TD type


----

## Notes

- When a blank FAL 6 is uploaded to the endpoint we get back 'message': 'No data rows found in file.' Therefore, I have had to create a secondary mapped error files for when we receive this message to ensure that the user sees the same field required errors as FAL 1 and FAL 5.