### PR TITLE
NMSW-397 Display task step statuses based on if we have file links for FAL 5 and 6

### DIFF
--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -56,45 +56,9 @@ const VoyageTaskList = () => {
       status: 'cannotStartYet',
     },
   );
-  const [steps, setStep] = useState([
-    {
-      item: 'generalDeclaration',
-      link: `${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
-      label: GENERAL_DECLARATION_LABEL,
-      status: 'completed', // this page does not load before this step is complete
-    },
-    {
-      item: 'crewDetails',
-      link: `${VOYAGE_CREW_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
-      label: CREW_DETAILS_LABEL,
-      status: 'required',
-
-    },
-    {
-      item: 'passengerDetails',
-      link: `${VOYAGE_PASSENGERS_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
-      label: PASSENGER_DETAILS_LABEL,
-      status: 'required',
-
-    },
-    {
-      item: 'supportingDocuments',
-      link: `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
-      label: SUPPORTING_DOCUMENTS_LABEL,
-      status: 'optional',
-
-    },
-  ]);
+  const [steps, setStep] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   document.title = 'Report a voyage';
-
-  const updateSteps = ({ itemName, newStatus }) => {
-    const updatedStepsArray = steps.map((arrayItem) => (
-      arrayItem.item === itemName
-        ? { ...arrayItem, status: newStatus }
-        : arrayItem));
-    setStep(updatedStepsArray);
-  };
 
   const updateDeclarationData = async () => {
     const response = await GetDeclaration({ declarationId });
@@ -102,16 +66,34 @@ const VoyageTaskList = () => {
       setDeclarationData(response.data);
       setVoyageTypeText(response.data?.FAL1.departureFromUk ? 'Departure from the UK' : 'Arrival to the UK');
 
-      updateSteps(
+      const updatedStatuses = [
         {
-          itemName: 'crewDetails',
-          newStatus: response.data.FAL5 ? 'completed' : 'required',
+          item: 'generalDeclaration',
+          link: `${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+          label: GENERAL_DECLARATION_LABEL,
+          status: 'completed', // this page does not load before this step is complete
         },
         {
-          itemName: 'passengerDetails',
-          newStatus: response.data.FAL6 ? 'completed' : 'required',
+          item: 'crewDetails',
+          link: `${VOYAGE_CREW_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+          label: CREW_DETAILS_LABEL,
+          status: response.data.FAL5 ? 'completed' : 'required',
         },
-      );
+        {
+          item: 'passengerDetails',
+          link: `${VOYAGE_PASSENGERS_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+          label: PASSENGER_DETAILS_LABEL,
+          status: response.data.FAL6 ? 'completed' : 'required',
+        },
+        {
+          item: 'supportingDocuments',
+          link: `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+          label: SUPPORTING_DOCUMENTS_LABEL,
+          status: 'optional',
+        },
+      ];
+
+      setStep(updatedStatuses);
 
       if (response.data.FAL1 && response.data.FAL5 && response.data.FAL6) {
         setCompletedSections(1);
@@ -137,8 +119,6 @@ const VoyageTaskList = () => {
       }
     }
 
-    // if report status is anything other than draft this page should not load, instead user will be taken
-    // directly to the check your answers page to view a cancelled or submitted report
     setIsLoading(false);
   };
 

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -115,7 +115,11 @@ const VoyageTaskList = () => {
 
       // Once we have generalDeclaration, crewDetails, passengerDetails all set to completed
       // then we can change completedSections to 1
-      setCompletedSections(0);
+      if (response.data.FAL1 && response.data.FAL5 && response.data.FAL6) {
+        setCompletedSections(1);
+      } else {
+        setCompletedSections(0);
+      }
 
       // and checkYourAnswer to notStarted
       setCheckYourAnswersStep({ ...checkYourAnswersStep });
@@ -155,7 +159,7 @@ const VoyageTaskList = () => {
   }
 
   if (isLoading) { return (<LoadingSpinner />); }
-  console.log('steps', steps)
+
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -102,11 +102,16 @@ const VoyageTaskList = () => {
       setDeclarationData(response.data);
       setVoyageTypeText(response.data?.FAL1.departureFromUk ? 'Departure from the UK' : 'Arrival to the UK');
 
-      // Once we have GET data for the other sections we can expand this to check which we have
-      // in the response data and then set new statuses accordingly
-      // e.g. we have reponse.data.FAL1 therefore generalDeclaration is completed
-      // leaving this here as example, but this page never loads without GenDec completed so this step is always status completed
-      updateSteps({ itemName: 'generalDeclaration', newStatus: 'completed' });
+      updateSteps(
+        {
+          itemName: 'crewDetails',
+          newStatus: response.data.FAL5 ? 'completed' : 'required',
+        },
+        {
+          itemName: 'passengerDetails',
+          newStatus: response.data.FAL6 ? 'completed' : 'required',
+        },
+      );
 
       // Once we have generalDeclaration, crewDetails, passengerDetails all set to completed
       // then we can change completedSections to 1
@@ -150,7 +155,7 @@ const VoyageTaskList = () => {
   }
 
   if (isLoading) { return (<LoadingSpinner />); }
-
+  console.log('steps', steps)
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -113,16 +113,13 @@ const VoyageTaskList = () => {
         },
       );
 
-      // Once we have generalDeclaration, crewDetails, passengerDetails all set to completed
-      // then we can change completedSections to 1
       if (response.data.FAL1 && response.data.FAL5 && response.data.FAL6) {
         setCompletedSections(1);
+        setCheckYourAnswersStep({ ...checkYourAnswersStep, status: 'notStarted' });
       } else {
         setCompletedSections(0);
+        setCheckYourAnswersStep({ ...checkYourAnswersStep, status: 'cannotStartYet' });
       }
-
-      // and checkYourAnswer to notStarted
-      setCheckYourAnswersStep({ ...checkYourAnswersStep });
     } else {
       switch (response?.status) {
         case 401:
@@ -195,14 +192,20 @@ const VoyageTaskList = () => {
               <h2 className="app-task-list__section"><span className="app-task-list__section-number">2. </span>Submit the report</h2>
               <ul className="app-task-list__items">
                 <li className="app-task-list__item">
-                  {/* <div data-testid="checkYourAnswers">
-                    <span>Check answers and submit</span>
-                    <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
-                  </div> */}
-                  <Link to={checkYourAnswersStep.link}>
-                    <span>Check answers and submit</span>
-                    <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
-                  </Link>
+                  {checkYourAnswersStep.status === 'cannotStartYet'
+                    && (
+                      <div data-testid="checkYourAnswers">
+                        <span>Check answers and submit</span>
+                        <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
+                      </div>
+                    )}
+                  {checkYourAnswersStep.status !== 'cannotStartYet'
+                    && (
+                      <Link to={checkYourAnswersStep.link}>
+                        <span>Check answers and submit</span>
+                        <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
+                      </Link>
+                    )}
                 </li>
               </ul>
             </li>


### PR DESCRIPTION
# Ticket

NMSW-397

----

## AC

GIVEN I have successfully uploaded a crew list
WHEN I return to the task list
THEN the Status of the "Upload crew list" task is displayed as "Completed"

GIVEN I have successfully uploaded a passenger list
WHEN I return to the task list
THEN the Status of the "Upload passenger list" task is displayed as "Completed" 

GIVEN I have successfully uploaded a crew and passenger list
WHEN I return to the task list
THEN the statement you have completed [x] of 2 sections should show 1 of 2

GIVEN I have successfully uploaded a passenger and crew list
WHEN I return to the task list
THEN the Status of the "'CYA' task is displayed as 'not started yet'
AND the link to the CYA page is clickable

----

## To test

- create a voyage
- upload Gen Dec form
- > task details should show
- gen dec as completed
- crew as required
- passenger as required
- CYA as cannot start yet with no link
- upload a crew form
- > task details should now show
- gen dec as completed
- crew as completed
- passenger as required
- CYA as cannot start yet with no link
- upload a passenger form
- > task details should now show
- gen dec as completed
- crew as completed
- passenger as completed
- CYA as not yet start WITH a link
- 'You have completed 1 of 2 sections.'

----

## Notes
