### PR TITLE
NMSW-522 Update FAL 5 erroring for blank files and field level errors

### DIFF
--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -6,6 +6,7 @@ import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY
 import {
   FILE_MISSING,
   FILE_TYPE_INVALID_PREFIX,
+  FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
 } from '../constants/AppAPIConstants';
 import {
@@ -132,7 +133,7 @@ const FileUploadForm = ({
               handleErrors({ errType: FILE_ERROR, errMessage: 'Select a file' });
             } else if (err?.response?.data?.message?.startsWith(FILE_TYPE_INVALID_PREFIX)) {
               handleErrors({ errType: FILE_ERROR, errMessage: `The file must be a ${fileTypesAllowed}` });
-            } else if (err?.response?.data?.message === FAL6_IS_EMPTY) {
+            } else if ((err?.response?.data?.message === FAL5_IS_EMPTY) || (err?.response?.data?.message === FAL6_IS_EMPTY)) {
               handleErrors({ errType: FILE_ERROR, errMessage: 'Template is empty' });
             } else {
               handleErrors({ errType: FIELD_ERROR, errData: err?.response?.data });

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -20,6 +20,7 @@ export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 // Responses
 export const FILE_MISSING = 'No file provided';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';
+export const FAL5_IS_EMPTY = 'File has no crew data';
 export const FAL6_IS_EMPTY = 'No data rows found in file.';
 export const TOKEN_EXPIRED = 'Token has expired';
 export const TOKEN_INVALID = 'Token is invalid or it has expired';

--- a/src/constants/ErrorMappingFal5.js
+++ b/src/constants/ErrorMappingFal5.js
@@ -3,6 +3,7 @@ const ErrorMappingFal5 = {
     order: 'a',
     'field required': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
     'travel document type must be 8 characters or less': 'Enter travel document as P, I, O or as Passport, ID card, Other',
+    'Enter travel document as P, I, O or as Passport, ID card, Other': 'Enter travel document as P, I, O or as Passport, ID card, Other',
   },
   B: { // other travel doument type
     order: 'b',
@@ -24,13 +25,13 @@ const ErrorMappingFal5 = {
     order: 'e',
     'field required': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
     'ensure this value has at most 35 characters': 'Enter the rank, rating or job title in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
+    'Enter the rank or rating using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
   },
   F: { // surname
     order: 'f',
     'field required': 'Enter family name or surname as it appears in the travel document',
     'surname must be 35 characters or less': 'Enter family name or surname in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
+    'Enter the surname using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
   },
   G: { // forenames
     order: 'g',
@@ -50,7 +51,7 @@ const ErrorMappingFal5 = {
   J: { // place of birth
     order: 'j',
     'place of birth must be 35 characters or less': 'Enter the place of birth in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
+    'Enter the place of birth using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
   },
   K: { // nationality
     order: 'k',

--- a/src/constants/ErrorMappingFal5.js
+++ b/src/constants/ErrorMappingFal5.js
@@ -1,44 +1,46 @@
 const ErrorMappingFal5 = {
   A: { // travel document type
     order: 'a',
-    'none is not an allowed value': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
-    'Enter travel document as P, I, O or as Passport, ID card, Other': 'Enter travel document as P, I, O or as Passport, ID card, Other',
+    'field required': 'Enter P, I or O, or you may enter the full word: P - Passport, I - ID card - for a national ID card or O - Other - for any other document',
+    'travel document type must be 8 characters or less': 'Enter travel document as P, I, O or as Passport, ID card, Other',
   },
   B: { // other travel doument type
     order: 'b',
     "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document": "You entered 'Other' as the travel document type. You must enter the type of travel document, for example SID for Seafarer's Identity Document",
+    'travel document nature must be 35 characters or less': 'Enter the type of travel document in 35 characters or less',
   },
   C: { // travel document issuing country
     order: 'c',
-    'none is not an allowed value': 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
-    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+    'field required': 'Enter the 3-letter ISO country code for the issuing country; for example, GBR, SWE, NLD',
+    'ensure this value has at most 3 characters': 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
   },
   D: { // travel document number
     order: 'd',
-    'none is not an allowed value': 'Enter the number of the travel document',
+    'field required': 'Enter the number of the travel document',
     'Number of the travel document must be only numbers': 'Enter the number of the travel document using only numbers',
-    'ensure this value has at most 35 characters': 'Enter the number of the travel document in 35 characters or less',
+    'travel document number must be 35 characters or less': 'Enter the number of the travel document in 35 characters or less',
   },
   E: { // rank or rating
     order: 'e',
-    'none is not an allowed value': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
+    'field required': 'Enter the rank, rating or job title; for supernumeraries just put SN or supernumerary, not the job title',
     'ensure this value has at most 35 characters': 'Enter the rank, rating or job title in 35 characters or less',
     'Enter the value using English letters instead of special characters not recognised': 'Enter the rank, rating or job title using English letters instead of special characters not recognised',
   },
   F: { // surname
     order: 'f',
-    'none is not an allowed value': 'Enter family name or surname as it appears in the travel document',
-    'ensure this value has at most 35 characters': 'Enter family name or surname in 35 characters or less',
+    'field required': 'Enter family name or surname as it appears in the travel document',
+    'surname must be 35 characters or less': 'Enter family name or surname in 35 characters or less',
     'Enter the value using English letters instead of special characters not recognised': 'Enter family name or surname using English letters instead of special characters not recognised',
   },
   G: { // forenames
     order: 'g',
-    'none is not an allowed value': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
-    'ensure this value has at most 35 characters': 'Enter all forenames or given names in 35 characters or less',
-    'Enter the value using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
+    'field required': 'Enter all forenames or given names as they appear in the travel document - if the crew member has no forename recorded enter UNKNOWN',
+    'forenames must be 35 characters or less': 'Enter all forenames or given names in 35 characters or less',
+    'Enter the forenames using English letters instead of special characters not recognised': 'Enter forenames using English letters instead of special characters not recognised',
   },
   H: { // gender
     order: 'h',
+    'field required': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
     'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
   },
   I: { // date of birth
@@ -47,12 +49,12 @@ const ErrorMappingFal5 = {
   },
   J: { // place of birth
     order: 'j',
-    'ensure this value has at most 35 characters': 'Enter the place of birth in 35 characters or less',
+    'place of birth must be 35 characters or less': 'Enter the place of birth in 35 characters or less',
     'Enter the value using English letters instead of special characters not recognised': 'Enter place of birth using English letters instead of special characters not recognised',
   },
   K: { // nationality
     order: 'k',
-    'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD': 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
+    'ensure this value has at most 3 characters': 'Enter the nationality as a 3-letter ISO country code; for example, GBR, SWE, NLD',
   },
   L: { // travel document expiry
     order: 'l',

--- a/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
@@ -47,13 +47,13 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        F5: 'none is not an allowed value',
-        A5: 'none is not an allowed value',
-        C5: 'none is not an allowed value',
-        H5: 'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document',
-        D5: 'none is not an allowed value',
-        E5: 'none is not an allowed value',
-        G5: 'none is not an allowed value',
+        F5: 'field required',
+        A5: 'field required',
+        C5: 'field required',
+        H5: 'field required',
+        D5: 'field required',
+        E5: 'field required',
+        G5: 'field required',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -139,13 +139,14 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        C5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
-        F6: 'ensure this value has at most 35 characters',
-        K5: 'Enter the country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
-        D13: 'ensure this value has at most 35 characters',
-        G9: 'ensure this value has at most 35 characters',
+        C5: 'ensure this value has at most 3 characters',
+        F6: 'surname must be 35 characters or less',
+        K5: 'ensure this value has at most 3 characters',
+        B24: 'travel document nature must be 35 characters or less',
+        D13: 'travel document number must be 35 characters or less',
+        G9: 'forenames must be 35 characters or less',
         E5: 'ensure this value has at most 35 characters',
-        J10: 'ensure this value has at most 35 characters',
+        J10: 'place of birth must be 35 characters or less',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');
@@ -155,6 +156,11 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith(FILE_UPLOAD_FIELD_ERRORS_URL, {
       state: {
         errorList: [
+          {
+            cell: 'B24',
+            message: 'Enter the type of travel document in 35 characters or less',
+            order: 'b',
+          },
           {
             cell: 'C5',
             message: 'Enter the issuing country as a 3-letter ISO country code; for example, GBR, SWE, NLD',
@@ -206,7 +212,8 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
         A5: 'Enter travel document as P, I, O or as Passport, ID card, Other',
         E12: 'Enter the value using English letters instead of special characters not recognised',
         D8: 'Number of the travel document must be only numbers',
-        G9: 'Enter the value using English letters instead of special characters not recognised',
+        H12: 'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document',
+        G9: 'Enter forenames using English letters instead of special characters not recognised',
         F6: 'Enter the value using English letters instead of special characters not recognised',
         J22: 'Enter the value using English letters instead of special characters not recognised',
       });
@@ -242,6 +249,11 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
             cell: 'G9',
             message: 'Enter forenames using English letters instead of special characters not recognised',
             order: 'g',
+          },
+          {
+            cell: 'H12',
+            message: 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+            order: 'h',
           },
           {
             cell: 'J22',

--- a/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrewErrorMapping.test.jsx
@@ -210,12 +210,12 @@ describe('Error mapping for Crew Details (FAL 5) tests', () => {
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
         A5: 'Enter travel document as P, I, O or as Passport, ID card, Other',
-        E12: 'Enter the value using English letters instead of special characters not recognised',
+        E12: 'Enter the rank or rating using English letters instead of special characters not recognised',
         D8: 'Number of the travel document must be only numbers',
         H12: 'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document',
         G9: 'Enter forenames using English letters instead of special characters not recognised',
-        F6: 'Enter the value using English letters instead of special characters not recognised',
-        J22: 'Enter the value using English letters instead of special characters not recognised',
+        F6: 'Enter the surname using English letters instead of special characters not recognised',
+        J22: 'Enter the place of birth using English letters instead of special characters not recognised',
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');


### PR DESCRIPTION
# Ticket

NMSW-522

----

## AC

Given I try to upload a blank FAL 5 file
When I click check for errors
Then I am shown a 'Template is empty' error in the error summary

Due to BE changes and after speaking with UCD - blank files should now return a 'Template is empty' error that will show in the error summary on the Crew Details upload page

Also, the wording we get from the BE for certain errors has been changed so we will also need to re-map these errors on the FE

- Blank field errors
- Max character errors
- Invalid character messages

----

## To test

- Run app
- Create a voyage
- Get to Crew details FAL 5 upload
- Upload a blank file
- > You should get a 'Template is empty' error in the summary
- Upload a file with invalid characters
- > You should be taken to the error page with invalid character errors
- Click re-upload file
- Upload a file with max characters
- > You should be taken to the error page with max character errors
- Upload a file with blank fields in some of the required fields
- > You should get field is required errors

----

## Notes
