### PR TITLE
NMSW-529

### DIFF
--- a/src/pages/Voyage/FileUploadConfirmation.jsx
+++ b/src/pages/Voyage/FileUploadConfirmation.jsx
@@ -9,7 +9,7 @@ const FileUploadConfirmation = () => {
   const declarationId = searchParams.get(URL_DECLARATIONID_IDENTIFIER);
   document.title = 'No errors found';
 
-  if (!declarationId || !state?.fileName) {
+  if (!declarationId) {
     return (
       <Message title="Something has gone wrong" redirectURL={YOUR_VOYAGES_URL} />
     );
@@ -32,7 +32,7 @@ const FileUploadConfirmation = () => {
             </div>
             <div className="govuk-notification-banner__content">
               <h3 className="govuk-notification-banner__heading">
-                {`${state?.fileName ? state?.fileName : ''} uploaded`}
+                {`${state?.fileName ? state?.fileName : 'File'} uploaded`}
               </h3>
             </div>
           </div>

--- a/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
+++ b/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
@@ -53,12 +53,10 @@ describe('File upload success confirmation page', () => {
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
-  it('should render an error without fileName in state', async () => {
+  it('should render a generic statement without fileName in state', async () => {
     mockUseLocationState.state = {};
     renderPage();
-    await screen.findByRole('heading', { name: 'Something has gone wrong' });
-    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByText('File uploaded')).toBeInTheDocument();
   });
 
   it('should go to the voyage task list page on button click', async () => {


### PR DESCRIPTION
# Ticket

NMSW-529

----

## AC

- user pastes a URL for a file upload successful page
- user is not signed in
- user signs in

**expected:**
we redirect to file upload success page

**actual:**
we redirected to something went wrong

This was because we required filename to be in state for file upload success page, and in this above scenario it is not.

----

## To test

- create a voyage up to a file upload success page
- copy the url
- sign out
- paste the url
- sign in
- you should be returned to the file upload success page

----

## Notes

If you paste this url and sign in as a user who does not own that declaration ID you will be shown the file upload success page. However when you click 'save and continue' you will get an error. Ticket 530