### PR TITLE
Test nmsw 397

### DIFF
--- a/cypress/e2e/features/check-your-answers-page.feature
+++ b/cypress/e2e/features/check-your-answers-page.feature
@@ -33,7 +33,7 @@ Feature: Check your answer page
     Then I can view Check Your Answers page
     Then I can verify the Check Your Answers page
 
-  Scenario: User can Verify the details upload and change the details
+  Scenario Outline: User can Verify the details upload and change the details
     And the details from my FAL 1 form are displayed on CYA page
     When I click change the voyage details link
     Then I am taken to upload-general-declaration page
@@ -48,6 +48,13 @@ Feature: Check your answer page
     And I sign-out
     When I try to access a protected CYA page with declaration Id
     Then I am taken to the sign-in page
-    When I have entered a correct email address and password and sign in
-    Then I can view Check Your Answers page
+    When I provide incorrect '<emailAddress>' and '<password>' and sign-in
+    Then I am taken to error message page
+    When I click - Click here to continue
+    Then I am taken to your-voyages page
+    And I sign-out
+    Examples:
+      | emailAddress                                       | password      |
+      | 98748f98-2dcf-41b8-8bc9-9627e6cd0d80@mailslurp.com | Test-NMSW-Dev |
+
 

--- a/cypress/e2e/features/check-your-answers-page.feature
+++ b/cypress/e2e/features/check-your-answers-page.feature
@@ -43,4 +43,11 @@ Feature: Check your answer page
     When I click save and continue
     Then I am taken to task details page
     When I click Check answers and submit
+    Then the FE sends a POST to the declarationId endpoint
     Then I can view Check Your Answers page
+    And I sign-out
+    When I try to access a protected CYA page with declaration Id
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
+    Then I can view Check Your Answers page
+

--- a/cypress/e2e/features/check-your-answers-page.feature
+++ b/cypress/e2e/features/check-your-answers-page.feature
@@ -12,12 +12,29 @@ Feature: Check your answer page
     When there are no errors, I am shown the no errors found page
     When I click save and continue
     Then I am taken to task details page
-    Then I can verify voyage details on the task details page
+    When I click crew details link
+    Then I am taken to upload-crew-details page
+    When I have uploaded 'Fal5-Files''Crew details including supernumeraries FAL 5-Positive-Test.xlsx'
+    When I click check for errors
+    When there are no errors, I am shown the no errors found page
+    When I click save and continue
+    Then I am taken to task details page
+    When I click Passenger details link
+    Then I am taken to Passenger-details page
+    When I select Yes to uploading passenger details
+    Then I am taken to upload-Passenger-details page
+    When I have uploaded 'Fal6-Files''Passenger details FAL 6-PositiveData.xlsx'
+    When I click check for errors
+    When there are no errors, I am shown the no errors found page
+    When I click save and continue
+    Then I am taken to task details page
+    And I can see Check answers and submit enabled
     When I click Check answers and submit
+    Then I can view Check Your Answers page
     Then I can verify the Check Your Answers page
 
-  Scenario: Verify the details of Voyage details
-    Then the details from my FAL 1 form are displayed on CYA page
+  Scenario: User can Verify the details upload and change the details
+    And the details from my FAL 1 form are displayed on CYA page
     When I click change the voyage details link
     Then I am taken to upload-general-declaration page
     When I have uploaded 'Fal1-Files''General declaration FAL 1 - goodData.xlsx'
@@ -25,6 +42,5 @@ Feature: Check your answer page
     When there are no errors, I am shown the no errors found page
     When I click save and continue
     Then I am taken to task details page
-    Then I can verify new voyage details on the task details page
     When I click Check answers and submit
     Then I can view Check Your Answers page

--- a/cypress/e2e/features/fal1-upload-general-declaration.feature
+++ b/cypress/e2e/features/fal1-upload-general-declaration.feature
@@ -28,7 +28,6 @@ Feature: Upload General declaration (FAL1) page
   Scenario: Upload general declaration (Fal1) successfully
     When I have uploaded 'Fal1-Files''General declaration FAL 1-Positive-test.xlsx'
     When I click check for errors
-    Then the FE sends a POST to the declaration-declarationId-upload-fal1 endpoint
     When there are no errors, I am shown the no errors found for 'General declaration FAL 1-Positive-test.xlsx'
     When I click save and continue
     Then I am taken to task details page

--- a/cypress/e2e/features/sign-in.feature
+++ b/cypress/e2e/features/sign-in.feature
@@ -20,7 +20,7 @@ Feature: User sign-in
   Scenario:  User should not be signed-in when email is in invalid format
     When the user enters invalid email address and sign-in
     Then I am shown corresponding error message
-      | Field | email-error                                                                  |
+      | Field | email-error                       |
       | Error | Error: Enter a real email address |
 
   Scenario: User should not be signed-in without providing email and password
@@ -38,5 +38,5 @@ Feature: User sign-in
       | 4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com | test-12  |
 
   Scenario: User should not be signed-in without providing email and password
-    When user try to access a protected page
-    Then user is redirected to NMSW landing page
+    When I try to access a protected page
+    Then I am taken to the sign-in page

--- a/cypress/e2e/features/task-details-page.feature
+++ b/cypress/e2e/features/task-details-page.feature
@@ -11,8 +11,14 @@ Feature: Task details page after file uploads
   Scenario: I can see task details page after fal1 gets uploaded successfully
     When I have uploaded 'Fal1-Files''General declaration FAL 1-Positive-test.xlsx'
     When I click check for errors
+    Then the FE sends a POST to the declarationId endpoint
     When there are no errors, I am shown the no errors found page
     When I click save and continue
+    Then I am taken to task details page
+    And I sign-out
+    When I try to access a protected page with declaration Id
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
     Then I am taken to task details page
     Then I can verify voyage details on the task details page
     And I can see Check answers and submit not enabled
@@ -31,8 +37,14 @@ Feature: Task details page after file uploads
     Then I am taken to upload-Passenger-details page
     When I have uploaded 'Fal6-Files''Passenger details FAL 6-PositiveData.xlsx'
     When I click check for errors
+    Then the FE sends a POST to the declarationId endpoint
     When there are no errors, I am shown the no errors found page
     When I click save and continue
+    Then I am taken to task details page
+    And I sign-out
+    When I try to access a protected page with declaration Id
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
     Then I am taken to task details page
     And I can see status for FAL6 as completed
     And I can see Check answers and submit enabled
@@ -45,7 +57,7 @@ Feature: Task details page after file uploads
     When I click Yes to delete the draft
     Then I am taken to your-voyages page
 
-  Scenario: Verify application navigates user to landing page with missing auth token
+  Scenario: Verify application navigates user to sign-in page with missing auth token
     When I have uploaded 'Fal1-Files''General declaration FAL 1-Positive-test.xlsx'
     When I click check for errors
     When there are no errors, I am shown the no errors found page

--- a/cypress/e2e/features/task-details-page.feature
+++ b/cypress/e2e/features/task-details-page.feature
@@ -15,6 +15,27 @@ Feature: Task details page after file uploads
     When I click save and continue
     Then I am taken to task details page
     Then I can verify voyage details on the task details page
+    And I can see Check answers and submit not enabled
+    When I click crew details link
+    Then I am taken to upload-crew-details page
+    When I have uploaded 'Fal5-Files''Crew details including supernumeraries FAL 5-Positive-Test.xlsx'
+    When I click check for errors
+    When there are no errors, I am shown the no errors found page
+    When I click save and continue
+    Then I am taken to task details page
+    And I can see status for FAL5 as completed
+    And I can see Check answers and submit not enabled
+    When I click Passenger details link
+    Then I am taken to Passenger-details page
+    When I select Yes to uploading passenger details
+    Then I am taken to upload-Passenger-details page
+    When I have uploaded 'Fal6-Files''Passenger details FAL 6-PositiveData.xlsx'
+    When I click check for errors
+    When there are no errors, I am shown the no errors found page
+    When I click save and continue
+    Then I am taken to task details page
+    And I can see status for FAL6 as completed
+    And I can see Check answers and submit enabled
     When I click delete draft
     Then I am taken to confirm delete draft page
     When I click No to delete the draft
@@ -30,7 +51,6 @@ Feature: Task details page after file uploads
     When there are no errors, I am shown the no errors found page
     When auth token is no longer available
     When I click save and continue
-    Then user is redirected to NMSW landing page
-#    And I click start now
-#    When I have entered a correct email address and password and sign in
-#    Then I am taken to task details page
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
+    Then I am taken to task details page

--- a/cypress/e2e/features/upload-supporting-documents.feature
+++ b/cypress/e2e/features/upload-supporting-documents.feature
@@ -46,6 +46,11 @@ Feature: Upload supporting documents
       | fileName                  |
       | MELLINA CREW EFFECTS.xlsx |
     Then I am shown an error message for 'MELLINA CREW EFFECTS.xlsx'
+    When auth token is no longer available
+    When I click upload files
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
+    Then I am taken to upload supporting documents page
     Then I am able to add more limited number files to already added supporting files
       | fileName                                     |
       | GDF1-arrival-errors.xlsx                     |
@@ -54,9 +59,17 @@ Feature: Upload supporting documents
       | fileName                                                             |
       | MELLINA SHIPS STORES (003).xlsx                                      |
       | NMSW FAL 5 and 6 Supporting Information - Crew Off Signers List.xlsx |
+      | General declaration FAL 1 - goodData.xlsx                            |
+      | MELLINA CREW EFFECTS.xlsx                                            |
+      | MELLINA GEN DEC.xlsx                                                 |
+      | MELLINA GEN DEC2.xlsx                                                |
+      | USPassportinside.jpg                                                 |
     Then I am shown corresponding error message
       | Field | multiFileUploadForm-error                                             |
-      | Error | Error: You've selected too many files: you can add up to 1 more files |
+      | Error | Error: You've selected too many files: you can add up to 6 more files |
     Then I am able to delete the file
+    When auth token is no longer available
     When I click save and continue
+    Then I am taken to the sign-in page
+    When I have entered a correct email address and password and sign in
     Then I am taken to task details page

--- a/cypress/e2e/pages/file-upload.page.js
+++ b/cypress/e2e/pages/file-upload.page.js
@@ -102,6 +102,10 @@ class FileUploadPage {
   selectNoPassenger() {
     cy.get('input[id="passengers-input[1]"]').click();
   }
+
+  clickUpload() {
+    cy.contains('Upload files').click();
+  }
 }
 
 export default new FileUploadPage();

--- a/cypress/e2e/pages/task.page.js
+++ b/cypress/e2e/pages/task.page.js
@@ -11,6 +11,7 @@ class TaskPage {
 
   checkFal1UploadDocStatus() {
     cy.get(':nth-child(1) > .app-task-list__items > :nth-child(1)').contains('General Declaration (FAL 1)Completed');
+    cy.get('main#content div:nth-child(2) > div > p').should('have.text','You have completed 0 of 2 sections.')
     cy.get(':nth-child(2) > .app-task-list__items > .app-task-list__item').contains('Check answers and submitCannot start yet');
   }
 
@@ -34,6 +35,15 @@ class TaskPage {
   clickNoDeleteDraft() {
     cy.get('input[value=deleteDraftNo]').click();
     cy.contains('Confirm').click();
+  }
+
+  checkFal5Status() {
+    cy.get('main#content li:nth-child(2) > a > strong').should('have.text','Completed');
+  }
+
+  checkFal6Status() {
+    cy.get('main#content li:nth-child(3) > a > strong').should('have.text','Completed');
+    cy.get('main#content div:nth-child(2) > div > p').should('have.text','You have completed 1 of 2 sections.');
   }
 }
 

--- a/cypress/support/step_definitions/check-your-answers-page.steps.js
+++ b/cypress/support/step_definitions/check-your-answers-page.steps.js
@@ -1,6 +1,7 @@
 import {Then, When} from "@badeball/cypress-cucumber-preprocessor";
 import cyaPage from "../../e2e/pages/cya.page";
 import BasePage from "../../e2e/pages/base.page";
+import FileUploadPage from "../../e2e/pages/file-upload.page";
 
 When('I click Check answers and submit', () => {
   cyaPage.clickCheckAnswersAndSubmit();
@@ -53,4 +54,9 @@ Then('I am taken to error message page', () => {
 
 When('I click - Click here to continue', () => {
   cy.contains('Click here to continue').click();
+});
+
+When('I click upload files', () => {
+  FileUploadPage.clickUpload();
+  cy.wait(1000);
 });

--- a/cypress/support/step_definitions/check-your-answers-page.steps.js
+++ b/cypress/support/step_definitions/check-your-answers-page.steps.js
@@ -1,5 +1,6 @@
 import {Then, When} from "@badeball/cypress-cucumber-preprocessor";
 import cyaPage from "../../e2e/pages/cya.page";
+import BasePage from "../../e2e/pages/base.page";
 
 When('I click Check answers and submit', () => {
   cyaPage.clickCheckAnswersAndSubmit();
@@ -44,4 +45,12 @@ Then('the details from my FAL 1 form are displayed on CYA page', () => {
 
 When('I click change the voyage details link', () => {
   cyaPage.clickChangeVoyageDetailLink();
+});
+
+Then('I am taken to error message page', () => {
+  BasePage.checkH1('Something has gone wrong');
+});
+
+When('I click - Click here to continue', () => {
+  cy.contains('Click here to continue').click();
 });

--- a/cypress/support/step_definitions/fal1-upload-general-declaration.steps.js
+++ b/cypress/support/step_definitions/fal1-upload-general-declaration.steps.js
@@ -3,6 +3,7 @@ import YourVoyagePage from "../../e2e/pages/your-voyage.page";
 import FileUploadPage from "../../e2e/pages/file-upload.page";
 import LandingPage from "../../e2e/pages/landing.page";
 import TaskPage from "../../e2e/pages/task.page";
+import SignInPage from "../../e2e/pages/sign-in.page";
 
 let fileName;
 
@@ -56,10 +57,11 @@ When('I click check for errors', () => {
   FileUploadPage.clickCheckForErrors();
 });
 
-Then('the FE sends a POST to the declaration-declarationId-upload-fal1 endpoint', () => {
+Then('the FE sends a POST to the declarationId endpoint', () => {
   cy.wait('@declaration').then((result) => {
     let url = result.request.url;
     let declarationId = url.split("/")[5];
+    cy.wrap(declarationId).as('declarationId');
   });
 });
 
@@ -77,4 +79,20 @@ Then('I am taken to task details page', () => {
 
 Then('I am directed back to the Upload general declaration FAL 1 page', () => {
   FileUploadPage.verifyUploadGeneralDecPage();
+});
+
+Then('I sign-out', () => {
+  SignInPage.clickSignOut();
+});
+
+When('I try to access a protected page with declaration Id', () => {
+  cy.get('@declarationId').then(declarationId => {
+ cy.visitUrl(`/report-voyage?report=${declarationId}`);
+ });
+});
+
+When('I try to access a protected CYA page with declaration Id', () => {
+  cy.get('@declarationId').then(declarationId => {
+    cy.visitUrl(`/report-voyage/check-your-answers?report=${declarationId}`);
+  });
 });

--- a/cypress/support/step_definitions/sign-in.steps.js
+++ b/cypress/support/step_definitions/sign-in.steps.js
@@ -66,6 +66,6 @@ Then('I can able to sign-out', () => {
   SignInPage.clickSignOut();
 });
 
-When('user try to access a protected page', () => {
+When('I try to access a protected page', () => {
   cy.visitUrl('/your-voyages');
 });

--- a/cypress/support/step_definitions/task-page.steps.js
+++ b/cypress/support/step_definitions/task-page.steps.js
@@ -7,12 +7,6 @@ Then('I can verify voyage details on the task details page', () => {
   TaskPage.checkFal1UploadDocStatus();
 });
 
-Then('I can verify new voyage details on the task details page', () => {
-  TaskPage.checkShipName('JensShip');
-  TaskPage.checkVoyageType('Arrival to the UK');
-  TaskPage.checkFal1UploadDocStatus();
-});
-
 When('I click delete draft', () => {
   TaskPage.clickDeleteDraftButton();
 });

--- a/cypress/support/step_definitions/task-page.steps.js
+++ b/cypress/support/step_definitions/task-page.steps.js
@@ -28,3 +28,21 @@ When('I click No to delete the draft', () => {
 When('I click Yes to delete the draft', () => {
   TaskPage.clickYesDeleteDraft();
 });
+
+Then('I can see status for FAL5 as completed', () => {
+TaskPage.checkFal5Status();
+});
+
+Then('I can see status for FAL6 as completed', () => {
+  TaskPage.checkFal6Status();
+});
+
+Then('I can see Check answers and submit not enabled', () => {
+  cy.get('main#content li > div > span').should('not.have.attr','a');
+  cy.get('main#content div > strong').should('have.text','Cannot start yet');
+});
+
+Then('I can see Check answers and submit enabled', () => {
+  cy.get('main#content li:nth-child(2) > ul > li >a').should('have.attr','href');
+  cy.get('main#content li:nth-child(2) > ul > li > a > strong').should('have.text','Not started');
+});

--- a/cypress/support/step_definitions/upload-supporting-documents.steps.js
+++ b/cypress/support/step_definitions/upload-supporting-documents.steps.js
@@ -45,9 +45,9 @@ Then('I am shown an error message for {string}', (file) => {
 });
 
 Then('I am able to delete the file', () => {
-  cy.get('.multi-file-upload--filelist').should('have.length', 7);
+  cy.get('.multi-file-upload--filelist').should('have.length', 2);
   fileUploadPage.clickDelete();
-  cy.get('.multi-file-upload--filelist').should('have.length', 6);
+  cy.get('.multi-file-upload--filelist').should('have.length', 1);
 });
 
 When('I upload a valid file, it gets uploaded', (table) => {


### PR DESCRIPTION
Test task list feature after FAL5 and 6 upload(NMSW-397)
Test added to cover NMSW-470 -Redirect to signin & back when auth token expires and user is mid way through report creation
## To test
Run E2E with
```
npm run cypress:run:dev -- --env MAIL_API_KEY=<API_KEY>
```
or
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
and select task-details-page.feature
check-your-answers-page.feature
fal1-upload-general-declaration.feature
upload-supporting-documents.feature

