### PR TITLE
NMSW-531 Display draft voyages

### DIFF
--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -229,14 +229,14 @@ const YourVoyages = () => {
                     <div className="govuk-grid-row">
 
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">
-                        <p className="govuk-body-s govuk-!-font-weight-bold">{voyage.shipName}</p>
+                        <p className="govuk-body-s govuk-!-font-weight-bold">{voyage.nameOfShip}</p>
                       </div>
 
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">
                         <p className="govuk-body-s">
                           Voyage type:
                           <br />
-                          {voyage.voyageType}
+                          {voyage.departureFromUk ? 'Departure from the UK' : 'Arrival to the UK'}
                         </p>
                       </div>
 
@@ -244,7 +244,7 @@ const YourVoyages = () => {
                         <p className="govuk-body-s">
                           Date:
                           <br />
-                          {voyage.voyageType === 'Arrival to the UK' ? voyage.arrivalDate : voyage.departureDate}
+                          {voyage.departureFromUk ? dayjs(voyage.departureDate).format('DD MMMM YYYY') : dayjs(voyage.arrivalDate).format('DD MMMM YYYY')}
                         </p>
                       </div>
 

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -265,8 +265,9 @@ const YourVoyages = () => {
                         <a href="#change" className="govuk-link small-link-text">{statusLinkText}</a>
                       </div>
                     </div>
-
-                    <p className="govuk-!-font-size-16">Submitted: 3 January 2023 by John Smith</p>
+                    {/* Commenting out this code due to it creating more complications for MVP - needs more discussion*/}
+                    {/* {statusType === 'submitted' && voyage.submissionDate && <p className="govuk-!-font-size-16">{`Submitted: ${dayjs(voyage.submissionDate).format('DD MMMM YYYY')} by ${voyage.signatory}`}</p>}
+                    {statusType !== 'submitted' && voyage.creationDate && <p className="govuk-!-font-size-16">{`Created: ${dayjs(voyage.creationDate).format('DD MMMM YYYY')} by ${voyage.signatory}`}</p>} */}
 
                   </div>
                 );

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -170,7 +170,7 @@ const YourVoyages = () => {
               </div>
             </div> */}
 
-            <div className="govuk-grid-column-three-quarters">
+            <div className="govuk-grid-column-full">
               <div className="govuk-grid-row">
                 <div className="govuk-grid-column-full">
                   <h2 className="govuk-heading-s govuk-!-margin-bottom-1 reported-voyages-margin--top">{`${voyageData.length} reported voyages`}</h2>

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -232,15 +232,15 @@ const YourVoyages = () => {
                 let statusTagClass;
                 let statusLinkText;
                 let statusType;
-                if (voyage.status.name === 'Submitted' || voyage.status.name === 'PreSubmitted') {
+                if (voyage.status === 'Submitted' || voyage.status === 'PreSubmitted') {
                   statusTagClass = 'govuk-tag govuk-tag--green';
                   statusLinkText = 'Review or cancel';
                   statusType = 'submitted';
-                } else if (voyage.status.name === 'Draft') {
+                } else if (voyage.status === 'Draft') {
                   statusTagClass = 'govuk-tag govuk-tag--grey';
                   statusLinkText = 'Continue';
                   statusType = 'draft';
-                } else if (voyage.status.name === 'Cancelled' || voyage.status.name === 'PreCancelled') {
+                } else if (voyage.status === 'Cancelled' || voyage.status === 'PreCancelled') {
                   statusTagClass = 'govuk-tag govuk-tag--orange';
                   statusLinkText = 'Review';
                   statusType = 'cancelled';
@@ -281,7 +281,7 @@ const YourVoyages = () => {
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">
                         <span className="govuk-body-s">Actions</span> <br />
                         <Link
-                          to={voyage.status.name === 'Draft' ? `${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}` : `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}`}
+                          to={voyage.status === 'Draft' ? `${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}` : `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}`}
                           className="govuk-link small-link-text"
                         >
                           {statusLinkText}

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -103,7 +103,8 @@ const YourVoyages = () => {
           <br />
 
           <div className="govuk-grid-row your-voyages__flex">
-            <div className="govuk-grid-column-one-quarter">
+            {/* We are removing filtering for MVP  */}
+            {/* <div className="govuk-grid-column-one-quarter">
               <div className="light-grey__border">
                 <fieldset className="govuk-fieldset">
                   <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -151,7 +152,7 @@ const YourVoyages = () => {
                         Submitted
                       </label>
                     </div>
-                    {/* <div className="govuk-radios__item">
+                    <div className="govuk-radios__item">
                         <input
                           className="govuk-radios__input"
                           id="cancelled"
@@ -164,24 +165,10 @@ const YourVoyages = () => {
                           Cancelled
                         </label>
                       </div>
-
-                      <div className="govuk-radios__item">
-                        <input
-                          className="govuk-radios__input"
-                          id="failed"
-                          name="reports"
-                          type="radio"
-                          value="failed"
-                          onChange={() => { }}
-                        />
-                        <label className="govuk-label govuk-radios__label" htmlFor="failed">
-                          Failed
-                        </label>
-                      </div> */}
                   </div>
                 </fieldset>
               </div>
-            </div>
+            </div> */}
 
             <div className="govuk-grid-column-three-quarters">
               <div className="govuk-grid-row">

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -66,13 +66,13 @@ const YourVoyages = () => {
         // We will delete drafts without a general declaration here instead of filtering them out
         const filteredData = response.data.results.reduce((results, data) => {
           if (data.departureFromUk !== null) {
-            results.push(data)
+            results.push(data);
           }
-          return results
-        }, [])
-        setVoyageData(filteredData)
+          return results;
+        }, []);
+        setVoyageData(filteredData);
       }
-      setIsLoading(false)
+      setIsLoading(false);
     } catch (err) {
       if (err?.response?.status === 422) {
         Auth.removeToken();
@@ -84,12 +84,12 @@ const YourVoyages = () => {
         setIsError(true);
       }
     }
-    setIsLoading(false)
+    setIsLoading(false);
   };
 
   useEffect(() => {
     setIsLoading(true);
-    getDeclarationData()
+    getDeclarationData();
   }, []);
 
   if (isError) {
@@ -282,12 +282,13 @@ const YourVoyages = () => {
                         <span className="govuk-body-s">Actions</span> <br />
                         <Link
                           to={voyage.status.name === 'Draft' ? `${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}` : `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}`}
-                          className="govuk-link small-link-text">
+                          className="govuk-link small-link-text"
+                        >
                           {statusLinkText}
                         </Link>
                       </div>
                     </div>
-                    {/* Commenting out this code due to it creating more complications for MVP - needs more discussion*/}
+                    {/* Commenting out this code due to it creating more complications for MVP - needs more discussion */}
                     {/* {statusType === 'submitted' && voyage.submissionDate && <p className="govuk-!-font-size-16">{`Submitted: ${dayjs(voyage.submissionDate).format('DD MMMM YYYY')} by ${voyage.signatory}`}</p>}
                     {statusType !== 'submitted' && voyage.creationDate && <p className="govuk-!-font-size-16">{`Created: ${dayjs(voyage.creationDate).format('DD MMMM YYYY')} by ${voyage.signatory}`}</p>} */}
 

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -207,30 +207,23 @@ const YourVoyages = () => {
                 let statusTagClass;
                 let statusLinkText;
                 let statusType;
-                if (voyage.status === 'Submitted' || voyage.status === 'PreSubmitted') {
+                if (voyage.status.name === 'Submitted' || voyage.status.name === 'PreSubmitted') {
                   statusTagClass = 'govuk-tag govuk-tag--green';
                   statusLinkText = 'Review or cancel';
                   statusType = 'submitted';
-                }
-                if (voyage.status === 'Draft') {
+                } else if (voyage.status.name === 'Draft') {
                   statusTagClass = 'govuk-tag govuk-tag--grey';
                   statusLinkText = 'Continue';
                   statusType = 'draft';
+                } else if (voyage.status.name === 'Cancelled' || voyage.status.name === 'PreCancelled') {
+                  statusTagClass = 'govuk-tag govuk-tag--orange';
+                  statusLinkText = 'Review';
+                  statusType = 'cancelled';
+                } else {
+                  statusTagClass = 'govuk-tag govuk-tag--red';
+                  statusLinkText = 'Review and re-submit';
+                  statusType = 'failed';
                 }
-                // This is for if/when we implement showing cancelled/failed reports
-                // } else if (voyage.status === 'Draft') {
-                //   statusTagClass = 'govuk-tag govuk-tag--grey';
-                //   statusLinkText = 'Continue';
-                //   statusType = 'draft';
-                // } else if (voyage.status === 'Cancelled' || voyage.status === 'PreCancelled') {
-                //   statusTagClass = 'govuk-tag govuk-tag--red';
-                //   statusLinkText = 'Review';
-                //   statusType = 'cancelled';
-                // } else {
-                //   statusTagClass = 'govuk-tag govuk-tag--red';
-                //   statusLinkText = 'Review and re-submit';
-                //   statusType = 'failed';
-                // }
                 return (
                   <div key={voyage.id} className="govuk-!-margin-top-5 light-grey__border">
                     <div className="govuk-grid-row">

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -6,7 +6,10 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CREATE_VOYAGE_ENDPOINT, TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
+  URL_DECLARATIONID_IDENTIFIER,
   VOYAGE_GENERAL_DECLARATION_UPLOAD_URL,
+  VOYAGE_SUPPORTING_DOCS_UPLOAD_URL,
+  VOYAGE_TASK_LIST_URL,
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
 import { SERVICE_NAME } from '../../constants/AppConstants';
@@ -277,7 +280,11 @@ const YourVoyages = () => {
 
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">
                         <span className="govuk-body-s">Actions</span> <br />
-                        <a href="#change" className="govuk-link small-link-text">{statusLinkText}</a>
+                        <Link
+                          to={voyage.status.name === 'Draft' ? `${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}` : `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${voyage.id}`}
+                          className="govuk-link small-link-text">
+                          {statusLinkText}
+                        </Link>
                       </div>
                     </div>
                     {/* Commenting out this code due to it creating more complications for MVP - needs more discussion*/}

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -10,21 +10,7 @@ import {
 import { SERVICE_NAME } from '../../constants/AppConstants';
 import Message from '../../components/Message';
 import Auth from '../../utils/Auth';
-
-const voyageList = [
-  {
-    id: '1', voyageType: 'Arrival to the UK', shipName: 'Disney Cruises', arrivalDate: '11th July 2023', departureDate: '15th July 2023', status: 'Submitted',
-  },
-  {
-    id: '2', voyageType: 'Departure from the UK', shipName: 'The Queen Mary', arrivalDate: '11th September 2023', departureDate: '15th September 2023', status: 'Draft',
-  },
-  // {
-  //   id: '3', voyageType: 'Departure from the UK', shipName: 'The Black Pearl', arrivalDate: '15th May 2023', departureDate: '27th May 2023', status: 'Cancelled',
-  // },
-  // {
-  //   id: '4', voyageType: 'Arrival to the UK', shipName: 'The Golden Hind', arrivalDate: '15th March 2023', departureDate: '27th March 2023', status: 'Failed',
-  // },
-];
+import LoadingSpinner from '../../components/LoadingSpinner';
 
 // NOTES:
 // - The filter buttons do nothing

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -54,8 +54,39 @@ const YourVoyages = () => {
     }
   };
 
+  const getDeclarationData = async () => {
+    try {
+      const response = await axios.get(CREATE_VOYAGE_ENDPOINT, {
+        headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+      });
+      if (response.status === 200) {
+        // We will delete drafts without a general declaration here instead of filtering them out
+        const filteredData = response.data.results.reduce((results, data) => {
+          if (data.departureFromUk !== null) {
+            results.push(data)
+          }
+          return results
+        }, [])
+        setVoyageData(filteredData)
+      }
+      setIsLoading(false)
+    } catch (err) {
+      if (err?.response?.status === 422) {
+        Auth.removeToken();
+        navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+      } else if (err?.response?.data?.msg === TOKEN_EXPIRED) {
+        Auth.removeToken();
+        navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+      } else {
+        setIsError(true);
+      }
+    }
+    setIsLoading(false)
+  };
+
   useEffect(() => {
-    setVoyageData(voyageList);
+    setIsLoading(true);
+    getDeclarationData()
   }, []);
 
   if (isError) {

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CREATE_VOYAGE_ENDPOINT, TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
@@ -18,6 +20,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 // - There is commented out code for when the filter is working but there are no voyages relating to the filter
 
 const YourVoyages = () => {
+  dayjs.extend(customParseFormat);
   const { state } = useLocation();
   const navigate = useNavigate();
   const [isError, setIsError] = useState(false);

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -95,6 +95,8 @@ const YourVoyages = () => {
     );
   }
 
+  if (isLoading) { return (<LoadingSpinner />); }
+
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -27,88 +27,331 @@ describe('Your voyages page tests', () => {
     window.sessionStorage.clear();
   });
 
-  it('should render the page with the Your Voyages as a H1', () => {
+  it('should render the page with the Your Voyages as a H1', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
-    expect(screen.getByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
+    expect(await screen.findByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
   });
 
-  it('should display a "Report a voyage" button', () => {
+  it('should display a "Report a voyage" button', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
-    expect(screen.getByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
   });
 
-  // add when we mock the GET api and return 0 results
-  // it('should show a no voyages message if no voyages', () => {
-  //   render(<MemoryRouter><YourVoyages /></MemoryRouter>);
-  //   expect(screen.getByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
-  // });
-
-  it('should render voyages if voyages exist', () => {
+  it('should show a no voyages message if no voyages', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
-    expect(screen.getByText('Select report type')).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'All' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Drafts' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Submitted' })).toBeInTheDocument();
-    expect(screen.getByText('All report types')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
+    expect(await screen.getByText('You have not reported any voyages yet')).toBeInTheDocument();
+  });
+
+  it('should render a draft voyage if one exists', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [
+          {
+            id: '1',
+            status: {
+              name: 'Draft',
+            },
+            submissionDate: null,
+            nameOfShip: 'Ship 1',
+            imoNumber: '1234567',
+            callSign: 'NA',
+            signatory: 'John Smith',
+            flagState: 'GBR',
+            departureFromUk: false,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-03-16',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-15',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+        ],
+      });
+
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText('All report types')).toBeInTheDocument();
+    expect(await screen.findByText('Ship 1')).toBeInTheDocument();
+    expect(await screen.findByText('draft')).toBeInTheDocument();
+    expect(await screen.findByText('Continue')).toBeInTheDocument();
+  });
+
+  it('should render submitted and preSumbitted reports if they exist', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [
+          {
+            id: '2',
+            status: {
+              name: 'Submitted',
+            },
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 2',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+          {
+            id: '3',
+            status: {
+              name: 'PreSubmitted',
+            },
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 3',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+        ],
+      });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText('Ship 2')).toBeInTheDocument();
+    expect(await screen.findByText('Ship 3')).toBeInTheDocument();
+    expect(await screen.findAllByText('submitted')).toHaveLength(2);
+    expect(await screen.findAllByText('Review or cancel')).toHaveLength(2);
+  });
+
+  it('should render cancelled and preCancelled reports if they exist', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [
+          {
+            id: '4',
+            status: {
+              name: 'Cancelled',
+            },
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 4',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+          {
+            id: '5',
+            status: {
+              name: 'PreCancelled',
+            },
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 5',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+        ],
+      });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText('Ship 5')).toBeInTheDocument();
+    expect(await screen.findByText('Ship 5')).toBeInTheDocument();
+    expect(await screen.findAllByText('cancelled')).toHaveLength(2);
+    expect(await screen.findAllByText('Review')).toHaveLength(2);
+  });
+
+  it('should render failed reports if they exist', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [
+          {
+            id: '6',
+            status: {
+              name: 'Failed',
+            },
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 6',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+        ],
+      });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText('Ship 6')).toBeInTheDocument();
+    expect(await screen.findByText('failed')).toBeInTheDocument();
+    expect(await screen.findByText('Review and re-submit')).toBeInTheDocument();
+  });
+
+  it('should redirect to sign in if getting the declarations returns a 422', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(422, { msg: 'Not enough segments' });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+    });
+  });
+
+  it('should redirect to sign in if getting the declarations returns a 401 token expired', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(401, { msg: TOKEN_EXPIRED });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+    });
   });
 
   it('should continue to General Declaration page if Report a voyage button click successful', async () => {
     const user = userEvent.setup();
     mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      })
       .onPost(CREATE_VOYAGE_ENDPOINT)
       .reply(200, {
         id: '123',
         status: {
           name: 'Draft',
         },
+        submissionDate: null,
+        nameOfShip: null,
+        imoNumber: null,
+        callSign: null,
+        signatory: null,
+        flagState: null,
+        departureFromUk: null,
+        departurePortUnlocode: null,
+        departureDate: null,
+        departureTime: null,
+        arrivalPortUnlocode: null,
+        arrivalDate: null,
+        arrivalTime: null,
+        previousPortUnlocode: null,
+        nextPortUnlocode: null,
+        cargo: null,
       });
 
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
-    expect(screen.getByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
-    user.click(screen.getByRole('button', { name: 'Report a voyage' }));
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`);
-    });
+
+    expect(await screen.findByRole('button', { name: 'Report a voyage' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Report a voyage' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`);
   });
 
   it('should redirect to sign in if Report a voyage button click returns a 422', async () => {
     const user = userEvent.setup();
     mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      })
       .onPost(CREATE_VOYAGE_ENDPOINT)
       .reply(422, { msg: 'Not enough segments' });
 
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await screen.findByRole('button', { name: 'Report a voyage' });
-    user.click(screen.getByRole('button', { name: 'Report a voyage' }));
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
-    });
+    await user.click(screen.getByRole('button', { name: 'Report a voyage' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
   });
 
   it('should redirect to sign in if Report a voyage button click returns a 401 token expired', async () => {
     const user = userEvent.setup();
     mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      })
       .onPost(CREATE_VOYAGE_ENDPOINT)
       .reply(401, { msg: TOKEN_EXPIRED });
 
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await screen.findByRole('button', { name: 'Report a voyage' });
-    user.click(screen.getByRole('button', { name: 'Report a voyage' }));
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
-      expect(sessionStorage.getItem('token')).toBe(null);
-    });
+    await user.click(screen.getByRole('button', { name: 'Report a voyage' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
+    expect(sessionStorage.getItem('token')).toBe(null);
   });
 
   it('should show error message is 500 response received', async () => {
     const user = userEvent.setup();
     mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [],
+      })
       .onPost(CREATE_VOYAGE_ENDPOINT)
       .reply(500);
 
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await screen.findByRole('button', { name: 'Report a voyage' });
-    user.click(screen.getByRole('button', { name: 'Report a voyage' }));
+    await user.click(screen.getByRole('button', { name: 'Report a voyage' }));
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -356,6 +356,4 @@ describe('Your voyages page tests', () => {
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
-
-  // TODO: rewrite tests when BE endpoint is ready as the mocked voyage data will always be availiable
 });

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -65,9 +65,7 @@ describe('Your voyages page tests', () => {
         results: [
           {
             id: '1',
-            status: {
-              name: 'Draft',
-            },
+            status: 'Draft',
             submissionDate: null,
             nameOfShip: 'Ship 1',
             imoNumber: '1234567',
@@ -102,9 +100,7 @@ describe('Your voyages page tests', () => {
         results: [
           {
             id: '2',
-            status: {
-              name: 'Submitted',
-            },
+            status: 'Submitted',
             submissionDate: '2023-02-11',
             nameOfShip: 'Ship 2',
             imoNumber: '123',
@@ -124,9 +120,7 @@ describe('Your voyages page tests', () => {
           },
           {
             id: '3',
-            status: {
-              name: 'PreSubmitted',
-            },
+            status: 'PreSubmitted',
             submissionDate: '2023-02-11',
             nameOfShip: 'Ship 3',
             imoNumber: '123',
@@ -160,9 +154,7 @@ describe('Your voyages page tests', () => {
         results: [
           {
             id: '4',
-            status: {
-              name: 'Cancelled',
-            },
+            status: 'Cancelled',
             submissionDate: '2023-02-11',
             nameOfShip: 'Ship 4',
             imoNumber: '123',
@@ -182,9 +174,7 @@ describe('Your voyages page tests', () => {
           },
           {
             id: '5',
-            status: {
-              name: 'PreCancelled',
-            },
+            status: 'PreCancelled',
             submissionDate: '2023-02-11',
             nameOfShip: 'Ship 5',
             imoNumber: '123',
@@ -218,9 +208,7 @@ describe('Your voyages page tests', () => {
         results: [
           {
             id: '6',
-            status: {
-              name: 'Failed',
-            },
+            status: 'Failed',
             submissionDate: '2023-02-11',
             nameOfShip: 'Ship 6',
             imoNumber: '123',
@@ -278,9 +266,7 @@ describe('Your voyages page tests', () => {
       .onPost(CREATE_VOYAGE_ENDPOINT)
       .reply(200, {
         id: '123',
-        status: {
-          name: 'Draft',
-        },
+        status: 'Draft',
         submissionDate: null,
         nameOfShip: null,
         imoNumber: null,


### PR DESCRIPTION
# Ticket

NMSW-531

----

## AC

GIVEN a voyage has been started, but has not been submitted
WHEN I view the voyage list
THEN the voyage is displayed as "DRAFT"

----

## To test

- Run app
- Sign in
- > If you have reports attached to your account you should see a list of draft reports with a continue button next to each
- > You should not see reports that do not have a FAL 1 attached (reports in the list without ship name, voyage type or a date)
- Click on continue
- > You should be taken to the task list page for that voyage (only for drafts)
- Go back to the your voyages page
- Delete your token and refresh
- > You should be taken to the sign in page

----

## Notes

- We have removed the filtering for MVP - new design has been okayed by UCD team
- We only get draft reports from the BE so only voyages with the status of draft will be seen
- Drafts without an attached FAL 1 still exist but are filtered out - this code will be changed once we can delete voyages
- The line at the bottom of each report on the prototype, for example, 'Submitted: {DATE} by {PERSON}' has been taken out, as this adds to the complexity when dealing with draft and cancelled voyages needing different dates from the BE for sorting so has been removed for MVP