### PR TITLE
NMSW-154 Display voyage details on the page inc file downloads

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -28,7 +28,7 @@ const Message = ({
           </button>
         )}
         {!button && (
-          <Link to={redirectURL || LANDING_URL}>Click here to continue</Link>
+          <Link className="govuk-link" to={redirectURL || LANDING_URL}>Click here to continue</Link>
         )}
       </div>
     </div>

--- a/src/components/__tests__/Message.test.jsx
+++ b/src/components/__tests__/Message.test.jsx
@@ -28,7 +28,7 @@ describe('Message component tests', () => {
       </MemoryRouter>,
     );
     expect(screen.getByRole('heading', { name: 'Title from props' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual('<a href="/url-from-props">Click here to continue</a>');
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual('<a class="govuk-link" href="/url-from-props">Click here to continue</a>');
   });
 
   it('should render title, button, and message (but not link) when message and button props passed', () => {

--- a/src/constants/ErrorMappingFal5.js
+++ b/src/constants/ErrorMappingFal5.js
@@ -42,6 +42,7 @@ const ErrorMappingFal5 = {
   H: { // gender
     order: 'h',
     'field required': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
+    'ensure this value has at most 6 characters': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
     'Enter M for male, F for female, or X for gender neutral if this is in the Travel Document': 'Enter M for male, F for female, or X for gender neutral if this is in the travel document',
   },
   I: { // date of birth

--- a/src/pages/Message/GenericConfirmation.jsx
+++ b/src/pages/Message/GenericConfirmation.jsx
@@ -28,6 +28,7 @@ const GenericConfirmation = () => {
 
         </div>
         <Link
+          className="govuk-link"
           to={state.nextPageLink}
         >
           Return to {state.nextPageName}

--- a/src/pages/Message/GenericMessage.jsx
+++ b/src/pages/Message/GenericMessage.jsx
@@ -22,7 +22,11 @@ const GenericMessage = () => {
           </button>
         )}
         {!state.button && (
-          <Link to={state?.redirectURL || LANDING_URL} state={state}>
+          <Link
+            className="govuk-link"
+            to={state?.redirectURL || LANDING_URL}
+            state={state}
+          >
             {state?.linkText || 'Click here to continue'}
           </Link>
         )}

--- a/src/pages/Message/__tests__/GenericConfirmation.test.jsx
+++ b/src/pages/Message/__tests__/GenericConfirmation.test.jsx
@@ -65,7 +65,7 @@ describe('Generic confirmation page', () => {
 
     render(<MemoryRouter><GenericConfirmation /></MemoryRouter>);
     expect(screen.getByRole('link', { name: 'Return to next page' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Return to next page' }).outerHTML).toEqual('<a href="/next-page">Return to next page</a>');
+    expect(screen.getByRole('link', { name: 'Return to next page' }).outerHTML).toEqual('<a class="govuk-link" href="/next-page">Return to next page</a>');
     await user.click(screen.getByRole('link', { name: 'Return to next page' }));
     expect(mockedUsedNavigate).toHaveBeenCalled();
     expect(mockedUsedNavigate).toHaveBeenCalledWith('/next-page', {

--- a/src/pages/NavPages/YourDetails/ChangeYourPassword.jsx
+++ b/src/pages/NavPages/YourDetails/ChangeYourPassword.jsx
@@ -21,7 +21,7 @@ const PasswordSupportingText = () => (
     <p className="govuk-body govuk-!-font-weight-bold">Enter a new password</p>
     <p className="govuk-body">Your password must be at least 10 characters long. There is no restriction on the characters you use.</p>
     <p className="govuk-body">
-      To create a long and strong password, the National Cyber Security Centre recommends using <a href={PASSWORD_GUIDENCE_URL} target="_blank" rel="noreferrer">3 random words (opens in new tab)</a>.
+      To create a long and strong password, the National Cyber Security Centre recommends using <a className="govuk-link" href={PASSWORD_GUIDENCE_URL} target="_blank" rel="noreferrer">3 random words (opens in new tab)</a>.
     </p>
   </div>
 );

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -340,6 +340,6 @@ describe('Your voyages page tests', () => {
     await user.click(screen.getByRole('button', { name: 'Report a voyage' }));
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 });

--- a/src/pages/Register/RegisterConfirmation.jsx
+++ b/src/pages/Register/RegisterConfirmation.jsx
@@ -28,7 +28,7 @@ const RegisterConfirmation = () => {
         {state?.email && <p className="govuk-body">We have sent a confirmation email to <strong>{state?.email}</strong>.</p>}
 
         <p className="govuk-body">
-          <Link to={SIGN_IN_URL}>Sign in</Link> to start using this service.
+          <Link className="govuk-link" to={SIGN_IN_URL}>Sign in</Link> to start using this service.
         </p>
       </div>
     </div>

--- a/src/pages/Register/RegisterYourPassword.jsx
+++ b/src/pages/Register/RegisterYourPassword.jsx
@@ -29,7 +29,7 @@ const SupportingText = () => (
   <div className="govuk-inset-text">
     <p className="govuk-body">Your password must be at least 10 characters long. There is no restriction on the characters you use.</p>
     <p className="govuk-body">
-      To create a long and strong password, the National Cyber Security Centre recommends using <a href={PASSWORD_GUIDENCE_URL} target="_blank" rel="noreferrer">3 random words (opens in new tab)</a>.
+      To create a long and strong password, the National Cyber Security Centre recommends using <a className="govuk-link" href={PASSWORD_GUIDENCE_URL} target="_blank" rel="noreferrer">3 random words (opens in new tab)</a>.
     </p>
   </div>
 );

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -31,7 +31,7 @@ import { scrollToTop } from '../../utils/ScrollToElement';
 const SupportingText = () => (
   <div className="govuk-inset-text">
     <p className="govuk-body">
-      If you do not have an account, you can <Link to={REGISTER_ACCOUNT_URL}>create one now</Link>.
+      If you do not have an account, you can <Link className="govuk-link" to={REGISTER_ACCOUNT_URL}>create one now</Link>.
     </p>
   </div>
 );

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -54,7 +54,7 @@ describe('Sign in tests', () => {
   it('should display a link to create account', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);
     expect(screen.getByText('create one now')).toBeInTheDocument();
-    expect(screen.getByText('create one now').outerHTML).toEqual('<a href="/create-account/email-address">create one now</a>');
+    expect(screen.getByText('create one now').outerHTML).toEqual('<a class="govuk-link" href="/create-account/email-address">create one now</a>');
   });
 
   it('should display an input field for password', () => {

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -25,24 +25,43 @@ const VoyageCheckYourAnswers = () => {
   const declarationId = searchParams.get(URL_DECLARATIONID_IDENTIFIER);
   const [isLoading, setIsLoading] = useState(false);
   const [voyageDetails, setVoyageDetails] = useState([]);
+  const [fal5Details, setFal5Details] = useState({
+    fal5Name: '',
+    fal5FileLink: '',
+  });
+  const [fal6Details, setFal6Details] = useState({
+    fal6Name: '',
+    fal6FileLink: '',
+  });
 
   document.title = 'Check your answers';
+
+  const getFalName = (URL) => {
+    // Splits BE file link after the last dash /
+    const falNameStep1 = URL?.split('/').pop();
+    // Splits the file name further so it gets everything before the ?
+    const falNameStep2 = falNameStep1?.split('?')[0];
+    // Decodes the encoded URL so only the file name is left
+    const falName = decodeURI(falNameStep2);
+    return falName;
+  };
 
   // values of this array will be populated by GET request when available
   const uploadedDocuments = [
     {
       id: 'crewDetails',
       title: 'Crew details',
-      value: '',
-      fileLink: '',
+      value: fal5Details?.fal5Name ? fal5Details?.fal5Name : '',
+      fileLink: fal5Details?.fal5FileLink ? fal5Details?.fal5FileLink : '',
       changeLink: `${VOYAGE_CREW_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
     },
     {
       id: 'passengerDetails',
       title: 'Passenger details',
-      value: '',
-      fileLink: '',
+      value: fal6Details?.fal6Name ? fal6Details?.fal6Name : '',
+      fileLink: fal6Details?.fal6FileLink ? fal6Details?.fal6FileLink : '',
       changeLink: `${VOYAGE_PASSENGERS_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+      noFileText: 'No passenger details provided',
     },
     {
       id: 'supportingDocuments',
@@ -50,6 +69,7 @@ const VoyageCheckYourAnswers = () => {
       value: '',
       fileLink: '',
       changeLink: `${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
+      noFileText: 'No supporting documents provided',
     },
   ];
 
@@ -133,6 +153,19 @@ const VoyageCheckYourAnswers = () => {
           value: response.data.FAL1.cargo,
         },
       ]);
+
+      setFal5Details({
+        fal5Name: getFalName(response?.data?.FAL5),
+        fal5FileLink: response?.data?.FAL5,
+      });
+
+      if (response.data.FAL6) {
+        setFal6Details({
+          fal6Name: getFalName(response?.data?.FAL6),
+          fal6FileLink: response?.data?.FAL6,
+        });
+      }
+
       setIsLoading(false);
     } else {
       switch (response?.status) {
@@ -225,7 +258,7 @@ const VoyageCheckYourAnswers = () => {
                   {item.title}
                 </dt>
                 <dd className="govuk-summary-list__value">
-                  {item.value}
+                  {item.fileLink ? <a className="govuk-link" href={item.fileLink} download>{item.value}</a> : item.noFileText}
                 </dd>
                 <dd className="govuk-summary-list__actions">
                   <Link

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -17,12 +17,15 @@ import {
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
 import GetDeclaration from '../../utils/GetDeclaration';
+import { scrollToElementId, scrollToTop } from '../../utils/ScrollToElement';
 
 const VoyageCheckYourAnswers = () => {
   dayjs.extend(customParseFormat);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const declarationId = searchParams.get(URL_DECLARATIONID_IDENTIFIER);
+  const [declarationData, setDeclarationData] = useState();
+  const [errors, setErrors] = useState();
   const [isLoading, setIsLoading] = useState(false);
   const [voyageDetails, setVoyageDetails] = useState([]);
   const [fal5Details, setFal5Details] = useState({
@@ -89,6 +92,7 @@ const VoyageCheckYourAnswers = () => {
   const updateDeclarationData = async () => {
     const response = await GetDeclaration({ declarationId });
     if (response.data) {
+      setDeclarationData(response.data);
       setVoyageDetails([
         {
           title: 'Voyage type',
@@ -186,7 +190,16 @@ const VoyageCheckYourAnswers = () => {
   };
 
   const handleSubmit = () => {
-    console.log('submit clicked for id', declarationId);
+    // This will most likely have a validate funtion in the future but at the moment there can only be a single error (I think)
+    if (declarationData.FAL1.passengers && !declarationData.FAL6) {
+      scrollToTop();
+      setErrors([{
+        name: 'passengerDetails',
+        message: 'Passenger details (FAL 6) upload is required for ships carrying passengers',
+      }]);
+    } else {
+      console.log('submit clicked for id', declarationId);
+    }
   };
 
   useEffect(() => {
@@ -207,6 +220,30 @@ const VoyageCheckYourAnswers = () => {
   return (
     <>
       <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          {errors?.length > 0 && (
+            <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" tabIndex={-1}>
+              <h2 className="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+              </h2>
+              <div className="govuk-error-summary__body">
+                <ul className="govuk-list govuk-error-summary__list">
+                  {errors.map((error) => (
+                    <li key={error.name}>
+                      <button
+                        className="govuk-button--text"
+                        type="button"
+                        onClick={(e) => { e.preventDefault(); scrollToElementId('passengerDetails'); }}
+                      >
+                        {error.message}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="govuk-grid-column-full">
           <h1 className="govuk-heading-xl">Check your answers</h1>
         </div>

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -36,14 +36,14 @@ const VoyageCheckYourAnswers = () => {
 
   document.title = 'Check your answers';
 
-  const getFalName = (URL) => {
+  const getFalFileName = (URL) => {
     // Splits BE file link after the last dash /
-    const falNameStep1 = URL?.split('/').pop();
+    const startOfFileName = URL?.split('/').pop();
     // Splits the file name further so it gets everything before the ?
-    const falNameStep2 = falNameStep1?.split('?')[0];
+    const encodedFileName = startOfFileName?.split('?')[0];
     // Decodes the encoded URL so only the file name is left
-    const falName = decodeURI(falNameStep2);
-    return falName;
+    const falFileName = decodeURI(encodedFileName);
+    return falFileName;
   };
 
   // values of this array will be populated by GET request when available
@@ -155,13 +155,13 @@ const VoyageCheckYourAnswers = () => {
       ]);
 
       setFal5Details({
-        fal5Name: getFalName(response?.data?.FAL5),
+        fal5Name: getFalFileName(response?.data?.FAL5),
         fal5FileLink: response?.data?.FAL5,
       });
 
       if (response.data.FAL6) {
         setFal6Details({
-          fal6Name: getFalName(response?.data?.FAL6),
+          fal6Name: getFalFileName(response?.data?.FAL6),
           fal6FileLink: response?.data?.FAL6,
         });
       }

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -24,6 +24,7 @@ const VoyageCheckYourAnswers = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const declarationId = searchParams.get(URL_DECLARATIONID_IDENTIFIER);
+  const errorSummaryRef = useRef(null);
   const [declarationData, setDeclarationData] = useState();
   const [errors, setErrors] = useState();
   const [isLoading, setIsLoading] = useState(false);
@@ -192,11 +193,12 @@ const VoyageCheckYourAnswers = () => {
   const handleSubmit = () => {
     // This will most likely have a validate funtion in the future but at the moment there can only be a single error (I think)
     if (declarationData.FAL1.passengers && !declarationData.FAL6) {
-      scrollToTop();
       setErrors([{
         name: 'passengerDetails',
         message: 'Passenger details (FAL 6) upload is required for ships carrying passengers',
       }]);
+      scrollToTop();
+      errorSummaryRef?.current?.focus();
     } else {
       console.log('submit clicked for id', declarationId);
     }
@@ -222,7 +224,7 @@ const VoyageCheckYourAnswers = () => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           {errors?.length > 0 && (
-            <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" tabIndex={-1}>
+            <div className="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary" ref={errorSummaryRef} tabIndex={-1}>
               <h2 className="govuk-error-summary__title" id="error-summary-title">
                 There is a problem
               </h2>

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -221,6 +221,7 @@ const VoyageCheckYourAnswers = () => {
               <dd className="govuk-summary-list__value" />
               <dd className="govuk-summary-list__actions">
                 <Link
+                  className="govuk-link"
                   to={`${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`}
                   aria-describedby="voyageDetails"
                 >
@@ -262,6 +263,7 @@ const VoyageCheckYourAnswers = () => {
                 </dd>
                 <dd className="govuk-summary-list__actions">
                   <Link
+                    className="govuk-link"
                     to={item.changeLink}
                     aria-describedby={item.id}
                   >

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -168,7 +168,7 @@ const VoyageTaskList = () => {
                 {
                   steps.map((item) => (
                     <li key={item.label} className="app-task-list__item">
-                      <Link to={item.link}>
+                      <Link className="govuk-link" to={item.link}>
                         <span>{item.label}</span>
                         <strong className={CLASSES_FOR_STATUS[item.status]}>{LABELS_FOR_STATUS[item.status]}</strong>
                       </Link>
@@ -190,7 +190,7 @@ const VoyageTaskList = () => {
                     )}
                   {checkYourAnswersStep.status !== 'cannotStartYet'
                     && (
-                      <Link to={checkYourAnswersStep.link}>
+                      <Link className="govuk-link" to={checkYourAnswersStep.link}>
                         <span>Check answers and submit</span>
                         <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
                       </Link>

--- a/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
+++ b/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
@@ -56,9 +56,7 @@ describe('File upload success confirmation page', () => {
   it('should render a generic statement without fileName in state', async () => {
     mockUseLocationState.state = {};
     renderPage();
-    await screen.findByRole('heading', { name: 'Something has gone wrong' });
-    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByText('File uploaded')).toBeInTheDocument();
   });
 
   it('should go to the voyage task list page on button click', async () => {

--- a/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
+++ b/src/pages/Voyage/__tests__/FileUploadConfirmation.test.jsx
@@ -50,13 +50,15 @@ describe('File upload success confirmation page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should render a generic statement without fileName in state', async () => {
     mockUseLocationState.state = {};
     renderPage();
-    expect(screen.getByText('File uploaded')).toBeInTheDocument();
+    await screen.findByRole('heading', { name: 'Something has gone wrong' });
+    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should go to the voyage task list page on button click', async () => {

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -33,7 +33,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('Voyage check your answers page', () => {
   const mockAxios = new MockAdapter(axios);
-  const mockedFAL1Response = {
+  const mockedFAL1And5Response = {
     FAL1: {
       nameOfShip: 'Test ship name',
       imoNumber: '1234567',
@@ -51,6 +51,30 @@ describe('Voyage check your answers page', () => {
       nextPortUnlocode: 'NLRTM',
       cargo: 'No cargo',
     },
+    FAL5: 'https://fal5-report-link.com',
+    FAL6: null,
+  };
+
+  const mockedAllFALResponse = {
+    FAL1: {
+      nameOfShip: 'Test ship name',
+      imoNumber: '1234567',
+      callSign: 'NA',
+      signatory: 'Captain Name',
+      flagState: 'GBR',
+      departureFromUk: false,
+      departurePortUnlocode: 'AUPOR',
+      departureDate: '2023-02-12',
+      departureTime: '09:23:00',
+      arrivalPortUnlocode: 'GBDOV',
+      arrivalDate: '2023-02-15',
+      arrivalTime: '14:00:00',
+      previousPortUnlocode: 'AUPOR',
+      nextPortUnlocode: 'NLRTM',
+      cargo: 'No cargo',
+    },
+    FAL5: 'https://fal5-report-link.com',
+    FAL6: 'https://fal6-report-link.com',
   };
 
   beforeEach(() => {
@@ -133,7 +157,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('heading', { name: 'Check your answers' })).toBeInTheDocument();
@@ -150,7 +174,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('button', { name: 'Save and submit' }).outerHTML).toEqual('<button type="button" class="govuk-button" data-module="govuk-button">Save and submit</button>');
@@ -163,7 +187,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByText('Voyage type').outerHTML).toEqual('<dt class="govuk-summary-list__key">Voyage type</dt>');
@@ -179,14 +203,15 @@ describe('Voyage check your answers page', () => {
     expect(screen.getByText('Supporting documents').outerHTML).toEqual('<dt id="supportingDocuments" class="govuk-summary-list__key">Supporting documents</dt>');
   });
 
-  it('should render the General Declaration values', async () => {
+  // To view the CYA page the FAL 5 file much be present
+  it('should render the General Declaration values and a Crew Details FAL 5 link', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByText('Arrival to the UK').outerHTML).toEqual('<dd class="govuk-summary-list__value">Arrival to the UK</dd>');
@@ -211,6 +236,24 @@ describe('Voyage check your answers page', () => {
 
     expect(screen.getByText('NL RTM').outerHTML).toEqual('<dd class="govuk-summary-list__value">NL RTM</dd>');
     expect(screen.getByText('No cargo').outerHTML).toEqual('<dd class="govuk-summary-list__value">No cargo</dd>');
+    expect(screen.getByRole('link', { name: 'fal5-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">fal5-report-link.com</a>');
+    expect(screen.getByText('No passenger details provided')).toBeInTheDocument();
+    expect(screen.getByText('No supporting documents provided')).toBeInTheDocument();
+  });
+
+  it('should render link for Passenger details a file is present', async () => {
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, mockedAllFALResponse);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+
+    expect(screen.getByRole('link', { name: 'fal5-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">fal5-report-link.com</a>');
+    expect(screen.getByRole('link', { name: 'fal6-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal6-report-link.com" download="">fal6-report-link.com</a>');
   });
 
   it('should fallback to displaying the alphaCode if we do not find a match in the country name lookup on flagState', async () => {
@@ -238,6 +281,8 @@ describe('Voyage check your answers page', () => {
           nextPortUnlocode: 'NLRTM',
           cargo: 'No cargo',
         },
+        FAL5: 'https://fal5-report-link.com',
+        FAL6: null,
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
@@ -257,7 +302,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change voyage details' })).toBeInTheDocument();
@@ -278,7 +323,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Crew details' })).toBeInTheDocument();
@@ -299,7 +344,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Passenger details' })).toBeInTheDocument();
@@ -320,7 +365,7 @@ describe('Voyage check your answers page', () => {
           Authorization: 'Bearer 123',
         },
       })
-      .reply(200, mockedFAL1Response);
+      .reply(200, mockedFAL1And5Response);
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Supporting documents' })).toBeInTheDocument();

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -99,7 +99,7 @@ describe('Voyage check your answers page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should redirect to Sign In if GET call returns a 401 response', async () => {
@@ -306,7 +306,7 @@ describe('Voyage check your answers page', () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change voyage details' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Change change voyage details' }).outerHTML).toEqual('<a aria-describedby="voyageDetails" href="/report-voyage/upload-general-declaration?report=123">Change<span class="govuk-visually-hidden"> change voyage details</span></a>');
+    expect(screen.getByRole('link', { name: 'Change change voyage details' }).outerHTML).toEqual('<a class="govuk-link" aria-describedby="voyageDetails" href="/report-voyage/upload-general-declaration?report=123">Change<span class="govuk-visually-hidden"> change voyage details</span></a>');
     // await user.click(screen.getByRole('link', { name: 'Change change voyage details' }));
     // await waitFor(() => {
     //   expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`, {
@@ -327,7 +327,7 @@ describe('Voyage check your answers page', () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Crew details' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Change change Crew details' }).outerHTML).toEqual('<a aria-describedby="crewDetails" href="/report-voyage/upload-crew-details?report=123">Change<span class="govuk-visually-hidden"> change Crew details</span></a>');
+    expect(screen.getByRole('link', { name: 'Change change Crew details' }).outerHTML).toEqual('<a class="govuk-link" aria-describedby="crewDetails" href="/report-voyage/upload-crew-details?report=123">Change<span class="govuk-visually-hidden"> change Crew details</span></a>');
     // await user.click(screen.getByRole('link', { name: 'Change change Crew details' }));
     // await waitFor(() => {
     //   expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_CREW_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`, {
@@ -348,7 +348,7 @@ describe('Voyage check your answers page', () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Passenger details' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Change change Passenger details' }).outerHTML).toEqual('<a aria-describedby="passengerDetails" href="/report-voyage/passenger-details?report=123">Change<span class="govuk-visually-hidden"> change Passenger details</span></a>');
+    expect(screen.getByRole('link', { name: 'Change change Passenger details' }).outerHTML).toEqual('<a class="govuk-link" aria-describedby="passengerDetails" href="/report-voyage/passenger-details?report=123">Change<span class="govuk-visually-hidden"> change Passenger details</span></a>');
     // await user.click(screen.getByRole('link', { name: 'Change change Passenger details' }));
     // await waitFor(() => {
     //   expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_PASSENGERS_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`, {
@@ -369,7 +369,7 @@ describe('Voyage check your answers page', () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     expect(screen.getByRole('link', { name: 'Change change Supporting documents' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Change change Supporting documents' }).outerHTML).toEqual('<a aria-describedby="supportingDocuments" href="/report-voyage/upload-supporting-documents?report=123">Change<span class="govuk-visually-hidden"> change Supporting documents</span></a>');
+    expect(screen.getByRole('link', { name: 'Change change Supporting documents' }).outerHTML).toEqual('<a class="govuk-link" aria-describedby="supportingDocuments" href="/report-voyage/upload-supporting-documents?report=123">Change<span class="govuk-visually-hidden"> change Supporting documents</span></a>');
     // await user.click(screen.getByRole('link', { name: 'Change change Supporting documents' }));
     // await waitFor(() => {
     //   expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`, {

--- a/src/pages/Voyage/__tests__/VoyageCrew.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCrew.test.jsx
@@ -42,7 +42,7 @@ describe('Voyage crew page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should show error if no file is selected and submit clicked', async () => {

--- a/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
@@ -50,7 +50,7 @@ describe('Voyage delete draft check are you sure page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should go to the your voyages details page, with details for confirmation banner, if user selects YES', async () => {

--- a/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageGeneralDeclaration.test.jsx
@@ -49,7 +49,7 @@ describe('Voyage general declaration page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should show error if no file is selected and submit clicked', async () => {

--- a/src/pages/Voyage/__tests__/VoyagePassengerUpload.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyagePassengerUpload.test.jsx
@@ -42,7 +42,7 @@ describe('Voyage passenger page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should show error if no file is selected and submit clicked', async () => {

--- a/src/pages/Voyage/__tests__/VoyagePassengers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyagePassengers.test.jsx
@@ -161,6 +161,6 @@ describe('Voyage passengers page', () => {
     await user.click(screen.getByRole('button', { name: 'Save and continue' }));
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 });

--- a/src/pages/Voyage/__tests__/VoyagePassengers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyagePassengers.test.jsx
@@ -56,7 +56,7 @@ describe('Voyage passengers page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should go to the upload passenger details page if user selects YES', async () => {

--- a/src/pages/Voyage/__tests__/VoyageSupportingDocsUpload.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageSupportingDocsUpload.test.jsx
@@ -47,7 +47,7 @@ describe('Voyage supporting docs page', () => {
     );
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should go to task details on save and continue click', async () => {

--- a/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
@@ -79,7 +79,7 @@ describe('Voyage task list page', () => {
 
     await screen.findByRole('heading', { name: 'Something has gone wrong' });
     expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
+    expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
   it('should redirect to Sign In if GET call returns a 401 response', async () => {
@@ -146,13 +146,13 @@ describe('Voyage task list page', () => {
     expect(screen.getByRole('heading', { name: '2. Submit the report' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Report a voyage' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' }).outerHTML).toBe('<a href="/report-voyage/upload-general-declaration?report=123"><span>General Declaration (FAL 1)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-general-declaration?report=123"><span>General Declaration (FAL 1)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toBe('<a href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
     expect(screen.getByRole('link', { name: 'Supporting documents Optional' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Supporting documents Optional' }).outerHTML).toBe('<a href="/report-voyage/upload-supporting-documents?report=123"><span>Supporting documents</span><strong class="govuk-tag govuk-tag--blue app-task-list__tag">Optional</strong></a>');
+    expect(screen.getByRole('link', { name: 'Supporting documents Optional' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-supporting-documents?report=123"><span>Supporting documents</span><strong class="govuk-tag govuk-tag--blue app-task-list__tag">Optional</strong></a>');
     expect(screen.getByText('Check answers and submit')).toBeInTheDocument();
     expect(screen.getByText('Cannot start yet')).toBeInTheDocument();
     expect(screen.getByTestId('checkYourAnswers').outerHTML).toBe('<div data-testid="checkYourAnswers"><span>Check answers and submit</span><strong class="govuk-tag govuk-tag--grey app-task-list__tag">Cannot start yet</strong></div>');
@@ -252,9 +252,9 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' }).outerHTML).toBe('<a href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
     expect(screen.getByTestId('completedSections')).toHaveTextContent('0');
   });
 
@@ -293,9 +293,9 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toBe('<a href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByTestId('completedSections')).toHaveTextContent('0');
   });
 
@@ -412,9 +412,9 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' }).outerHTML).toBe('<a href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByTestId('completedSections')).toHaveTextContent('1');
   });
 
@@ -439,7 +439,7 @@ describe('Voyage task list page', () => {
     );
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' }).outerHTML).toEqual('<a href="/report-voyage/upload-general-declaration?report=123"><span>General Declaration (FAL 1)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'General Declaration (FAL 1) Completed' }).outerHTML).toEqual('<a class="govuk-link" href="/report-voyage/upload-general-declaration?report=123"><span>General Declaration (FAL 1)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
   });
 
   it('should load the Crew Details upload page if Crew is clicked', async () => {
@@ -454,7 +454,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toEqual('<a href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries (FAL 5) Required' }).outerHTML).toEqual('<a class="govuk-link" href="/report-voyage/upload-crew-details?report=123"><span>Crew details including supernumeraries (FAL 5)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
   });
 
   it('should load the Passenger Details yes/no page if Passenger is clicked', async () => {
@@ -470,7 +470,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toEqual('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toEqual('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
 
     // await user.click(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }));
     // await waitFor(() => {
@@ -493,7 +493,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Supporting documents Optional' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Supporting documents Optional' }).outerHTML).toEqual('<a href="/report-voyage/upload-supporting-documents?report=123"><span>Supporting documents</span><strong class="govuk-tag govuk-tag--blue app-task-list__tag">Optional</strong></a>');
+    expect(screen.getByRole('link', { name: 'Supporting documents Optional' }).outerHTML).toEqual('<a class="govuk-link" href="/report-voyage/upload-supporting-documents?report=123"><span>Supporting documents</span><strong class="govuk-tag govuk-tag--blue app-task-list__tag">Optional</strong></a>');
 
     // await user.click(screen.getByRole('link', { name: 'Supporting documents Optional' }));
     // await waitFor(() => {
@@ -538,7 +538,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Check answers and submit Not started' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Check answers and submit Not started' }).outerHTML).toEqual('<a href="/report-voyage/check-your-answers?report=123"><span>Check answers and submit</span><strong class="govuk-tag govuk-tag--grey app-task-list__tag">Not started</strong></a>');
+    expect(screen.getByRole('link', { name: 'Check answers and submit Not started' }).outerHTML).toEqual('<a class="govuk-link" href="/report-voyage/check-your-answers?report=123"><span>Check answers and submit</span><strong class="govuk-tag govuk-tag--grey app-task-list__tag">Not started</strong></a>');
   });
 
   it('should load the delete draft page if delete draft is clicked', async () => {

--- a/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
@@ -334,7 +334,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Required' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag govuk-tag--pink app-task-list__tag">Required</strong></a>');
     expect(screen.getByTestId('completedSections')).toHaveTextContent('0');
   });
 
@@ -373,7 +373,7 @@ describe('Voyage task list page', () => {
     renderPage();
     await screen.findByRole('heading', { name: 'Report a voyage' });
     expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
+    expect(screen.getByRole('link', { name: 'Any passenger details (FAL 6) Completed' }).outerHTML).toBe('<a class="govuk-link" href="/report-voyage/passenger-details?report=123"><span>Any passenger details (FAL 6)</span><strong class="govuk-tag app-task-list__tag">Completed</strong></a>');
     expect(screen.getByTestId('completedSections')).toHaveTextContent('0');
   });
 


### PR DESCRIPTION
# Ticket

NMSW-154

----

## AC

GIVEN I have a link to an uploaded crew file
WHEN I click on the file name
THEN the file will be downloaded

GIVEN I have a link to an uploaded passenger file
WHEN I click on the file name
THEN the file will be downloaded

----

## To test

- Run app
- Sign in
- Complete General declaration FAL 1
- Complete Crew details (FAL 5)
- Click on Any passenger details
- Select no to passengers
- The CYA link should be enabled
- Click on the CYA link
- Scroll down to the file uploads sections
- > You should see a link to the FAL 5 you uploaded and have the ability to download it
- > It should be the same name that you uploaded
- > The passenger section should state 'No passenger details provided'
- > The supporting documents section should state 'No supporting documents provided'
- Click on change next to Passenger details
- Select yes
- Go back to CYA (do NOT upload a file)
- On the CYA page click submit
- > You should get an error of 'Passenger details (FAL 6) upload is required for ships carrying passengers' in the error summary
- Click on change next to Passenger details
- Select yes
- Upload a good FAL 6
- Return to the CYA page
- > You should see a link to the FAL 6 you uploaded and have the ability to download it
- > It should be the same name that you uploaded

----

## Notes
