### PR TITLE
NMSW-203 Forgotten password, send for a different email

### DIFF
--- a/src/pages/SignIn/ResendRequestPasswordReset.jsx
+++ b/src/pages/SignIn/ResendRequestPasswordReset.jsx
@@ -1,7 +1,100 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import {
+  REQUEST_PASSSWORD_RESET_ENDPOINT,
+} from '../../constants/AppAPIConstants';
+import {
+  DISPLAY_DETAILS,
+  FIELD_EMAIL,
+  SINGLE_PAGE_FORM,
+  VALIDATE_EMAIL_ADDRESS,
+  VALIDATE_REQUIRED,
+} from '../../constants/AppConstants';
+import {
+  MESSAGE_URL,
+  REQUEST_PASSWORD_RESET_CONFIRMATION_URL,
+  REQUEST_PASSWORD_RESET_URL,
+} from '../../constants/AppUrlConstants';
+import DisplayForm from '../../components/DisplayForm';
+
+const SupportingText = () => (
+  <p className="govuk-body">Emails sometimes take a few minutes to arrive. If you did not receive the link, you can request a new one.</p>
+);
+
 const ResendRequestPasswordReset = () => {
-  console.log('resend page');
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  document.title = 'Resend password reset email';
+
+  const formActions = {
+    submit: {
+      label: 'Request a new link',
+    },
+  };
+  const formFields = [
+    {
+      type: FIELD_EMAIL,
+      displayType: DISPLAY_DETAILS,
+      fieldName: 'emailAddress',
+      label: 'Email address',
+      value: state?.dataToSubmit?.emailAddress,
+      linkText: 'Change where the email was sent',
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Enter your email address',
+        },
+        {
+          type: VALIDATE_EMAIL_ADDRESS,
+          message: 'Enter a real email address',
+        },
+      ],
+    },
+  ];
+
+  const requestPasswordResetEmail = async ({ emailToSendTo }) => {
+    try {
+      const controller = new AbortController();
+      const response = await axios.post(REQUEST_PASSSWORD_RESET_ENDPOINT, {
+        email: emailToSendTo,
+      }, {
+        signal: controller.signal,
+      });
+
+      if (response.status === 204) {
+        navigate(REQUEST_PASSWORD_RESET_CONFIRMATION_URL, { state: { dataToSubmit: { emailAddress: emailToSendTo } } });
+      }
+    } catch (err) {
+      if (err.response.status === 401) {
+        // 401 is invalid email address but we don't message that to the user so we show them the same confirmation page
+        navigate(REQUEST_PASSWORD_RESET_CONFIRMATION_URL, { state: { dataToSubmit: { emailAddress: emailToSendTo } } });
+      } else {
+        navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: REQUEST_PASSWORD_RESET_URL } });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = async (formData) => {
+    setIsLoading(true);
+    requestPasswordResetEmail({ emailToSendTo: formData.formData.emailAddress });
+  };
+
   return (
-    <h1>Resend</h1>
+    <DisplayForm
+      formId="formSecondPage"
+      fields={formFields}
+      formActions={formActions}
+      formType={SINGLE_PAGE_FORM}
+      isLoading={isLoading}
+      pageHeading="Request a new verification link"
+      handleSubmit={handleSubmit}
+    >
+      <SupportingText />
+    </DisplayForm>
   );
 };
 

--- a/src/pages/SignIn/__tests__/RequestPasswordResetConfirmation.test.jsx
+++ b/src/pages/SignIn/__tests__/RequestPasswordResetConfirmation.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import RequestPasswordResetConfirmation from '../RequestPasswordResetConfirmation';
+import { REQUEST_PASSWORD_RESET_RESEND_URL } from '../../../constants/AppUrlConstants';
+
+let mockUseLocationState = {};
+const mockedUseNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => mockUseLocationState),
+}));
+
+describe('Confirm request password reset check your email tests', () => {
+  beforeEach(() => {
+    mockUseLocationState = {};
+  });
+
+  it('should render page with content', () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
+    expect(screen.getByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+  });
+
+  it('should show the email address from state in the page', () => {
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
+    expect(screen.getByText('testemail@email.com')).toBeInTheDocument();
+  });
+
+  it('should include a link to resend your verificaiton email', () => {
+    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
+    expect(screen.getByRole('link', { name: 'Not received an email?' }).outerHTML).toEqual('<a class="govuk-body govuk-link" href="/forgotten-password/request-new-link">Not received an email?</a>');
+  });
+
+  it('should navigate to the resend request page with email address if link clicked', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
+    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
+    expect(screen.getByText('testemail@email.com')).toBeInTheDocument();
+    await user.click(screen.getByRole('link', { name: 'Not received an email?' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(REQUEST_PASSWORD_RESET_RESEND_URL, {
+      preventScrollReset: undefined, relative: undefined, replace: false, state: { dataToSubmit: { emailAddress: 'testemail@email.com' } },
+    }); // params on Link generated links by default
+  });
+});

--- a/src/pages/SignIn/__tests__/ResendRequestPasswordReset.test.jsx
+++ b/src/pages/SignIn/__tests__/ResendRequestPasswordReset.test.jsx
@@ -1,8 +1,17 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import RequestPasswordResetConfirmation from '../RequestPasswordResetConfirmation';
-import { REQUEST_PASSWORD_RESET_RESEND_URL } from '../../../constants/AppUrlConstants';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {
+  REQUEST_PASSSWORD_RESET_ENDPOINT,
+} from '../../../constants/AppAPIConstants';
+import {
+  MESSAGE_URL,
+  REQUEST_PASSWORD_RESET_CONFIRMATION_URL,
+  REQUEST_PASSWORD_RESET_URL,
+} from '../../../constants/AppUrlConstants';
+import ResendRequestPasswordReset from '../ResendRequestPasswordReset';
 
 let mockUseLocationState = {};
 const mockedUseNavigate = jest.fn();
@@ -12,36 +21,145 @@ jest.mock('react-router', () => ({
   useLocation: jest.fn().mockImplementation(() => mockUseLocationState),
 }));
 
-describe('Confirm request password reset check your email tests', () => {
+describe('Resend password reset link email', () => {
+  const mockAxios = new MockAdapter(axios);
+  const scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
   beforeEach(() => {
+    mockAxios.reset();
     mockUseLocationState = {};
+    window.sessionStorage.clear();
   });
 
-  it('should render page with content', () => {
+  // ================
+  // RENDER
+  // ================
+  it('should render page with content when there is no state', () => {
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    expect(screen.getByText('Request a new verification link')).toBeInTheDocument();
+    expect(screen.getByText('Emails sometimes take a few minutes to arrive. If you did not receive the link, you can request a new one.')).toBeInTheDocument();
+    expect(screen.getByTestId('details-component').outerHTML).toEqual('<details class="govuk-details" data-module="govuk-details" data-testid="details-component"><summary class="govuk-details__summary"><span class="govuk-details__summary-text">Change where the email was sent</span></summary><div class="govuk-details__text"><label class="govuk-label" for="emailAddress-input">Email address</label><div id="emailAddress-hint" class="govuk-hint"></div><p id="emailAddress-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> </p><input class="govuk-input" id="emailAddress-input" name="emailAddress" type="email" autocomplete="email" value=""></div></details>');
+    expect(screen.getByRole('button', { name: 'Request a new link' })).toBeInTheDocument('');
+  });
+
+  it('should render page with content when email address is in state', () => {
     mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
-    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
-    expect(screen.getByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    expect(screen.getByText('Request a new verification link')).toBeInTheDocument();
+    expect(screen.getByText('Emails sometimes take a few minutes to arrive. If you did not receive the link, you can request a new one.')).toBeInTheDocument();
+    expect(screen.getByTestId('details-component').outerHTML).toEqual('<details class="govuk-details" data-module="govuk-details" data-testid="details-component"><summary class="govuk-details__summary"><span class="govuk-details__summary-text">Change where the email was sent</span></summary><div class="govuk-details__text"><label class="govuk-label" for="emailAddress-input">Email address</label><div id="emailAddress-hint" class="govuk-hint"></div><p id="emailAddress-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> </p><input class="govuk-input" id="emailAddress-input" name="emailAddress" type="email" autocomplete="email" value="testemail@email.com"></div></details>');
+    expect(screen.getByRole('button', { name: 'Request a new link' })).toBeInTheDocument('');
   });
 
-  it('should show the email address from state in the page', () => {
-    mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
-    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
-    expect(screen.getByText('testemail@email.com')).toBeInTheDocument();
+  // ================
+  // ERROR
+  // ================
+  it('should display the Error Summary if there are errors', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getByText('There is a problem')).toBeInTheDocument();
   });
 
-  it('should include a link to resend your verificaiton email', () => {
-    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
-    expect(screen.getByRole('link', { name: 'Not received an email?' }).outerHTML).toEqual('<a class="govuk-body govuk-link" href="/forgotten-password/request-new-link">Not received an email?</a>');
+  it('should display the email required error if there is no email address', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getAllByText('Enter your email address')).toHaveLength(2);
   });
 
-  it('should navigate to the resend request page with email address if link clicked', async () => {
+  it('should scroll to email field and set focus on email input if user clicks on email required error link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await user.click(screen.getByRole('button', { name: 'Enter your email address' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', { name: /email/i })[0]).toHaveFocus();
+  });
+
+  it('should display the email invalid error if the email address has no @', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail');
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
+  });
+
+  it('should display the email invalid error if the email address has no .xx', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getAllByText('Enter a real email address')).toHaveLength(2);
+  });
+
+  it('should scroll to email field and set focus on email input if user clicks on email invalid format error link', async () => {
+    const user = userEvent.setup();
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getAllByRole('textbox', { name: /email/i })[0], 'testemail@boo');
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    await user.click(screen.getByRole('button', { name: 'Enter a real email address' }));
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(screen.getAllByRole('textbox', { name: /email/i })[0]).toHaveFocus();
+  });
+
+  // ================
+  // POST
+  // ================
+  it('should navigate to confirmation page if successful POST to resend response', async () => {
     const user = userEvent.setup();
     mockUseLocationState = { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } };
-    render(<MemoryRouter><RequestPasswordResetConfirmation /></MemoryRouter>);
-    expect(screen.getByText('testemail@email.com')).toBeInTheDocument();
-    await user.click(screen.getByRole('link', { name: 'Not received an email?' }));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(REQUEST_PASSWORD_RESET_RESEND_URL, {
-      preventScrollReset: undefined, relative: undefined, replace: false, state: { dataToSubmit: { emailAddress: 'testemail@email.com' } },
-    }); // params on Link generated links by default
+    mockAxios
+      .onPost(REQUEST_PASSSWORD_RESET_ENDPOINT)
+      .reply(204);
+
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Request a new link' }));
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(REQUEST_PASSWORD_RESET_CONFIRMATION_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
+    });
+  });
+
+  it('should navigate to confirmation page if invalid email address POST response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPost(REQUEST_PASSSWORD_RESET_ENDPOINT, { email: 'test@test.com' })
+      .reply(401);
+
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getByRole('textbox', { name: 'Email address' }), 'test@test.com');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(REQUEST_PASSWORD_RESET_CONFIRMATION_URL, { state: { dataToSubmit: { emailAddress: 'test@test.com' } } });
+  });
+
+  it('should navigate to message page if error POST response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPost(REQUEST_PASSSWORD_RESET_ENDPOINT, { email: 'test@test.com' })
+      .reply(400);
+
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getByRole('textbox', { name: 'Email address' }), 'test@test.com');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: undefined, redirectURL: REQUEST_PASSWORD_RESET_URL } });
+  });
+
+  it('should navigate to message page if 500 POST response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPost(REQUEST_PASSSWORD_RESET_ENDPOINT, { email: 'test@test.com' })
+      .reply(500);
+
+    render(<MemoryRouter><ResendRequestPasswordReset /></MemoryRouter>);
+    await user.type(screen.getByRole('textbox', { name: 'Email address' }), 'test@test.com');
+    await user.click(screen.getByTestId('submit-button'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: undefined, redirectURL: REQUEST_PASSWORD_RESET_URL } });
   });
 });


### PR DESCRIPTION
# Ticket



----

## AC

Given I have entered a registered and validated email address
When I click submit
Then I should be shown the confirmation page
And I should receive a password reset email

Given I click 'not received an email' on the confirmation page
Then I should be taken to the request a new link page

**Given I click request a new link on the confirmation page
When the stored email address is a registered and validated one
Then I should be shown the confirmation page
And I should receive a password reset email**

**Given I click change where the email was sent on the confirmation page
And I enter a registered and validated email address in the field
When I click request a new link
Then I should be shown the confirmation page
And I should receive a password reset email**

**Given I enter an email address that is not registered and validated on the [forgot password page, or the request new link page]
When I click submit
Then I should be shown the confirmation page
But no email should be sent**





----

## To test

SCENARIO 1: registered and validated email : can reset their password
**NOTE: to get to the request a new email page for testing UI purposes change the '401' error handler to '400'**

- go to /forgotten-password
- enter a registered and validated email address
- > you should be taken to the confirmation page
- > ~~you should receive a password reset email (delete this for now)~~
- click on not received an email
- > you should be taken to the request a new email page
- click request a new link
- > you should be taken to the confirmation page
- > ~~you should receive a password reset email (delete this for now)~~
- click request a new link
- enter a different registered and validated email address
- > you should be taken to the confirmation page
- > ~~the owner of that email address should receive a password reset email (delete this for now)~~

SCENARIO 2: cannot reset password as email not registered and validated
**NOTE: to get to the request a new email page for testing UI purposes change the '401' error handler to '400'**

- go to /forgotten-password
- click submit
- > you should receive an error on the page
- enter a badly formatted email
- click submit
- > you should receive an error on the page
- enter a correctly formatted email that is not registered and validated
- > you should be taken to the confirmation page
- check the network tab
- > you should see a 401 error, which indicates there was no email sent
- go back to the /forgotten-password page
- enter a registered and validated email address
- > you should be taken to the confirmation page
- > ~~you should receive a password reset email (delete this for now)~~
- click on not received an email
- > you should be taken to the request a new email page
- click request a new link
- > you should be taken to the confirmation page
- > ~~you should receive a password reset email (delete this for now)~~
- click request a new link
- enter a different registered and validated email address
- > you should be taken to the confirmation page
- > ~~the owner of that email address should receive a password reset email (delete this for now)~~

----

## Notes
- secret for the template Id for the email hasn't been added for dev/staging yet so success cases will always throw an error
