### PR TITLE
NMSW-554 Update FE code to accommodate BE changes to how we receive FAL data

### DIFF
--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -67,7 +67,7 @@ const VoyageTaskList = () => {
       setVoyageTypeText(response.data?.FAL1.departureFromUk ? 'Departure from the UK' : 'Arrival to the UK');
 
       let isPassengers;
-      if (response.data?.FAL1.passengers && response.data?.FAL6) {
+      if (response.data?.FAL1.passengers && response.data?.FAL6.length > 0) {
         isPassengers = 'completed';
       } else if (response.data?.FAL1.passengers === false) {
         isPassengers = 'completed';
@@ -86,7 +86,7 @@ const VoyageTaskList = () => {
           item: 'crewDetails',
           link: `${VOYAGE_CREW_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`,
           label: CREW_DETAILS_LABEL,
-          status: response.data.FAL5 ? 'completed' : 'required',
+          status: response.data?.FAL5.length > 0 ? 'completed' : 'required',
         },
         {
           item: 'passengerDetails',
@@ -104,7 +104,7 @@ const VoyageTaskList = () => {
 
       setStep(updatedStatuses);
 
-      if (response.data.FAL1 && response.data.FAL5 && isPassengers === 'completed') {
+      if (response.data?.FAL1 && response.data?.FAL5.length > 0 && isPassengers === 'completed') {
         setCompletedSections(1);
         setCheckYourAnswersStep({ ...checkYourAnswersStep, status: 'notStarted' });
       } else {

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -54,8 +54,16 @@ describe('Voyage check your answers page', () => {
       creationDate: '2023-02-10',
       submissionDate: '2023-02-11',
     },
-    FAL5: 'https://fal5-report-link.com',
-    FAL6: null,
+    FAL5: [
+      {
+        filename: 'Crew details including supernumeraries FAL 5.xlsx',
+        id: 'FAL5',
+        size: '118385',
+        url: 'https://fal5-report-link.com',
+      },
+    ],
+    FAL6: [],
+    supporting: [],
   };
 
   const mockedAllFALResponse = {
@@ -79,8 +87,23 @@ describe('Voyage check your answers page', () => {
       creationDate: '2023-02-10',
       submissionDate: '2023-02-11',
     },
-    FAL5: 'https://fal5-report-link.com',
-    FAL6: 'https://fal6-report-link.com',
+    FAL5: [
+      {
+        filename: 'Crew details including supernumeraries FAL 5.xlsx',
+        id: 'FAL5',
+        size: '118385',
+        url: 'https://fal5-report-link.com',
+      },
+    ],
+    FAL6: [
+      {
+        filename: 'Passenger details FAL 6.xlsx',
+        id: 'FAL6',
+        size: '118385',
+        url: 'https://fal6-report-link.com',
+      },
+    ],
+    supporting: [],
   };
 
   beforeEach(() => {
@@ -242,7 +265,7 @@ describe('Voyage check your answers page', () => {
 
     expect(screen.getByText('NL RTM').outerHTML).toEqual('<dd class="govuk-summary-list__value">NL RTM</dd>');
     expect(screen.getByText('No cargo').outerHTML).toEqual('<dd class="govuk-summary-list__value">No cargo</dd>');
-    expect(screen.getByRole('link', { name: 'fal5-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">fal5-report-link.com</a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries FAL 5.xlsx' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">Crew details including supernumeraries FAL 5.xlsx</a>');
     expect(screen.getByText('No passenger details provided')).toBeInTheDocument();
     expect(screen.getByText('No supporting documents provided')).toBeInTheDocument();
   });
@@ -258,8 +281,8 @@ describe('Voyage check your answers page', () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
-    expect(screen.getByRole('link', { name: 'fal5-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">fal5-report-link.com</a>');
-    expect(screen.getByRole('link', { name: 'fal6-report-link.com' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal6-report-link.com" download="">fal6-report-link.com</a>');
+    expect(screen.getByRole('link', { name: 'Crew details including supernumeraries FAL 5.xlsx' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal5-report-link.com" download="">Crew details including supernumeraries FAL 5.xlsx</a>');
+    expect(screen.getByRole('link', { name: 'Passenger details FAL 6.xlsx' }).outerHTML).toEqual('<a class="govuk-link" href="https://fal6-report-link.com" download="">Passenger details FAL 6.xlsx</a>');
   });
 
   it('should error if passengers is true but no FAL 6 has been provided', async () => {
@@ -291,8 +314,16 @@ describe('Voyage check your answers page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: 'https://fal5-report-link.com',
-        FAL6: null,
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
@@ -330,8 +361,16 @@ describe('Voyage check your answers page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: 'https://fal5-report-link.com',
-        FAL6: null,
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));

--- a/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageTaskList.test.jsx
@@ -52,8 +52,9 @@ describe('Voyage task list page', () => {
       creationDate: '2023-02-10',
       submissionDate: '2023-02-11',
     },
-    FAL5: null,
-    FAL6: null,
+    FAL5: [],
+    FAL6: [],
+    supporting: [],
   };
 
   beforeEach(() => {
@@ -208,6 +209,9 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
+        FAL5: [],
+        FAL6: [],
+        supporting: [],
       });
 
     renderPage();
@@ -245,8 +249,16 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: 'https://fal5-report-link.com',
-        FAL6: null,
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
       });
 
     renderPage();
@@ -286,8 +298,16 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: null,
-        FAL6: 'https://fal6-report-link.com',
+        FAL5: [],
+        FAL6: [
+          {
+            filename: 'Passenger details FAL 6',
+            id: 'FAL6',
+            size: '118385',
+            url: 'https://fal6-report-link.com',
+          },
+        ],
+        supporting: [],
       });
 
     renderPage();
@@ -327,8 +347,9 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: null,
-        FAL6: null,
+        FAL5: [],
+        FAL6: [],
+        supporting: [],
       });
 
     renderPage();
@@ -366,8 +387,9 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: null,
-        FAL6: null,
+        FAL5: [],
+        FAL6: [],
+        supporting: [],
       });
 
     renderPage();
@@ -405,8 +427,23 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: 'https://fal5-report-link.com',
-        FAL6: 'https://fal6-report-link.com',
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [
+          {
+            filename: 'Passenger details FAL 6',
+            id: 'FAL6',
+            size: '118385',
+            url: 'https://fal6-report-link.com',
+          },
+        ],
+        supporting: [],
       });
 
     renderPage();
@@ -531,8 +568,23 @@ describe('Voyage task list page', () => {
           creationDate: '2023-02-10',
           submissionDate: '2023-02-11',
         },
-        FAL5: 'https://fal5-report-link.com',
-        FAL6: 'https://fal6-report-link.com',
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [
+          {
+            filename: 'Passenger details FAL 6',
+            id: 'FAL6',
+            size: '118385',
+            url: 'https://fal6-report-link.com',
+          },
+        ],
+        supporting: [],
       });
 
     renderPage();


### PR DESCRIPTION
# Ticket

NMSW-554

----

## AC

We now receive FAL 5 and 6 data as a list of objects which means that the code for NMSW-424 and NMSW-154) is no longer working as expected.

FE code that needs updating:
- Tasklist page: Make sure that the statuses are updating as expected for FAL 5 and 6 uploads
- CYA page: Make sure the page loads and displays the filename and has a link with the ability to download the file as expected

----

## To test

- Follow test steps for https://github.com/UKHomeOffice/nmsw-ui/pull/312
- Follow test steps for https://github.com/UKHomeOffice/nmsw-ui/pull/313

----

## Notes
