### PR TITLE
NMSW-516 Update supporting document upload endpoint

### DIFF
--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -6,6 +6,7 @@ import { SIGN_IN_URL } from '../constants/AppUrlConstants';
 import Auth from '../utils/Auth';
 import LoadingSpinner from './LoadingSpinner';
 import '../assets/css/multiFileUploadForm.scss';
+import { FILE_TYPE_INVALID_PREFIX } from '../constants/AppAPIConstants';
 
 const FILE_STATUS_PENDING = 'Pending';
 const FILE_STATUS_IN_PROGRESS = 'in progress';
@@ -159,6 +160,21 @@ const MultiFileUploadForm = ({
         return response;
       } catch (err) {
         switch (err?.response?.status) {
+          case 400:
+            if (err?.response?.data?.message?.startsWith(FILE_TYPE_INVALID_PREFIX)) {
+              updateFileStatus({
+                file: selectedFile,
+                status: FILE_STATUS_ERROR,
+                errorMessage: 'The file must be a csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml',
+              });
+            } else {
+              updateFileStatus({
+                file: selectedFile,
+                status: FILE_STATUS_ERROR,
+                errorMessage: err?.response?.data?.message ? err.response.data.message : 'There was a problem check file and try again',
+              });
+            }
+            break;
           case 401:
           case 422:
             Auth.removeToken();

--- a/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
+++ b/src/components/__tests__/DisplayFormTests/ErrorSummaryAndLinks.test.jsx
@@ -179,7 +179,7 @@ describe('Display Form', () => {
       </MemoryRouter>,
     );
     await user.click(screen.getByRole('button', { name: 'Submit test button' }));
-    await screen.getByText('There is a problem');
+    await screen.findByText('There is a problem');
 
     await screen.findByRole('heading', { name: 'There is a problem' });
     expect(screen.getByText('There is a problem').outerHTML).toEqual('<h2 class="govuk-error-summary__title" id="error-summary-title">There is a problem</h2>');

--- a/src/components/__tests__/MultiFileUploadStatus.test.jsx
+++ b/src/components/__tests__/MultiFileUploadStatus.test.jsx
@@ -108,7 +108,9 @@ describe('Multi file upload status tests', () => {
     expect(screen.getAllByText('Pending')).toHaveLength(2);
 
     await user.click(screen.getByRole('button', { name: 'Upload files' }));
-    expect(screen.queryByText('Loading')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Loading')).not.toBeInTheDocument();
+    });
     expect(screen.getAllByText('error response')).toHaveLength(2);
   });
 

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -15,6 +15,7 @@ export const ENDPOINT_DECLARATION_PATH = '/declaration';
 export const ENDPOINT_FILE_UPLOAD_GENERAL_DECLARATION_PATH = '/upload-fal1';
 export const ENDPOINT_FILE_UPLOAD_CREW_DETAILS_PATH = '/upload-fal5';
 export const ENDPOINT_FILE_UPLOAD_PASSENGER_DETAILS_PATH = '/upload-fal6';
+export const ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH = '/supporting';
 export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 
 // Responses

--- a/src/pages/Voyage/VoyageSupportingDocsUpload.jsx
+++ b/src/pages/Voyage/VoyageSupportingDocsUpload.jsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 import Message from '../../components/Message';
 import MultiFileUploadForm from '../../components/MultiFileUploadForm';
-import { API_URL, ENDPOINT_DECLARATION_PATH, ENDPOINT_FILE_UPLOAD_GENERAL_DECLARATION_PATH } from '../../constants/AppAPIConstants';
+import { API_URL, ENDPOINT_DECLARATION_PATH, ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH } from '../../constants/AppAPIConstants';
 import {
   URL_DECLARATIONID_IDENTIFIER,
   VOYAGE_SUPPORTING_DOCS_UPLOAD_URL,
@@ -21,7 +21,7 @@ const VoyageSupportingDocsUpload = () => {
   }
   return (
     <MultiFileUploadForm
-      endpoint={`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}${ENDPOINT_FILE_UPLOAD_GENERAL_DECLARATION_PATH}`}
+      endpoint={`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`}
       pageHeading="Upload supporting documents"
       submitButtonLabel="Save and continue"
       urlNextPage={`${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}`}


### PR DESCRIPTION
# Ticket

NMSW-516

----

## AC

GIVEN I am creating a declaration
WHEN I am on the supporting docs page
THEN I am able to upload docs of types csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml


GIVEN I am creating a declaration
WHEN I am on the supporting docs page
THEN I am NOT able to upload docs that are not of types csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml

----

## To test

- Run app
- Sign in
- Create a declaration
- Go through the journey until the tasklist page
- Click on supporting documents
- Add a file of type csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml
- Click upload
- > In the network tab you should see a successful post to the supporting documents endpoint
- Add a file that is NOT a csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml
- Click upload
- You should see an error of 'The file must be a csv, doc, docm, docx, rtf, txt, xls, xlsm, xlsx, xltm, xltx, xlw or xml' next too the uploaded file


----

## Notes
