### PR TITLE
Replace sign in unverified flow

### DIFF
--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -10,24 +10,21 @@ import {
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
 import {
-  REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT,
   SIGN_IN_ENDPOINT,
-  USER_ALREADY_VERIFIED,
   USER_NOT_VERIFIED,
   USER_SIGN_IN_DETAILS_INVALID,
 } from '../../constants/AppAPIConstants';
 import {
+  LOGGED_IN_LANDING,
   MESSAGE_URL,
   REGISTER_ACCOUNT_URL,
-  SIGN_IN_URL,
-  LOGGED_IN_LANDING,
   REGISTER_EMAIL_RESEND_URL,
-  REGISTER_EMAIL_CHECK_URL,
-  ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
   REQUEST_PASSWORD_RESET_URL,
+  SIGN_IN_URL,
 } from '../../constants/AppUrlConstants';
 import Auth from '../../utils/Auth';
 import { scrollToTop } from '../../utils/ScrollToElement';
+import Message from '../../components/Message';
 
 const SupportingText = () => (
   <div className="govuk-inset-text">
@@ -42,6 +39,7 @@ const SignIn = () => {
   const { state } = useLocation();
   const [errors, setErrors] = useState();
   const [isLoading, setIsLoading] = useState(false);
+  const [isNotActivated, setIsNotActivated] = useState(false);
   document.title = 'Sign in';
 
   // Form fields
@@ -84,31 +82,6 @@ const SignIn = () => {
     setIsLoading(false);
   };
 
-  const resendVerificationEmail = async (emailToSendTo) => {
-    try {
-      const controller = new AbortController();
-      const response = await axios.post(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT, {
-        email: emailToSendTo,
-      }, {
-        signal: controller.signal,
-      });
-
-      if (response.status === 204) {
-        navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: emailToSendTo } } });
-      }
-    } catch (err) {
-      if (err?.response?.data?.message === USER_ALREADY_VERIFIED) {
-        // Edgecase where somehow user activates their account while we're processing a resend verification email
-        navigate(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: emailToSendTo } } });
-      } else {
-        // USER_NOT_REGISTERED & 500 errors will fall into this bucket (error out on USER_NOT_REGISTERED as it shouldn't occur here and we don't want to cause a loop of register/resend running)
-        navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: SIGN_IN_URL } });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   const handleSubmit = async ({ formData }) => {
     setIsLoading(true);
     try {
@@ -124,23 +97,29 @@ const SignIn = () => {
         setErrors('Email and password combination is invalid');
         scrollToTop();
       } else if (err?.response?.data?.message === USER_NOT_VERIFIED) {
-        navigate(REGISTER_EMAIL_RESEND_URL, { state: { dataToSubmit: { emailAddress: formData?.email } } });
+        setIsNotActivated(true);
+        scrollToTop();
       } else {
-        /* currently if a user is registered but not verified
-         * (aka in database but not able to sign in yet) we get a 500 response
-         * To handle that until API can be updated with a clear response
-         * for this scenario, any other error we will attempt to re-send verification
-         * email.
-         * Once we have an error response we can use to identify this scenario then
-         * we can go back to the navigate(MESSAGE ...) code below
-         */
-        resendVerificationEmail(formData.email);
-        // navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: SIGN_IN_URL } });
+        navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: SIGN_IN_URL } });
       }
     } finally {
       setIsLoading(false);
     }
   };
+
+  if (isNotActivated) {
+    const buttonProps = {
+      buttonLabel: 'Request a new email verification link',
+      buttonNavigateTo: REGISTER_EMAIL_RESEND_URL,
+    };
+    return (
+      <Message
+        button={buttonProps}
+        title="Your email address has not been verified"
+        message="You need to verify your email address to finish creating your account."
+      />
+    );
+  }
 
   return (
     <>

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -5,19 +5,14 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import SignIn from './SignIn';
 import {
-  REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT,
   SIGN_IN_ENDPOINT,
-  USER_ALREADY_VERIFIED,
   USER_NOT_VERIFIED,
   USER_SIGN_IN_DETAILS_INVALID,
 } from '../../constants/AppAPIConstants';
 import {
   MESSAGE_URL,
-  REGISTER_EMAIL_RESEND_URL,
   SIGN_IN_URL,
   LOGGED_IN_LANDING,
-  REGISTER_EMAIL_CHECK_URL,
-  ERROR_ACCOUNT_ALREADY_ACTIVE_URL,
 } from '../../constants/AppUrlConstants';
 
 const mockUseLocationState = { state: {} };
@@ -234,22 +229,22 @@ describe('Sign in tests', () => {
     expect(screen.getByText('Email and password combination is invalid')).toBeInTheDocument();
   });
 
-  it('should redirect to re-send verification email page if user is not verified', async () => {
-    const user = userEvent.setup();
+  // it('should redirect to re-send verification email page if user is not verified', async () => {
+  //   const user = userEvent.setup();
 
-    mockAxios
-      .onPost(SIGN_IN_ENDPOINT)
-      .reply(401, {
-        message: USER_NOT_VERIFIED,
-      });
+  //   mockAxios
+  //     .onPost(SIGN_IN_ENDPOINT)
+  //     .reply(401, {
+  //       message: USER_NOT_VERIFIED,
+  //     });
 
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
+  //   render(<MemoryRouter><SignIn /></MemoryRouter>);
 
-    await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
-    await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
-    await user.click(screen.getByTestId('submit-button'));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
-  });
+  //   await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
+  //   await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
+  //   await user.click(screen.getByTestId('submit-button'));
+  //   expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
+  // });
 
   it('should clear API error when something is typed into input', async () => {
     const user = userEvent.setup();
@@ -291,66 +286,29 @@ describe('Sign in tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith('/thisurl', { state: { redirectURL: '/thisurl', otherState: 'another piece of state' } });
   });
 
-  // ================
-  // TESTS for temporary work around for 500/unhandled errors
-  // ================
-  /* See comment around line 128 in SignIn.jsx as to temporary process for 500 errors */
-  // it('should redirect to error page if 500 response received', async () => {
-  //   const user = userEvent.setup();
-  //   mockAxios
-  //     .onPost(SIGN_IN_ENDPOINT)
-  //     .reply(500);
-
-  //   render(<MemoryRouter><SignIn /></MemoryRouter>);
-
-  //   await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
-  //   await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   await waitFor(() => {
-  //     expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', redirectURL: SIGN_IN_URL } }); // on error we redirect to error page
-  //   });
-  // });
-
-  it('should send verification email if 500 response received to sign in', async () => {
+  it('should show instructions to send verification email if user not yet activated', async () => {
     const user = userEvent.setup();
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(500)
-      .onPost(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT)
-      .reply(204);
-
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-
-    await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
-    await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
-    await user.click(screen.getByTestId('submit-button'));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
-  });
-
-  it('should redirect to user already verified if 500 from sign in and 400 already verified received', async () => {
-    const user = userEvent.setup();
-    mockAxios
-      .onPost(SIGN_IN_ENDPOINT)
-      .reply(500)
-      .onPost(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT)
-      .reply(409, {
-        message: USER_ALREADY_VERIFIED,
+      .reply(401, {
+        message: USER_NOT_VERIFIED,
       });
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
-
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
     await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
     await user.click(screen.getByTestId('submit-button'));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(ERROR_ACCOUNT_ALREADY_ACTIVE_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
+    screen.findByRole('heading', { name: 'Your email address has not been verified' });
+    expect(screen.getByRole('heading', { name: 'Your email address has not been verified' })).toBeInTheDocument();
+    expect(screen.getByText('You need to verify your email address to finish creating your account.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Request a new email verification link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Request a new email verification link' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Request a new email verification link</button>');
   });
 
   it('should redirect to message page if 500 from sign in and 500/unknown error received', async () => {
     const user = userEvent.setup();
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(500)
-      .onPost(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT)
       .reply(500);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);

--- a/src/pages/SignIn/SignIn.test.jsx
+++ b/src/pages/SignIn/SignIn.test.jsx
@@ -229,23 +229,6 @@ describe('Sign in tests', () => {
     expect(screen.getByText('Email and password combination is invalid')).toBeInTheDocument();
   });
 
-  // it('should redirect to re-send verification email page if user is not verified', async () => {
-  //   const user = userEvent.setup();
-
-  //   mockAxios
-  //     .onPost(SIGN_IN_ENDPOINT)
-  //     .reply(401, {
-  //       message: USER_NOT_VERIFIED,
-  //     });
-
-  //   render(<MemoryRouter><SignIn /></MemoryRouter>);
-
-  //   await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
-  //   await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
-  //   await user.click(screen.getByTestId('submit-button'));
-  //   expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL, { state: { dataToSubmit: { emailAddress: 'testemail@email.com' } } });
-  // });
-
   it('should clear API error when something is typed into input', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
# Ticket

NMSW-204

----

## AC

Given a user has registered but not verified their email
When they submit the sign in form
Then they are shown an info page asking them to verify their email

_Note: we had two other implementations of handling this scenario which are removed as part of this PR as once this new UX was designed for the forgotten password flow it was decided to use the same UX for sign in_

----

## To test

- register an email address
- go to sign in
- try to sign in with that email and any password
- > you should see the 'you need to verify' page

----

## Notes
