### PR TITLE
NMSW-552 Handle duplicate records between FAL5 and FAL6 errors

### DIFF
--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../constants/AppConstants';
 import {
   DUPLICATE_RECORDS,
-  FILE_MISSING,
-  FILE_TYPE_INVALID_PREFIX,
   FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
+  FILE_MISSING,
+  FILE_TOO_LARGE,
+  FILE_TYPE_INVALID_CSV_XLSX,
 } from '../constants/AppAPIConstants';
 import {
   FILE_UPLOAD_FIELD_ERRORS_URL,
@@ -47,10 +48,13 @@ const FileUploadForm = ({
 
   const handleErrors = ({ errorData }) => {
     switch (errorData.message) {
+      case DUPLICATE_RECORDS:
+        setError({ id: FILE_UPLOAD_ID, message: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." });
+        break;
       case FILE_MISSING:
         setError({ id: FILE_UPLOAD_ID, message: 'Select a file' });
         break;
-      case FILE_TYPE_INVALID_PREFIX:
+      case FILE_TYPE_INVALID_CSV_XLSX:
         setError({ id: FILE_UPLOAD_ID, message: `The file must be a ${fileTypesAllowed}` });
         break;
       case FAL5_IS_EMPTY:
@@ -59,8 +63,8 @@ const FileUploadForm = ({
       case FAL6_IS_EMPTY:
         setError({ id: FILE_UPLOAD_ID, message: 'Template is empty' });
         break;
-      case DUPLICATE_RECORDS:
-        setError({ id: FILE_UPLOAD_ID, message: 'Details listed on this file are not allowed, because they’re the same as details you’ve already uploaded. Check the details in your file and try uploading again.' });
+      case FILE_TOO_LARGE:
+        setError({ id: FILE_UPLOAD_ID, message: `The file must be smaller than ${MAX_FILE_SIZE_DISPLAY}MB` });
         break;
       default: {
         const errorList = MapErrorMessages({ errData: errorData, errorMessageMapFile });
@@ -122,7 +126,7 @@ const FileUploadForm = ({
     if (Object.entries(selectedFile).length < 1) {
       handleErrors({ errorData: { message: FILE_MISSING } });
     } else if (selectedFile?.file.size > MAX_FILE_SIZE) {
-      handleErrors({ errorData: { message: `The file must be smaller than ${MAX_FILE_SIZE_DISPLAY}MB` } });
+      handleErrors({ errorData: { message: FILE_TOO_LARGE } });
     } else {
       const dataToSubmit = new FormData();
       dataToSubmit.append('file', selectedFile?.file, selectedFile?.file?.name);

--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../constants/AppConstants';
 import {
   DUPLICATE_RECORDS,
+  DUPLICATE_RECORDS_FAL5,
   FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
   FILE_MISSING,
@@ -49,6 +50,9 @@ const FileUploadForm = ({
   const handleErrors = ({ errorData }) => {
     switch (errorData.message) {
       case DUPLICATE_RECORDS:
+        setError({ id: FILE_UPLOAD_ID, message: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." });
+        break;
+      case DUPLICATE_RECORDS_FAL5:
         setError({ id: FILE_UPLOAD_ID, message: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." });
         break;
       case FILE_MISSING:

--- a/src/components/__tests__/FileUploadForm.test.jsx
+++ b/src/components/__tests__/FileUploadForm.test.jsx
@@ -4,7 +4,13 @@ import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../../constants/AppConstants';
-import { FILE_MISSING, FILE_TYPE_INVALID_PREFIX } from '../../constants/AppAPIConstants';
+import {
+  DUPLICATE_RECORDS,
+  FAL5_IS_EMPTY,
+  FAL6_IS_EMPTY,
+  FILE_MISSING,
+  FILE_TYPE_INVALID_CSV_XLSX,
+} from '../../constants/AppAPIConstants';
 import {
   FILE_UPLOAD_FIELD_ERRORS_URL,
   LOGGED_IN_LANDING,
@@ -138,13 +144,76 @@ describe('File upload tests', () => {
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
+  it('should show an error if the API returns a FAL 5 is empty response', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        message: FAL5_IS_EMPTY,
+      });
+    renderPage();
+    // make sure file is recognised so the FE no the FE file error isn't triggered
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Template is empty' })).toBeInTheDocument();
+    expect(screen.getAllByText('Template is empty')).toHaveLength(2);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+
+  it('should show an error if the API returns a FAL 6 is empty response', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        message: FAL6_IS_EMPTY,
+      });
+    renderPage();
+    // make sure file is recognised so the FE no the FE file error isn't triggered
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Template is empty' })).toBeInTheDocument();
+    expect(screen.getAllByText('Template is empty')).toHaveLength(2);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+
+  it('should show an error if the API returns a duplicate records response', async () => {
+    const user = userEvent.setup();
+    const file = new File(['template'], 'template.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockAxios
+      .onPost('/specific-endpoint-path-for-filetype')
+      .reply(400, {
+        message: DUPLICATE_RECORDS,
+      });
+    renderPage();
+    // make sure file is recognised so the FE no the FE file error isn't triggered
+    const input = screen.getByLabelText('Title from props');
+    await user.upload(input, file);
+    expect(input.files[0]).toStrictEqual(file);
+    await user.click(screen.getByRole('button', { name: 'Submit text from props' }));
+    await screen.findByRole('heading', { name: 'There is a problem' });
+    expect(screen.getByRole('alert', { name: 'There is a problem' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." })).toBeInTheDocument();
+    expect(screen.getAllByText("Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again.")).toHaveLength(2);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+  });
+
   it('should show an error if API returns a file is invalid type response', async () => {
     const user = userEvent.setup();
     const file = new File(['template'], 'image.png', { type: 'image/png' });
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        message: `${FILE_TYPE_INVALID_PREFIX}: Not a ['xlsx', 'csv']`,
+        message: FILE_TYPE_INVALID_CSV_XLSX,
       });
     renderPage();
     const input = screen.getByLabelText('Title from props');

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -22,7 +22,9 @@ export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 // Responses
 export const DUPLICATE_RECORDS = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL5).';
 export const FILE_MISSING = 'No file provided';
+export const FILE_TOO_LARGE = 'Large file';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';
+export const FILE_TYPE_INVALID_CSV_XLSX = "Invalid file type: Not a ['csv', 'xlsx']";
 export const FAL5_IS_EMPTY = 'File has no crew data';
 export const FAL6_IS_EMPTY = 'No data rows found in file.';
 export const TOKEN_EXPIRED = 'Token has expired';

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -21,6 +21,7 @@ export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 
 // Responses
 export const DUPLICATE_RECORDS = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL5).';
+export const DUPLICATE_RECORDS_FAL5 = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL6).';
 export const FILE_MISSING = 'No file provided';
 export const FILE_TOO_LARGE = 'Large file';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -20,6 +20,7 @@ export const ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH = '/supporting';
 export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 
 // Responses
+export const DUPLICATE_RECORDS = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL5).';
 export const FILE_MISSING = 'No file provided';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';
 export const FAL5_IS_EMPTY = 'File has no crew data';


### PR DESCRIPTION
# Ticket



----

## AC

Given I have uploaded a FAL5 form
When I attempt to upload a FAL6 form that has a record that contains the same travel_document_id and country as a record on the FAL5 form
Then I am shown an error

Given I am uploading a FAL5 form
When I attempt to upload a FAL5 form that has two or more records that contain the same travel document id and country
Then I am shown an error

Given I am uploading a FAL6 form
When I attempt to upload a FAL6 form that has two or more records that contain the same travel document id and country
Then I am shown an error


----

## To test

Scenario one

- create a FAL5 and FAL6 form where at least one row on each has the same travel document number and country
- create a declaration
- upload the FAL5 form
- upload the FAL6 form
- > you should see an error

Scenario two

- create a FAL5 form where at least two rows on this form have the same travel document number and country
- create a declaration
- upload the FAL5 form
- > you should see an error

Scenario three

- create a FAL6 form where at least two rows on this form have the same travel document number and country
- create a declaration
- upload the FAL6 form
- > you should see an error

----

## Notes

Added test cover for empty templates as well