### PR TITLE
NMSW-538 Add status tag component and refactor to use it

### DIFF
--- a/src/components/StatusTag.jsx
+++ b/src/components/StatusTag.jsx
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import {
+  DECLARATION_STATUS_CANCELLED,
+  DECLARATION_STATUS_DRAFT,
+  DECLARATION_STATUS_PRECANCELLED,
+  DECLARATION_STATUS_PRESUBMITTED,
+  DECLARATION_STATUS_SUBMITTED,
+  DECLARATION_STEP_STATUS_COMPLETED,
+  DECLARATION_STEP_STATUS_CANNOT_START,
+  DECLARATION_STEP_STATUS_NOT_STARTED,
+  DECLARATION_STEP_STATUS_OPTIONAL,
+  DECLARATION_STEP_STATUS_REQUIRED,
+} from '../constants/AppConstants';
+
+const StatusTag = ({ status }) => {
+  let tagClass;
+  let label;
+
+  switch (status) {
+    case DECLARATION_STATUS_CANCELLED:
+      tagClass = 'govuk-tag govuk-tag--orange';
+      label = 'Cancelled';
+      break;
+    case DECLARATION_STATUS_DRAFT:
+      tagClass = 'govuk-tag govuk-tag--grey';
+      label = 'Draft';
+      break;
+    case DECLARATION_STATUS_PRECANCELLED:
+      tagClass = 'govuk-tag govuk-tag--orange';
+      label = 'Cancelled';
+      break;
+    case DECLARATION_STATUS_PRESUBMITTED:
+      tagClass = 'govuk-tag govuk-tag--green';
+      label = 'Submitted';
+      break;
+    case DECLARATION_STATUS_SUBMITTED:
+      tagClass = 'govuk-tag govuk-tag--green';
+      label = 'Submitted';
+      break;
+
+    case DECLARATION_STEP_STATUS_CANNOT_START:
+      tagClass = 'govuk-tag govuk-tag--grey app-task-list__tag';
+      label = 'Cannot start yet';
+      break;
+    case DECLARATION_STEP_STATUS_COMPLETED:
+      tagClass = 'govuk-tag app-task-list__tag';
+      label = 'Completed';
+      break;
+    case DECLARATION_STEP_STATUS_NOT_STARTED:
+      tagClass = 'govuk-tag govuk-tag--grey app-task-list__tag';
+      label = 'Not started';
+      break;
+    case DECLARATION_STEP_STATUS_OPTIONAL:
+      tagClass = 'govuk-tag govuk-tag--blue app-task-list__tag';
+      label = 'Optional';
+      break;
+    case DECLARATION_STEP_STATUS_REQUIRED:
+      tagClass = 'govuk-tag govuk-tag--pink app-task-list__tag';
+      label = 'Required';
+      break;
+    default: {
+      tagClass = 'govuk-tag';
+      label = '';
+    }
+  }
+
+  return (
+    <strong className={tagClass}>{label}</strong>
+  );
+};
+
+export default StatusTag;
+
+StatusTag.propTypes = {
+  status: PropTypes.string,
+};

--- a/src/components/StatusTag.jsx
+++ b/src/components/StatusTag.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import {
   DECLARATION_STATUS_CANCELLED,
   DECLARATION_STATUS_DRAFT,
+  DECLARATION_STATUS_FAILED,
   DECLARATION_STATUS_PRECANCELLED,
   DECLARATION_STATUS_PRESUBMITTED,
   DECLARATION_STATUS_SUBMITTED,
@@ -24,6 +25,10 @@ const StatusTag = ({ status }) => {
     case DECLARATION_STATUS_DRAFT:
       tagClass = 'govuk-tag govuk-tag--grey';
       label = 'Draft';
+      break;
+    case DECLARATION_STATUS_FAILED:
+      tagClass = 'govuk-tag govuk-tag--red';
+      label = 'Failed';
       break;
     case DECLARATION_STATUS_PRECANCELLED:
       tagClass = 'govuk-tag govuk-tag--orange';
@@ -59,7 +64,7 @@ const StatusTag = ({ status }) => {
       label = 'Required';
       break;
     default: {
-      tagClass = 'govuk-tag';
+      tagClass = '';
       label = '';
     }
   }

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -2,8 +2,16 @@
 export const SERVICE_NAME = 'National Maritime Single Window';
 
 // Declarations
+export const DECLARATION_STATUS_CANCELLED = 'Cancelled';
 export const DECLARATION_STATUS_DRAFT = 'Draft';
+export const DECLARATION_STATUS_PRECANCELLED = 'PreCancelled';
 export const DECLARATION_STATUS_PRESUBMITTED = 'PreSubmitted';
+export const DECLARATION_STATUS_SUBMITTED = 'Submitted';
+export const DECLARATION_STEP_STATUS_COMPLETED = 'completed';
+export const DECLARATION_STEP_STATUS_CANNOT_START = 'cannotStartYet';
+export const DECLARATION_STEP_STATUS_NOT_STARTED = 'notStarted';
+export const DECLARATION_STEP_STATUS_OPTIONAL = 'optional';
+export const DECLARATION_STEP_STATUS_REQUIRED = 'required';
 
 // Forms: display types
 export const DISPLAY_DETAILS = 'details';

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -4,6 +4,7 @@ export const SERVICE_NAME = 'National Maritime Single Window';
 // Declarations
 export const DECLARATION_STATUS_CANCELLED = 'Cancelled';
 export const DECLARATION_STATUS_DRAFT = 'Draft';
+export const DECLARATION_STATUS_FAILED = 'Failed';
 export const DECLARATION_STATUS_PRECANCELLED = 'PreCancelled';
 export const DECLARATION_STATUS_PRESUBMITTED = 'PreSubmitted';
 export const DECLARATION_STATUS_SUBMITTED = 'Submitted';

--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CREATE_VOYAGE_ENDPOINT, TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
+import { SERVICE_NAME } from '../../constants/AppConstants';
 import {
   SIGN_IN_URL,
   URL_DECLARATIONID_IDENTIFIER,
@@ -12,10 +13,10 @@ import {
   VOYAGE_TASK_LIST_URL,
   YOUR_VOYAGES_URL,
 } from '../../constants/AppUrlConstants';
-import { SERVICE_NAME } from '../../constants/AppConstants';
-import Message from '../../components/Message';
-import Auth from '../../utils/Auth';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import Message from '../../components/Message';
+import StatusTag from '../../components/StatusTag';
+import Auth from '../../utils/Auth';
 
 // NOTES:
 // - The filter buttons do nothing
@@ -24,14 +25,14 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 
 const YourVoyages = () => {
   dayjs.extend(customParseFormat);
-  const { state } = useLocation();
+  // const { state } = useLocation();
   const navigate = useNavigate();
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [voyageData, setVoyageData] = useState();
 
   document.title = SERVICE_NAME;
-  console.log('confbanner', state?.confirmationBanner);
+  // console.log('confbanner', state?.confirmationBanner);
 
   const handleClick = async () => {
     setIsLoading(true);
@@ -40,7 +41,6 @@ const YourVoyages = () => {
         headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
       });
       if (response.status === 200) {
-        console.log('declaration id', response.data.id);
         navigate(`${VOYAGE_GENERAL_DECLARATION_UPLOAD_URL}?report=${response.data.id}`);
       }
     } catch (err) {
@@ -227,27 +227,18 @@ const YourVoyages = () => {
                 </div>
               </div>
 
-              {/* TODO: See if there is a cleaner way to set these attributes for diffrerent statuses */}
               {voyageData?.map((voyage) => {
-                let statusTagClass;
                 let statusLinkText;
-                let statusType;
                 if (voyage.status === 'Submitted' || voyage.status === 'PreSubmitted') {
-                  statusTagClass = 'govuk-tag govuk-tag--green';
                   statusLinkText = 'Review or cancel';
-                  statusType = 'submitted';
                 } else if (voyage.status === 'Draft') {
-                  statusTagClass = 'govuk-tag govuk-tag--grey';
                   statusLinkText = 'Continue';
-                  statusType = 'draft';
                 } else if (voyage.status === 'Cancelled' || voyage.status === 'PreCancelled') {
-                  statusTagClass = 'govuk-tag govuk-tag--orange';
                   statusLinkText = 'Review';
-                  statusType = 'cancelled';
-                } else {
-                  statusTagClass = 'govuk-tag govuk-tag--red';
+                } else if (voyage.status === 'Failed') {
                   statusLinkText = 'Review and re-submit';
-                  statusType = 'failed';
+                } else {
+                  statusLinkText = 'Review and re-submit';
                 }
                 return (
                   <div key={voyage.id} className="govuk-!-margin-top-5 light-grey__border">
@@ -275,7 +266,7 @@ const YourVoyages = () => {
 
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">
                         <span className="govuk-body-s">Status</span> <br />
-                        <strong className={statusTagClass}>{statusType}</strong>
+                        <StatusTag status={voyage.status} />
                       </div>
 
                       <div className="govuk-grid-column-one-quarter reported-voyages__columns reported-voyages__text">

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -89,7 +89,7 @@ describe('Your voyages page tests', () => {
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     expect(await screen.findByText('All report types')).toBeInTheDocument();
     expect(await screen.findByText('Ship 1')).toBeInTheDocument();
-    expect(await screen.findByText('draft')).toBeInTheDocument();
+    expect(await screen.findByText('Draft')).toBeInTheDocument();
     expect(await screen.findByText('Continue')).toBeInTheDocument();
   });
 
@@ -143,7 +143,7 @@ describe('Your voyages page tests', () => {
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     expect(await screen.findByText('Ship 2')).toBeInTheDocument();
     expect(await screen.findByText('Ship 3')).toBeInTheDocument();
-    expect(await screen.findAllByText('submitted')).toHaveLength(2);
+    expect(await screen.findAllByText('Submitted')).toHaveLength(2);
     expect(await screen.findAllByText('Review or cancel')).toHaveLength(2);
   });
 
@@ -197,7 +197,7 @@ describe('Your voyages page tests', () => {
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     expect(await screen.findByText('Ship 5')).toBeInTheDocument();
     expect(await screen.findByText('Ship 5')).toBeInTheDocument();
-    expect(await screen.findAllByText('cancelled')).toHaveLength(2);
+    expect(await screen.findAllByText('Cancelled')).toHaveLength(2);
     expect(await screen.findAllByText('Review')).toHaveLength(2);
   });
 
@@ -230,7 +230,7 @@ describe('Your voyages page tests', () => {
       });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     expect(await screen.findByText('Ship 6')).toBeInTheDocument();
-    expect(await screen.findByText('failed')).toBeInTheDocument();
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
     expect(await screen.findByText('Review and re-submit')).toBeInTheDocument();
   });
 

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -234,6 +234,38 @@ describe('Your voyages page tests', () => {
     expect(await screen.findByText('Review and re-submit')).toBeInTheDocument();
   });
 
+  it('should default to a review status if no status/unknown is received (should not happen but it is our catchall incase of changes)', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(200, {
+        results: [
+          {
+            id: '6',
+            status: '',
+            submissionDate: '2023-02-11',
+            nameOfShip: 'Ship 6',
+            imoNumber: '123',
+            callSign: 'NA',
+            signatory: 'John Doe',
+            flagState: 'GBR',
+            departureFromUk: true,
+            departurePortUnlocode: 'AU XXX',
+            departureDate: '2023-02-12',
+            departureTime: '14:00:00',
+            arrivalPortUnlocode: 'GB POR',
+            arrivalDate: '2023-02-19',
+            arrivalTime: '14:00:00',
+            previousPortUnlocode: 'AU XXX',
+            nextPortUnlocode: 'NL RTM',
+            cargo: 'No cargo',
+          },
+        ],
+      });
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText('Ship 6')).toBeInTheDocument();
+    expect(await screen.findByText('Review and re-submit')).toBeInTheDocument();
+  });
+
   it('should redirect to sign in if getting the declarations returns a 422', async () => {
     mockAxios
       .onGet(CREATE_VOYAGE_ENDPOINT)

--- a/src/pages/Voyage/VoyageTaskList.jsx
+++ b/src/pages/Voyage/VoyageTaskList.jsx
@@ -22,24 +22,9 @@ import {
 } from '../../constants/AppUrlConstants';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import Message from '../../components/Message';
+import StatusTag from '../../components/StatusTag';
 import Auth from '../../utils/Auth';
 import GetDeclaration from '../../utils/GetDeclaration';
-
-const CLASSES_FOR_STATUS = {
-  completed: 'govuk-tag app-task-list__tag',
-  required: 'govuk-tag govuk-tag--pink app-task-list__tag',
-  optional: 'govuk-tag govuk-tag--blue app-task-list__tag',
-  notStarted: 'govuk-tag govuk-tag--grey app-task-list__tag',
-  cannotStartYet: 'govuk-tag govuk-tag--grey app-task-list__tag',
-};
-
-const LABELS_FOR_STATUS = {
-  completed: 'Completed',
-  required: 'Required',
-  optional: 'Optional',
-  notStarted: 'Not started',
-  cannotStartYet: 'Cannot start yet',
-};
 
 const VoyageTaskList = () => {
   const navigate = useNavigate();
@@ -170,7 +155,7 @@ const VoyageTaskList = () => {
                     <li key={item.label} className="app-task-list__item">
                       <Link className="govuk-link" to={item.link}>
                         <span>{item.label}</span>
-                        <strong className={CLASSES_FOR_STATUS[item.status]}>{LABELS_FOR_STATUS[item.status]}</strong>
+                        <StatusTag status={item.status} />
                       </Link>
                     </li>
                   ))
@@ -185,14 +170,14 @@ const VoyageTaskList = () => {
                     && (
                       <div data-testid="checkYourAnswers">
                         <span>Check answers and submit</span>
-                        <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
+                        <StatusTag status={checkYourAnswersStep.status} />
                       </div>
                     )}
                   {checkYourAnswersStep.status !== 'cannotStartYet'
                     && (
                       <Link className="govuk-link" to={checkYourAnswersStep.link}>
                         <span>Check answers and submit</span>
-                        <strong className={CLASSES_FOR_STATUS[checkYourAnswersStep.status]}>{LABELS_FOR_STATUS[checkYourAnswersStep.status]}</strong>
+                        <StatusTag status={checkYourAnswersStep.status} />
                       </Link>
                     )}
                 </li>


### PR DESCRIPTION
# Ticket



----

## AC

We're using status tags across a few files now so add a status tag component and refactor existing places to use it

----

## To test

- view Your voyages
- > draft tags should appear as before
- create a declaration
- add a FAL1
- > task details page should show the completed, required, optional, and cannot start tags as before
- add a FAL5 and select no for passengers
- > CYA should now show a not started tag as before

----

## Notes
Not all statuses are used on a page yet so some are currently untestable in the UI but I've added them here in preparation for future PRs