### PR TITLE
Test NMSW-557 Show uploaded supporting documents on CYA page (with ab…

### DIFF
--- a/cypress/e2e/features/check-your-answers-page.feature
+++ b/cypress/e2e/features/check-your-answers-page.feature
@@ -44,8 +44,16 @@ Feature: Check your answer page
     Then I am taken to task details page
     And I can see Check answers and submit enabled
     When I click Check answers and submit
-    Then I can view Check Your Answers page
-    Then I can verify the Check Your Answers page
+    When there is no supporting documents attached, I can see-no supporting documents message
+    When I click change next to supporting documents
+    Then I am taken to upload supporting documents page
+    Then I am able to choose valid number of documents and upload in Files added section
+      | fileName                       |
+      | ValidMELLINA CREW EFFECTS.xlsx |
+    When I click save and continue
+    Then I am taken to task details page
+    When I click Check answers and submit
+    Then I can verify Check Your Answers page
 
   @regression
   Scenario Outline: User can Verify the details upload and change the details
@@ -54,6 +62,8 @@ Feature: Check your answer page
     When I click on the file name for 'Fal5-Files', it is downloaded
     Then I can see a link to an uploaded passenger file 'Fal6-Files''Passenger details FAL 6-PositiveData.xlsx'
     When I click on the file name for 'Fal6-Files', it is downloaded
+    Then I can see a link to an uploaded supporting document files 'Supporting-Documents''ValidMELLINA CREW EFFECTS.xlsx'
+    When I click on the file name for 'Supporting-Documents', it is downloaded
     When I click change the voyage details link
     Then I am taken to upload-general-declaration page
     When I have uploaded 'Fal1-Files''General declaration FAL 1 - goodData.xlsx'

--- a/cypress/e2e/pages/cya.page.js
+++ b/cypress/e2e/pages/cya.page.js
@@ -50,25 +50,31 @@ class CyaPage {
       case 'Fal6-Files':
         cy.get(':nth-child(2) > .govuk-summary-list__value > .govuk-link').should('include', fileName);
         break;
+      case 'Supporting-Docs':
+        cy.get('#supportingDocuments').parent.find('govuk-summary-list__value').should('include', fileName);
+        break;
     }
   }
 
   clickFalUploadedFile(folderName) {
     switch (folderName) {
       case 'Fal5-Files':
-        cy.get(':nth-child(1) > .govuk-summary-list__value > .govuk-link').invoke('attr','href').then((href) => {
-          cy.log(href);
-          cy.downloadFile(href,'downloads','fal5.xlsx');
+        cy.get(':nth-child(1) > .govuk-summary-list__value > .govuk-link').invoke('attr', 'href').then((href) => {
+          cy.downloadFile(href, 'downloads', 'fal5.xlsx');
         })
         break;
       case 'Fal6-Files':
-        cy.get(':nth-child(2) > .govuk-summary-list__value > .govuk-link').invoke('attr','href').then((href) => {
-          cy.downloadFile(href,'downloads','fal6.xlsx');
+        cy.get(':nth-child(2) > .govuk-summary-list__value > .govuk-link').invoke('attr', 'href').then((href) => {
+          cy.downloadFile(href, 'downloads', 'fal6.xlsx');
+        })
+        break;
+      case 'supportingDocs':
+        cy.get('#supportingDocuments').parent().find('a').invoke('attr', 'href').then((href) => {
+          cy.downloadFile(href, 'downloads', 'supportingDocs.xlsx');
         })
         break;
     }
   }
-
 }
 
 export default new CyaPage();

--- a/cypress/support/step_definitions/check-your-answers-page.steps.js
+++ b/cypress/support/step_definitions/check-your-answers-page.steps.js
@@ -8,7 +8,7 @@ When('I click Check answers and submit', () => {
   cyaPage.clickCheckAnswersAndSubmit();
 });
 
-When('I can verify the Check Your Answers page', () => {
+Then('I can verify Check Your Answers page', () => {
   cyaPage.verifyCYAPage();
   cyaPage.verifySaveAndSubmitButton();
   cyaPage.verifyH2Headings();
@@ -74,6 +74,10 @@ Then('I can see a link to an uploaded passenger file {string}{string}', (folderN
   CyaPage.verifyFileUploaded(fileName);
 });
 
+Then('I can see a link to an uploaded supporting document files {string}{string}', (folderName, fileName) => {
+  CyaPage.verifyFileUploaded(fileName);
+});
+
 Then('passenger section state No passenger details provided', () => {
   cy.get('#passengerDetails').next().contains('No passenger details provided');
   cy.get('#supportingDocuments').next().contains('No supporting documents provided');
@@ -81,6 +85,10 @@ Then('passenger section state No passenger details provided', () => {
 
 When('I click on change next to Passenger details', () => {
 cy.get('#passengerDetails').parent().find('a').contains('Change').click();
+});
+
+When('I click change next to supporting documents', () => {
+  cy.get('#supportingDocuments').parent().find('a').contains('Change').click();
 });
 
 When('I navigate back to check your answers page', () => {
@@ -91,4 +99,8 @@ When('I navigate back to check your answers page', () => {
 
 When('I click Save and Submit', () => {
   cyaPage.clickSaveAndSubmitButton();
+});
+
+When('there is no supporting documents attached, I can see-no supporting documents message', () => {
+  cy.get('#supportingDocuments').parent().find('span').contains('No supporting documents provided');
 });


### PR DESCRIPTION

Test covered for NMSW-557
Show uploaded supporting documents on CYA page with the ability to download
----

## To test
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
Select check-your-answers-page.feature
