### PR TITLE
NMSW-546 Delete a draft report

### DIFF
--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -25,14 +25,14 @@ import Auth from '../../utils/Auth';
 
 const YourVoyages = () => {
   dayjs.extend(customParseFormat);
-  // const { state } = useLocation();
+  const { state } = useLocation();
   const navigate = useNavigate();
+  const [notification, setNotification] = useState({});
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [voyageData, setVoyageData] = useState();
 
   document.title = SERVICE_NAME;
-  // console.log('confbanner', state?.confirmationBanner);
 
   const handleClick = async () => {
     setIsLoading(true);
@@ -90,7 +90,16 @@ const YourVoyages = () => {
   useEffect(() => {
     setIsLoading(true);
     getDeclarationData();
-  }, []);
+
+    if (state?.confirmationBanner?.message) {
+      setNotification({
+        show: true,
+        message: state?.confirmationBanner?.message,
+      });
+      // eslint-disable-next-line no-restricted-globals
+      navigate(location.pathname, { replace: true });
+    }
+  }, [state]);
 
   if (isError) {
     return (
@@ -104,6 +113,25 @@ const YourVoyages = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
+          {notification.show && (
+            <div
+              className="govuk-notification-banner govuk-notification-banner--success"
+              role="alert"
+              aria-labelledby="govuk-notification-banner-title"
+              data-module="govuk-notification-banner"
+            >
+              <div className="govuk-notification-banner__header">
+                <h2 className="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                  Success
+                </h2>
+              </div>
+              <div className="govuk-notification-banner__content">
+                <h3 className="govuk-notification-banner__heading">
+                  {notification.message}
+                </h3>
+              </div>
+            </div>
+          )}
           <h1 className="govuk-heading-xl govuk-!-margin-bottom-4">Your voyages</h1>
           {voyageData?.length === 0 && (
             <div className="govuk-inset-text">

--- a/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageDeleteDraftCheck.test.jsx
@@ -1,13 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import {
   URL_DECLARATIONID_IDENTIFIER,
   YOUR_VOYAGES_URL,
   VOYAGE_TASK_LIST_URL,
   VOYAGE_DELETE_DRAFT_CHECK_URL,
+  SIGN_IN_URL,
+  MESSAGE_URL,
 } from '../../../constants/AppUrlConstants';
 import VoyageDeleteDraftCheck from '../VoyageDeleteDraftCheck';
+import { API_URL, ENDPOINT_DECLARATION_PATH } from '../../../constants/AppAPIConstants';
 
 let mockUseLocationState = { state: {} };
 const mockedUseNavigate = jest.fn();
@@ -27,7 +32,9 @@ const renderPage = () => {
 };
 
 describe('Voyage delete draft check are you sure page', () => {
+  const mockAxios = new MockAdapter(axios);
   beforeEach(() => {
+    mockAxios.reset();
     window.sessionStorage.clear();
     mockUseLocationState.state = {};
   });
@@ -53,16 +60,6 @@ describe('Voyage delete draft check are you sure page', () => {
     expect(screen.getByRole('link', { name: 'Click here to continue' }).outerHTML).toEqual(`<a class="govuk-link" href="${YOUR_VOYAGES_URL}">Click here to continue</a>`);
   });
 
-  it('should go to the your voyages details page, with details for confirmation banner, if user selects YES', async () => {
-    mockUseLocationState = { state: { shipName: 'My ship name' } };
-    const user = userEvent.setup();
-    renderPage();
-    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
-    await user.click(screen.getByRole('radio', { name: 'Yes' }));
-    await user.click(screen.getByRole('button', { name: 'Confirm' }));
-    expect(mockedUseNavigate).toHaveBeenCalledWith(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: 'Report for My ship name deleted.' } } });
-  });
-
   it('should go to the task details page if user selects NO', async () => {
     mockUseLocationState = { state: { shipName: 'My ship name' } };
     const user = userEvent.setup();
@@ -71,5 +68,77 @@ describe('Voyage delete draft check are you sure page', () => {
     await user.click(screen.getByRole('radio', { name: 'No' }));
     await user.click(screen.getByRole('button', { name: 'Confirm' }));
     expect(mockedUseNavigate).toHaveBeenCalledWith(`${VOYAGE_TASK_LIST_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`);
+  });
+
+  it('should go to the your voyages details page, with details for confirmation banner, if user selects YES & DELETE success', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    mockAxios
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(204);
+
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: 'Report for My ship name deleted.' } } });
+  });
+
+  it('should redirect to sign in if user selects YES but token invalid/expired (401)', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    mockAxios
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(401);
+
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: `${VOYAGE_TASK_LIST_URL}?report=123` } });
+  });
+
+  it('should redirect to sign in if user selects YES but token invalid/expired (422)', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    mockAxios
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(422);
+
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: `${VOYAGE_TASK_LIST_URL}?report=123` } });
+  });
+
+  it('should redirect to message page on any other error', async () => {
+    mockUseLocationState = { state: { shipName: 'My ship name' } };
+    const user = userEvent.setup();
+    mockAxios
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(500);
+
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: undefined, redirectURL: `${VOYAGE_TASK_LIST_URL}?report=123` } });
   });
 });


### PR DESCRIPTION
# Ticket



----

## AC

GIVEN a declaration is a draft (has not yet been submitted)
WHEN the user deletes the declaration
THEN it no longer appears in the voyage list

----

## To test

- load your voyages page
- > there should be no notification banner
- go to a report
- click delete
- click yes
- click submit [note not actually deleting at the moment]
- > you should be returned to your voyages page
- > you should see a notification banner confirming you deleted that ships draft
- refresh the page
- > there should be no notification banner


----

## Notes
Endpoint not yet available so this will fail in the browser