### PR TITLE
NMSW-514 Delete supporting docs pt 2

### DIFF
--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -83,10 +83,23 @@ const MultiFileUploadForm = ({
   const [maxFilesError, setMaxFilesError] = useState();
   const [supportingDocumentsList, setSupportingDocumentsList] = useState([]);
 
+  const getPendingFiles = () => {
+    const pendingFiles = filesAddedForUpload.reduce((results, fileToCheck) => {
+      if (fileToCheck.status === FILE_STATUS_PENDING) {
+        results.push(fileToCheck);
+      }
+      return results;
+    }, []);
+    setFilesAddedForUpload(pendingFiles);
+  };
+
   const getDeclarationData = async () => {
     const response = await GetDeclaration({ declarationId });
     if (response.data) {
       setSupportingDocumentsList(response?.data?.supporting);
+      if (filesAddedForUpload.length > 0) {
+        getPendingFiles();
+      }
     } else {
       switch (response?.status) {
         case 401:

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -335,34 +335,70 @@ describe('Multi file upload tests', () => {
     expect(mockAxios.history.delete.length).toBe(1);
   });
 
-  // This currently will fail because the file gets deleted from the S3 but not the database so the file is still present in the list and will be displayed
-  // it('should remove an already uploaded file from the list if its delete button is clicked', async () => {
-  //   const user = userEvent.setup();
-  //   mockAxios
-  //     .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
-  //       headers: {
-  //         Authorization: 'Bearer 123',
-  //       },
-  //     })
-  //     .reply(200, mockedFAL1AndSupportingResponse)
-  //     .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, { id: 'supporting1' }, {
-  //       headers: {
-  //         Authorization: 'Bearer 123',
-  //       }
-  //     })
-  //     .reply(200, {
-  //       message: 'File successfully deleted'
-  //     })
-  //   renderPage();
-  //   await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+  it('should remove an already uploaded file from the list if its delete button is clicked', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, mockedFAL1AndSupportingResponse)
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, { id: 'supporting1' }, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        message: 'File successfully deleted',
+      })
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-11',
+        },
+        FAL5: [],
+        FAL6: [],
+        supporting: [
+          {
+            id: 'supporting2',
+            filename: 'supportingFile2',
+            size: '118687',
+            url: 'https://supporting2-link.com',
+          },
+        ],
+      });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
-  //   // user clicks delete on one
-  //   await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    // user clicks delete on one
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
 
-  //   expect(screen.queryByText('supportingFile1')).not.toBeInTheDocument();
-  //   expect(screen.getByText('supportingFile2')).toBeInTheDocument();
-  //   expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(1);
-  // });
+    expect(screen.queryByText('supportingFile1')).not.toBeInTheDocument();
+    expect(screen.getByText('supportingFile2')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(1);
+  });
 
   it('should load the next page on submit button click', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
# Ticket

NMSW-514 (pt 2 now that BE is working)

----

## AC

A bug was found where if you upload a file, then delete that file, you see two instances of that file. This was because the files in 'limbo' state (uploaded but were not retrieved from the initial GET call) are still a part of the filesAddedForUpload array but on calling the getDeclarationData again, they also become a part of the supportingDocumentsList so they appear twice. This code does this by filtering files with a pending tag so that these do not disappear is you delete an uploaded file in it's 'limbo' state

----

## To test

Scenario 1: Deleting previously uploaded file 
- Run app
- Sign in
- Create a voyage declaration
- Get to supporting docs section
- Upload a couple of files
- Refresh the page
- Delete one of the files
- > It should be removed from the list and you should only see one file

Scenario 2: Deleting an uploaded file in 'limbo' state
- Add a couple more files
- Upload them (should be in the 'limbo' state)
- Delete one
- > It should disappear from the list
- > There should not be a duplicate file

Scenario 3: Deleting an uploaded file in 'limbo' when there is a file in 'pending' state
- Add a another file
- Upload it
- Add another file (should be in 'pending' state)
- Delete the first file
- You should still have a file in 'pending'

----

## Notes
