### PR TITLE
NMSW-245 On GET drafts delete any without general declarations

### DIFF
--- a/src/pages/NavPages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages.jsx
@@ -4,7 +4,9 @@ import axios from 'axios';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { SERVICE_NAME } from '../../constants/AppConstants';
-import { API_URL, CREATE_VOYAGE_ENDPOINT, ENDPOINT_DECLARATION_PATH, TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
+import {
+  API_URL, CREATE_VOYAGE_ENDPOINT, ENDPOINT_DECLARATION_PATH, TOKEN_EXPIRED,
+} from '../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
   URL_DECLARATIONID_IDENTIFIER,
@@ -65,8 +67,8 @@ const YourVoyages = () => {
         headers: {
           Authorization: `Bearer ${Auth.retrieveToken()}`,
         },
-      })
-      return response.data
+      });
+      return response.data;
     } catch (err) {
       if (err?.response?.status === 422) {
         Auth.removeToken();
@@ -76,7 +78,8 @@ const YourVoyages = () => {
         navigate(SIGN_IN_URL, { state: { redirectURL: YOUR_VOYAGES_URL } });
       }
     }
-  }
+    return null;
+  };
 
   const getDeclarationData = async () => {
     try {
@@ -84,13 +87,14 @@ const YourVoyages = () => {
         headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
       });
       if (response.status === 200) {
-        const results = []
+        const results = [];
         response.data.results.map((declaration) => {
           if (declaration.departureFromUk !== null) {
             results.push(declaration);
           } else {
-            deleteInvalidDeclarations(declaration.id)
+            deleteInvalidDeclarations(declaration.id);
           }
+          return results;
         });
         setVoyageData(results);
       }

--- a/src/pages/NavPages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/__tests__/YourVoyages.test.jsx
@@ -1,9 +1,13 @@
-import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import {
+  render, screen, waitFor, waitForElementToBeRemoved,
+} from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { API_URL, CREATE_VOYAGE_ENDPOINT, ENDPOINT_DECLARATION_PATH, TOKEN_EXPIRED } from '../../../constants/AppAPIConstants';
+import {
+  API_URL, CREATE_VOYAGE_ENDPOINT, ENDPOINT_DECLARATION_PATH, TOKEN_EXPIRED,
+} from '../../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
   URL_DECLARATIONID_IDENTIFIER,
@@ -508,17 +512,17 @@ describe('Your voyages page tests', () => {
       .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/2`, {
         headers: {
           Authorization: 'Bearer 123',
-        }
+        },
       })
       .reply(200, {
-        msg: 'Draft successfully deleted'
-      })
+        msg: 'Draft successfully deleted',
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
-    expect(mockAxios.history.delete.length).toBe(1)
+    expect(mockAxios.history.delete.length).toBe(1);
     expect(screen.getByText('Ship 1')).toBeInTheDocument();
-    expect(screen.getByText('draft')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('Continue')).toBeInTheDocument();
   });
 
@@ -572,16 +576,16 @@ describe('Your voyages page tests', () => {
       .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/2`, {
         headers: {
           Authorization: 'Bearer 123',
-        }
+        },
       })
       .reply(400, {
-        msg: 'Error message'
-      })
+        msg: 'Error message',
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
     expect(screen.getByText('Ship 1')).toBeInTheDocument();
-    expect(screen.getByText('draft')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('Continue')).toBeInTheDocument();
   });
 
@@ -715,11 +719,11 @@ describe('Your voyages page tests', () => {
       .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/2`, {
         headers: {
           Authorization: 'Bearer 123',
-        }
+        },
       })
       .reply(422, {
-        msg: 'Not enough segments'
-      })
+        msg: 'Not enough segments',
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 
@@ -777,11 +781,11 @@ describe('Your voyages page tests', () => {
       .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/2`, {
         headers: {
           Authorization: 'Bearer 123',
-        }
+        },
       })
       .reply(401, {
-        msg: TOKEN_EXPIRED
-      })
+        msg: TOKEN_EXPIRED,
+      });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
 


### PR DESCRIPTION
# Ticket

NMSW-245

----

## AC

If a voyage is in draft status and does not have general declaration details then we send a delete request for it 

----

## To test

- Run app
- Sign in
- Go to Your voyages
- You should only see declarations with General declarations attached
- Open network tab
- Create a declaration (do not upload general declaration)
- Go back to your voyages
- You should see a successful delete request for the declaration you just created

----

## Notes

- I opened this as a draft because the delete request was running twice and one was failing as the declaration no longer existed - this has now been resolved by jennikate so I have also reviewed her changes