### PR TITLE
NMSW-584

### DIFF
--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -294,7 +294,7 @@ const MultiFileUploadForm = ({
           updateFileStatus({ file: fileName, status: FILE_STATUS_IN_PROGRESS });
         }
 
-        const response = await axios({
+        await axios({
           method: 'delete',
           url: endpoint,
           data: {
@@ -304,9 +304,7 @@ const MultiFileUploadForm = ({
             Authorization: `Bearer ${Auth.retrieveToken()}`,
           },
         });
-        if (response?.status === 200) {
-          getDeclarationData();
-        }
+        getDeclarationData();
       } catch (err) {
         switch (err?.response?.status) {
           case 401:

--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -297,11 +297,11 @@ const MultiFileUploadForm = ({
         await axios({
           method: 'delete',
           url: endpoint,
-          data: {
-            id,
-          },
           headers: {
             Authorization: `Bearer ${Auth.retrieveToken()}`,
+          },
+          data: {
+            id,
           },
         });
         getDeclarationData();

--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -291,7 +291,7 @@ const MultiFileUploadForm = ({
           newState[indexInSupportingDocumentsList].status = FILE_STATUS_IN_PROGRESS;
           setSupportingDocumentsList(newState);
         } else {
-          updateFileStatus({ file: fileName, status: FILE_STATUS_IN_PROGRESS });
+          updateFileStatus({ file: { file: { name: fileName } }, status: FILE_STATUS_IN_PROGRESS });
         }
 
         await axios({

--- a/src/components/MultiFileUploadForm.jsx
+++ b/src/components/MultiFileUploadForm.jsx
@@ -76,10 +76,12 @@ const MultiFileUploadForm = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const declarationId = searchParams.get(URL_DECLARATIONID_IDENTIFIER);
+  const [disableButtons, setDisableButtons] = useState(false);
   const [dragActive, setDragActive] = useState(false);
   const [errors, setErrors] = useState([]);
   const [filesAddedForUpload, setFilesAddedForUpload] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingFilelist, setIsLoadingFilelist] = useState(false);
   const [maxFilesError, setMaxFilesError] = useState();
   const [supportingDocumentsList, setSupportingDocumentsList] = useState([]);
 
@@ -94,9 +96,14 @@ const MultiFileUploadForm = ({
   };
 
   const getDeclarationData = async () => {
+    setIsLoadingFilelist(true);
     const response = await GetDeclaration({ declarationId });
     if (response.data) {
-      setSupportingDocumentsList(response?.data?.supporting);
+      const addedStatus = response.data.supporting.map((document) => ({
+        ...document,
+        status: FILE_STATUS_SUCCESS,
+      }));
+      setSupportingDocumentsList(addedStatus);
       if (filesAddedForUpload.length > 0) {
         getPendingFiles();
       }
@@ -117,6 +124,7 @@ const MultiFileUploadForm = ({
       }
     }
     setIsLoading(false);
+    setIsLoadingFilelist(false);
   };
 
   const handleDrag = (e) => {
@@ -214,6 +222,7 @@ const MultiFileUploadForm = ({
       const dataToSubmit = new FormData();
       dataToSubmit.append('file', selectedFile?.file, selectedFile?.file?.name);
       try {
+        setDisableButtons(true);
         const response = await axios.post(endpoint, dataToSubmit, {
           headers: {
             Authorization: `Bearer ${Auth.retrieveToken()}`,
@@ -246,6 +255,8 @@ const MultiFileUploadForm = ({
           });
         }
         return err;
+      } finally {
+        setDisableButtons(false);
       }
     };
 
@@ -266,6 +277,23 @@ const MultiFileUploadForm = ({
     e.preventDefault();
     if (id) {
       try {
+        setDisableButtons(true);
+
+        /* If user has just uploaded a file it doesn't exist in the supportingDocumentsList
+         * however if they uploaded it previously it does
+         * so on delete we have to check two places to change status to in progress
+         * which in turn shows the loading spinner
+         * TODO: refactor this to make it less repetative
+         */
+        const indexInSupportingDocumentsList = supportingDocumentsList.findIndex((existingFile) => existingFile.id === id);
+        if (indexInSupportingDocumentsList !== -1) {
+          const newState = [...supportingDocumentsList];
+          newState[indexInSupportingDocumentsList].status = FILE_STATUS_IN_PROGRESS;
+          setSupportingDocumentsList(newState);
+        } else {
+          updateFileStatus({ file: fileName, status: FILE_STATUS_IN_PROGRESS });
+        }
+
         const response = await axios({
           method: 'delete',
           url: endpoint,
@@ -308,6 +336,7 @@ const MultiFileUploadForm = ({
 
   useEffect(() => {
     setIsLoading(true);
+    setDisableButtons(true);
     getDeclarationData();
   }, []);
 
@@ -316,6 +345,12 @@ const MultiFileUploadForm = ({
       errorSummaryRef?.current?.focus();
     }
   }, [errors]);
+
+  useEffect(() => {
+    if (!isLoadingFilelist) {
+      setDisableButtons(false);
+    }
+  }, [isLoadingFilelist]);
 
   /*
    * when the drag goes over our button element in the dragarea,
@@ -382,6 +417,7 @@ const MultiFileUploadForm = ({
                       className="govuk-button--text"
                       type="button"
                       onClick={onChooseFilesButtonClick}
+                      disabled={disableButtons}
                     >
                       Choose files
                     </button>
@@ -403,6 +439,7 @@ const MultiFileUploadForm = ({
               className="govuk-button govuk-button--secondary"
               type="button"
               onClick={onUploadFiles}
+              disabled={disableButtons}
             >
               Upload files
             </button>
@@ -417,13 +454,15 @@ const MultiFileUploadForm = ({
               {supportingDocumentsList.map((file) => (
                 <div key={file.filename} className="govuk-grid-row  govuk-!-margin-bottom-5 multi-file-upload--filelist">
                   <div className="nmsw-grid-column-ten-twelfths">
-                    <FileStatusSuccess fileName={file.filename} />
+                    {file.status === FILE_STATUS_SUCCESS && <FileStatusSuccess fileName={file.filename} />}
+                    {file.status === FILE_STATUS_IN_PROGRESS && <FileStatusInProgress fileName={file.filename} />}
                   </div>
                   <div className="nmsw-grid-column-two-twelfths govuk-!-text-align-right">
                     <button
                       className="govuk-button govuk-button--warning govuk-!-margin-bottom-5"
                       type="button"
                       onClick={(e) => handleDelete({ e, fileName: file.filename, id: file.id })}
+                      disabled={disableButtons}
                     >
                       Delete
                     </button>
@@ -448,6 +487,7 @@ const MultiFileUploadForm = ({
                       className="govuk-button govuk-button--warning govuk-!-margin-bottom-5"
                       type="button"
                       onClick={(e) => handleDelete({ e, fileName: file.file.name, id: file.id })}
+                      disabled={disableButtons}
                     >
                       Delete
                     </button>
@@ -460,6 +500,7 @@ const MultiFileUploadForm = ({
             className="govuk-button govuk-button--primary"
             type="button"
             onClick={onContinue}
+            disabled={disableButtons}
           >
             {submitButtonLabel || 'Save and continue'}
           </button>

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -9,7 +9,13 @@ import {
   ENDPOINT_DECLARATION_PATH,
   ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH,
 } from '../../constants/AppAPIConstants';
-import { URL_DECLARATIONID_IDENTIFIER, VOYAGE_SUPPORTING_DOCS_UPLOAD_URL } from '../../constants/AppUrlConstants';
+import {
+  MESSAGE_URL,
+  SIGN_IN_URL,
+  URL_DECLARATIONID_IDENTIFIER,
+  VOYAGE_SUPPORTING_DOCS_UPLOAD_URL,
+  YOUR_VOYAGES_URL,
+} from '../../constants/AppUrlConstants';
 import MultiFileUploadForm from '../MultiFileUploadForm';
 
 const mockedUseNavigate = jest.fn();
@@ -147,6 +153,45 @@ describe('Multi file upload tests', () => {
     expect(screen.getByText('supportingFile1')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
     expect(screen.getAllByText('has been uploaded')).toHaveLength(2);
+  });
+
+  it('should redirect user to sign in if 422 response received on GET call', async () => {
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(422);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: '/this-page/123' } });
+  });
+
+  it('should redirect user to sign in if 401 response received on GET call', async () => {
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(401);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: '/this-page/123' } });
+  });
+
+  it('should redirect user to sign in if other error response received on GET call', async () => {
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(500);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: undefined, redirectURL: YOUR_VOYAGES_URL } });
   });
 
   it('should accept one file added and display it in the file list', async () => {

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -415,4 +415,38 @@ describe('Multi file upload tests', () => {
     await user.click(screen.getByRole('button', { name: 'Submit button label from props' }));
     expect(mockedUseNavigate).toHaveBeenCalledWith('/next-page/123');
   });
+
+  it('should not leave buttons in a disabled state when actions are complete', async () => {
+    const user = userEvent.setup();
+    const files = [
+      new File(['template1'], 'template1.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+    ];
+
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, mockedFAL1Response);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+
+    const input = screen.getByTestId('multiFileUploadInput');
+    await user.upload(input, files);
+
+    await user.click(screen.getByRole('button', { name: 'Upload files' }));
+    expect(screen.getByRole('button', { name: 'Upload files' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit button label from props' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Submit button label from props' }));
+    expect(screen.getByRole('button', { name: 'Upload files' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit button label from props' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('button', { name: 'Upload files' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit button label from props' })).not.toBeDisabled();
+  });
 });

--- a/src/components/__tests__/MultiFileUploadForm.test.jsx
+++ b/src/components/__tests__/MultiFileUploadForm.test.jsx
@@ -318,20 +318,19 @@ describe('Multi file upload tests', () => {
         },
       })
       .reply(200, mockedFAL1AndSupportingResponse)
-      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, { id: 'supporting1' }, {
-        headers: {
-          Authorization: 'Bearer 123',
-        },
-      })
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(200, {
         message: 'File successfully deleted',
       });
+
     renderPage();
+
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('supportingFile1')).toBeInTheDocument();
+    expect(screen.getByText('supportingFile2')).toBeInTheDocument();
 
     // user clicks delete on one
     await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
-
     expect(mockAxios.history.delete.length).toBe(1);
   });
 

--- a/src/components/__tests__/MultiFileUploadStatus.test.jsx
+++ b/src/components/__tests__/MultiFileUploadStatus.test.jsx
@@ -9,6 +9,7 @@ import {
   API_URL,
   ENDPOINT_DECLARATION_ATTACHMENTS_PATH,
   ENDPOINT_DECLARATION_PATH,
+  ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH,
 } from '../../constants/AppAPIConstants';
 import {
   SIGN_IN_URL,
@@ -28,7 +29,7 @@ const renderPage = () => {
   render(
     <MemoryRouter initialEntries={[`${VOYAGE_SUPPORTING_DOCS_UPLOAD_URL}?${URL_DECLARATIONID_IDENTIFIER}=123`]}>
       <MultiFileUploadForm
-        endpoint="/upload-file-endpoint"
+        endpoint={`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`}
         pageHeading="Title from props"
         submitButtonLabel="Submit button label from props"
         urlNextPage="/next-page/123"
@@ -128,7 +129,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(() => new Promise((resolve) => {
         setTimeout(() => {
           resolve([201, null]);
@@ -161,7 +162,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(() => new Promise((resolve) => {
         setTimeout(() => {
           resolve([201, null]);
@@ -195,7 +196,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(200, {
         message: 'success response',
       });
@@ -227,7 +228,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(400, {
         message: 'Invalid file type',
       });
@@ -258,7 +259,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(400, {
         message: MAX_SUPPORTING_FILE_SIZE,
       });
@@ -290,7 +291,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(400, {
         message: 'error response',
       });
@@ -322,7 +323,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(500);
 
     renderPage();
@@ -349,7 +350,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(422);
 
     renderPage();
@@ -375,7 +376,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1Response)
-      .onPost('/upload-file-endpoint')
+      .onPost(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
       .reply(401);
 
     renderPage();
@@ -401,11 +402,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1AndSupportingResponse)
-      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, { id: 'supporting1' }, {
-        headers: {
-          Authorization: 'Bearer 123',
-        },
-      })
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`)
       .reply(() => new Promise((resolve) => {
         setTimeout(() => {
           resolve([200, null]);
@@ -433,11 +430,7 @@ describe('Multi file upload status tests', () => {
         },
       })
       .reply(200, mockedFAL1AndSupportingResponse)
-      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, { id: 'supporting1' }, {
-        headers: {
-          Authorization: 'Bearer 123',
-        },
-      })
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`)
       .reply(() => new Promise((resolve) => {
         setTimeout(() => {
           resolve([200, null]);
@@ -453,5 +446,47 @@ describe('Multi file upload status tests', () => {
     expect(screen.getByRole('button', { name: 'Submit button label from props' })).toBeDisabled();
     expect(screen.getAllByRole('button', { name: 'Delete' })[0]).toBeDisabled();
     expect(screen.getAllByRole('button', { name: 'Delete' })[1]).toBeDisabled();
+  });
+
+  it('should redirect user to sign in if auth token missing on DELETE', async () => {
+    const user = userEvent.setup();
+    // Force a delay so we can test the file goes to an inprogress state
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, mockedFAL1AndSupportingResponse)
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
+      .reply(422);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getAllByText('has been uploaded')).toHaveLength(2);
+
+    // user clicks delete on one
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: '/this-page/123' } });
+  });
+
+  it('should redirect user to sign in if auth token invalid/expired on DELETE', async () => {
+    const user = userEvent.setup();
+    // Force a delay so we can test the file goes to an inprogress state
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, mockedFAL1AndSupportingResponse)
+      .onDelete(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH}`)
+      .reply(401);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getAllByText('has been uploaded')).toHaveLength(2);
+
+    // user clicks delete on one
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: '/this-page/123' } });
   });
 });


### PR DESCRIPTION
# Ticket



----

## AC

Given I have uploaded files previously
When I click delete next to one
The button should be disabled so I cannot accidentally click it again

----

## To test

- create a declaration
- go to supporting docs
- add some files
- upload those files
- make sure you're on slow 3G
- click delete next to one file
- > the button should be disabled while the delete processes


----

## Notes
