### PR TITLE
NMSW-552 Remap errors as wording has changed from API

### DIFF
--- a/src/components/FileUploadForm.jsx
+++ b/src/components/FileUploadForm.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../constants/AppConstants';
 import {
   DUPLICATE_RECORDS,
-  DUPLICATE_RECORDS_FAL5,
   FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
   FILE_MISSING,
@@ -50,9 +49,6 @@ const FileUploadForm = ({
   const handleErrors = ({ errorData }) => {
     switch (errorData.message) {
       case DUPLICATE_RECORDS:
-        setError({ id: FILE_UPLOAD_ID, message: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." });
-        break;
-      case DUPLICATE_RECORDS_FAL5:
         setError({ id: FILE_UPLOAD_ID, message: "Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again." });
         break;
       case FILE_MISSING:

--- a/src/components/__tests__/FileUploadForm.test.jsx
+++ b/src/components/__tests__/FileUploadForm.test.jsx
@@ -6,7 +6,6 @@ import MockAdapter from 'axios-mock-adapter';
 import { GENERAL_DECLARATION_TEMPLATE_NAME, MAX_FILE_SIZE, MAX_FILE_SIZE_DISPLAY } from '../../constants/AppConstants';
 import {
   DUPLICATE_RECORDS,
-  DUPLICATE_RECORDS_FAL5,
   FAL5_IS_EMPTY,
   FAL6_IS_EMPTY,
   FILE_MISSING,
@@ -193,7 +192,7 @@ describe('File upload tests', () => {
     mockAxios
       .onPost('/specific-endpoint-path-for-filetype')
       .reply(400, {
-        message: DUPLICATE_RECORDS_FAL5,
+        message: DUPLICATE_RECORDS,
       });
     renderPage();
     // make sure file is recognised so the FE no the FE file error isn't triggered

--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -23,8 +23,7 @@ export const ENDPOINT_FILE_UPLOAD_SUPPORTING_DOCUMENTS_PATH = '/supporting';
 export const ENDPOINT_DECLARATION_ATTACHMENTS_PATH = '/attachments';
 
 // Responses
-export const DUPLICATE_RECORDS = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL5).';
-export const DUPLICATE_RECORDS_FAL5 = 'Duplicate person records found. Please check the upload (note that duplication could be in FAL6).';
+export const DUPLICATE_RECORDS = 'Duplicate person records found. Please check the upload (note that duplication could be across FAL5 and 6).';
 export const FILE_MISSING = 'No file provided';
 export const FILE_TOO_LARGE = 'Large file';
 export const FILE_TYPE_INVALID_PREFIX = 'Invalid file type';


### PR DESCRIPTION
# Ticket



----

## AC

Error wording was updated in API as part of the overhaul of error messaging
We still need to catch this particular error in front end as we display it as a form error, not the error list page error

----

## To test

You will need
- a FAL 5 where two or more rows have the same document number and country
- a FAL 6 where two or more rows have the same document number and country
- a FAL 5 which has all unique rows
- a FAL 6 which has all unique rows within the file, however at least one of the rows should have the same document number and country as a row on the unique FAL 5 document

- create a declaration
- upload a FAL 5 where two or more rows have the same document number and country
- > you should see the error `Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again.` above the form

- upload the FAL 5 that has unique rows
- go to passenger and select yes
- upload the FAL 6 that has unique rows other than one that is the same as FAL 5
- > you should see the error `Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again.` above the form

- upload the FAL 6 where two or more rows have the same document number and country
- > you should see the error `Details listed on this file are not allowed, because they're the same as details you've already uploaded. Check the details in your file and try uploading again.` above the form

----

## Notes
