### PR TITLE
Test NMSW-162 help page feature and footer links

### DIFF
--- a/cypress/e2e/features/landing-page.feature
+++ b/cypress/e2e/features/landing-page.feature
@@ -22,4 +22,24 @@ Feature: Landing page with link to Fal templates
     Then I am taken to your-voyages page
     When I click your details tab
     Then I am taken to your details page
+    When I click help tab
+    Then I am taken to help and support page
+    When I click File templates, I can able to download to use
+    When I click footer Contact us Link
+    Then I am taken to contact us page
+    When I click help section in contact us page
+    Then I am taken to help and support page with help menu highlighted
     And I can able to sign-out
+    Then I am taken to the sign-in page
+    When I click submit required forms using email
+    Then I am taken to help and support page
+    When I click footer Contact us Link
+    Then I am taken to contact us page
+    When I click help section in contact us page
+    Then I am taken to help and support page
+    When I click footer Accessibility link
+    Then I am taken to accessibility page
+    When I click footer Cookies link
+    Then I am taken to cookie page
+    When I click Privacy link
+    Then I am taken to Privacy notice page

--- a/cypress/support/step_definitions/landing-page.steps.js
+++ b/cypress/support/step_definitions/landing-page.steps.js
@@ -1,6 +1,7 @@
 import {When, Then} from '@badeball/cypress-cucumber-preprocessor';
 import LandingPage from "../../e2e/pages/landing.page";
 import YourDetailsInfoPage from "../../e2e/pages/your-details-info.page";
+import BasePage from "../../e2e/pages/base.page";
 
 When('I click start now', () => {
   LandingPage.clickStartNow();
@@ -25,8 +26,16 @@ When('I click your details tab', () => {
   cy.get('[data-testid="listitem-YourDetails"] > .govuk-header__link').click();
 });
 
+When('I click help tab', () => {
+  cy.get('[data-testid="listitem-Help"] > .govuk-header__link').click();
+});
+
 Then('I am taken to your details page', () => {
   YourDetailsInfoPage.checkHeading();
+});
+
+Then('I am taken to help and support page', () => {
+  BasePage.checkH1('Help and support for the National Maritime Single Window');
 });
 
 When('I click GOV UK logo', () => {
@@ -45,4 +54,49 @@ Then('I can click short survey link for feedback', () => {
   cy.get('.feedback-banner-text--container').contains('We welcome your feedback');
   cy.get('[data-testid="feedbackText"] > .govuk-link').invoke('removeAttr', 'target').click();
   cy.visitUrl('/');
+});
+
+When('I click submit required forms using email', () => {
+  cy.contains('submit the required forms using email').click();
+});
+
+When('I click footer Contact us Link', () => {
+  cy.get('li:nth-of-type(4) > .govuk-footer__link').should('have.text', 'Contact us').click();
+});
+
+Then('I am taken to contact us page', () => {
+  BasePage.checkH1('Contact us');
+});
+
+When('I click footer Accessibility link', () => {
+  cy.get('li:nth-of-type(3) > .govuk-footer__link').should('have.text', 'Accessibility').click();
+});
+
+When('I click footer Cookies link', () => {
+  cy.get('li:nth-of-type(2) > .govuk-footer__link').should('have.text', 'Cookies').click();
+});
+
+Then('I am taken to cookie page', () => {
+  BasePage.checkH1('Cookies');
+});
+
+Then('I am taken to accessibility page', () => {
+  BasePage.checkH1('Accessibility statement for National Maritime Single Window');
+});
+
+When('I click Privacy link', () => {
+  cy.get('li:nth-of-type(1) > .govuk-footer__link').should('have.text', 'Privacy').click();
+});
+
+Then('I am taken to Privacy notice page', () => {
+  BasePage.checkH1('Privacy notice for National Maritime Single Window');
+});
+
+When('I click help section in contact us page', () => {
+  cy.get('.govuk-body > .govuk-link').should('have.text', 'help section').click();
+});
+
+Then('I am taken to help and support page with help menu highlighted', () => {
+  BasePage.checkH1('Help and support for the National Maritime Single Window');
+  cy.get('li.govuk-header__navigation-item.govuk-header__navigation-item--active').should('have.text', 'Help');
 });


### PR DESCRIPTION
Test added for [NMSW-162] help page
Test added to verify footer links
## To test
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
Select landing-page.feature