### PR TITLE
NMSW-551 Add group details to your details page

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -11,6 +11,7 @@ export const SIGN_IN_ENDPOINT = `${apiUrl}/sign-in`;
 export const SIGN_OUT_ENDPOINT = `${apiUrl}/sign-out`;
 
 // Manager user
+export const GROUP_ENDPOINT = `${apiUrl}/group`;
 export const USER_ENDPOINT = `${apiUrl}/user`;
 
 // Report a voyage

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import LoadingSpinner from '../../../components/LoadingSpinner';
-import { GROUP_ENDPOINT, USER_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { USER_ENDPOINT } from '../../../constants/AppAPIConstants';
 import {
   // CHANGE_YOUR_DETAILS_PAGE_URL,
   MESSAGE_URL,
@@ -17,10 +17,22 @@ import Auth from '../../../utils/Auth';
 const YourDetails = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
-  const [groupData, setGroupData] = useState({});
   const [userData, setUserData] = useState({});
 
   document.title = YOUR_DETAILS_PAGE_NAME;
+
+  const formatCompanyType = (value) => {
+    // using a switch as we know post MVP this list will be extended to include more types
+    let response;
+    switch (value) {
+      case 'ShippingAgent': response = 'Shipping agent';
+        break;
+      case 'OtherEmail': response = 'Other';
+        break;
+      default: response = 'Other';
+    }
+    return response;
+  };
 
   const getUserData = async () => {
     try {
@@ -30,14 +42,10 @@ const YourDetails = () => {
         },
       });
 
-      const groupResponse = await axios.get(GROUP_ENDPOINT, {
-        headers: {
-          Authorization: `Bearer ${Auth.retrieveToken()}`,
-        },
+      setUserData({
+        ...userResponse.data,
+        companyType: formatCompanyType(userResponse?.data?.group?.groupName),
       });
-
-      setUserData(userResponse.data);
-      setGroupData(groupResponse.data);
     } catch (err) {
       if (err?.response?.status === 401 || err?.response?.status === 422) {
         Auth.removeToken();
@@ -80,14 +88,14 @@ const YourDetails = () => {
             </dd>
           </div>
 
-          <div className="govuk-summary-list__row">
+          {/* <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
               Your company name
             </dt>
             <dd className="govuk-summary-list__value">
-              {groupData.groupName}
+              {}
             </dd>
-          </div>
+          </div> */}
 
           <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
@@ -126,7 +134,7 @@ const YourDetails = () => {
               Company type
             </dt>
             <dd className="govuk-summary-list__value">
-              {groupData.groupType?.name}
+              {userData.companyType}
             </dd>
           </div>
 

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -126,7 +126,7 @@ const YourDetails = () => {
               Company type
             </dt>
             <dd className="govuk-summary-list__value">
-              {groupData.typeOfCompany}
+              {groupData.groupType?.name}
             </dd>
           </div>
 

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -21,19 +21,6 @@ const YourDetails = () => {
 
   document.title = YOUR_DETAILS_PAGE_NAME;
 
-  const formatCompanyType = (value) => {
-    // using a switch as we know post MVP this list will be extended to include more types
-    let response;
-    switch (value) {
-      case 'ShippingAgent': response = 'Shipping agent';
-        break;
-      case 'OtherEmail': response = 'Other';
-        break;
-      default: response = 'Other';
-    }
-    return response;
-  };
-
   const getUserData = async () => {
     try {
       const userResponse = await axios.get(USER_ENDPOINT, {
@@ -42,10 +29,7 @@ const YourDetails = () => {
         },
       });
 
-      setUserData({
-        ...userResponse.data,
-        companyType: formatCompanyType(userResponse?.data?.group?.groupName),
-      });
+      setUserData(userResponse.data);
     } catch (err) {
       if (err?.response?.status === 401 || err?.response?.status === 422) {
         Auth.removeToken();
@@ -88,14 +72,14 @@ const YourDetails = () => {
             </dd>
           </div>
 
-          {/* <div className="govuk-summary-list__row">
+          <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
               Your company name
             </dt>
             <dd className="govuk-summary-list__value">
-              {}
+              {userData.group?.groupName}
             </dd>
-          </div> */}
+          </div>
 
           <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
@@ -129,14 +113,14 @@ const YourDetails = () => {
             </dd>
           </div>
 
-          <div className="govuk-summary-list__row">
+          {/* <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
               Company type
             </dt>
             <dd className="govuk-summary-list__value">
               {userData.companyType}
             </dd>
-          </div>
+          </div> */}
 
           <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import LoadingSpinner from '../../../components/LoadingSpinner';
-import { USER_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { GROUP_ENDPOINT, USER_ENDPOINT } from '../../../constants/AppAPIConstants';
 import {
   // CHANGE_YOUR_DETAILS_PAGE_URL,
   MESSAGE_URL,
@@ -16,6 +16,7 @@ import Auth from '../../../utils/Auth';
 
 const YourDetails = () => {
   const navigate = useNavigate();
+  const [groupData, setGroupData] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [userData, setUserData] = useState({});
 
@@ -29,7 +30,14 @@ const YourDetails = () => {
         },
       });
 
+      const groupResponse = await axios.get(GROUP_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${Auth.retrieveToken()}`,
+        },
+      });
+
       setUserData(userResponse.data);
+      setGroupData(groupResponse.data);
     } catch (err) {
       if (err?.response?.status === 401 || err?.response?.status === 422) {
         Auth.removeToken();
@@ -77,7 +85,7 @@ const YourDetails = () => {
               Your company name
             </dt>
             <dd className="govuk-summary-list__value">
-              {userData.group?.groupName}
+              {groupData.groupName}
             </dd>
           </div>
 
@@ -113,12 +121,13 @@ const YourDetails = () => {
             </dd>
           </div>
 
-          {/* <div className="govuk-summary-list__row">
+          {/* although this is the right keys, we're only getting 'null' back for accounts so commenting out for MVP
+          <div className="govuk-summary-list__row">
             <dt className="govuk-summary-list__key">
               Company type
             </dt>
             <dd className="govuk-summary-list__value">
-              {userData.companyType}
+              {groupData.groupType?.name}
             </dd>
           </div> */}
 

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import LoadingSpinner from '../../../components/LoadingSpinner';
-import { USER_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { GROUP_ENDPOINT, USER_ENDPOINT } from '../../../constants/AppAPIConstants';
 import {
   // CHANGE_YOUR_DETAILS_PAGE_URL,
   MESSAGE_URL,
@@ -17,18 +17,27 @@ import Auth from '../../../utils/Auth';
 const YourDetails = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
+  const [groupData, setGroupData] = useState({});
   const [userData, setUserData] = useState({});
 
   document.title = YOUR_DETAILS_PAGE_NAME;
 
   const getUserData = async () => {
     try {
-      const response = await axios.get(USER_ENDPOINT, {
+      const userResponse = await axios.get(USER_ENDPOINT, {
         headers: {
           Authorization: `Bearer ${Auth.retrieveToken()}`,
         },
       });
-      setUserData(response.data);
+
+      const groupResponse = await axios.get(GROUP_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${Auth.retrieveToken()}`,
+        },
+      });
+
+      setUserData(userResponse.data);
+      setGroupData(groupResponse.data);
     } catch (err) {
       if (err?.response?.status === 401 || err?.response?.status === 422) {
         Auth.removeToken();
@@ -76,7 +85,7 @@ const YourDetails = () => {
               Your company name
             </dt>
             <dd className="govuk-summary-list__value">
-              {/* {userData.company} */}
+              {groupData.groupName}
             </dd>
           </div>
 
@@ -117,7 +126,7 @@ const YourDetails = () => {
               Company type
             </dt>
             <dd className="govuk-summary-list__value">
-              {/* {userData.companyType} */}
+              {groupData.typeOfCompany}
             </dd>
           </div>
 

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import YourDetails from '../YourDetails';
-import { GROUP_ENDPOINT, TOKEN_EXPIRED, USER_ENDPOINT } from '../../../../constants/AppAPIConstants';
+import { TOKEN_EXPIRED, USER_ENDPOINT } from '../../../../constants/AppAPIConstants';
 import { MESSAGE_URL, SIGN_IN_URL, YOUR_DETAILS_PAGE_URL } from '../../../../constants/AppUrlConstants';
 
 const mockedUseNavigate = jest.fn();

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import YourDetails from '../YourDetails';
-import { TOKEN_EXPIRED, USER_ENDPOINT } from '../../../../constants/AppAPIConstants';
+import { GROUP_ENDPOINT, TOKEN_EXPIRED, USER_ENDPOINT } from '../../../../constants/AppAPIConstants';
 import { MESSAGE_URL, SIGN_IN_URL, YOUR_DETAILS_PAGE_URL } from '../../../../constants/AppUrlConstants';
 
 const mockedUseNavigate = jest.fn();
@@ -17,6 +17,31 @@ jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useNavigate: () => mockedUseNavigate,
 }));
+
+const userResponse = {
+  userId: '123',
+  email: 'useremail@test.com',
+  fullName: 'Bob Doe',
+  phoneNumber: '(44)123456789',
+  countryCode: 'GBR',
+  verified: true,
+  dateCreated: '2023-02-06T16:21:09.958032',
+  lastUpdated: '2023-04-18T09:09:54.759977',
+  userType: {
+    userTypeId: '321',
+    name: 'Admin',
+  },
+  groupId: '456',
+};
+const groupResponse = {
+  groupId: 'abc',
+  groupName: 'Company Name',
+  website: null,
+  dateCreated: '2023-02-06T16:21:09.633696',
+  typeOfCompany: 'Shipping Agency',
+  lastUpdated: '2023-02-07T08:21:09.667603',
+  groupType: null,
+};
 
 describe('Your details tests', () => {
   const mockAxios = new MockAdapter(axios);
@@ -41,24 +66,12 @@ describe('Your details tests', () => {
     expect(screen.getByRole('link', { name: 'Change your password' })).toBeInTheDocument();
   });
 
-  it('should render user details if success response', async () => {
+  it('should render user & group details if success response', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
-      .reply(200, {
-        userId: '123',
-        email: 'useremail@test.com',
-        fullName: 'Bob Doe',
-        phoneNumber: '(44)123456789',
-        countryCode: 'GBR',
-        verified: true,
-        dateCreated: '2023-02-06T16:21:09.958032',
-        lastUpdated: '2023-04-18T09:09:54.759977',
-        userType: {
-          userTypeId: '321',
-          name: 'Admin',
-        },
-        groupId: '456',
-      });
+      .reply(200, userResponse)
+      .onGet(GROUP_ENDPOINT)
+      .reply(200, groupResponse);
 
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
@@ -67,11 +80,28 @@ describe('Your details tests', () => {
     expect(screen.getByText('(44)123456789')).toBeInTheDocument();
     expect(screen.getByText('GBR')).toBeInTheDocument();
     expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Company Name')).toBeInTheDocument();
+    expect(screen.getByText('Shipping Agency')).toBeInTheDocument();
   });
 
-  it('should redirect to sign in if getting the declarations returns a 422', async () => {
+  it('should redirect to sign in if getting the user declarations returns a 422', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
+      .reply(422, { msg: 'Not enough segments' })
+      .onGet(GROUP_ENDPOINT)
+      .reply(200, groupResponse);
+    render(<MemoryRouter><YourDetails /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_DETAILS_PAGE_URL } });
+    });
+  });
+
+  it('should redirect to sign in if getting the group declarations returns a 422', async () => {
+    mockAxios
+      .onGet(USER_ENDPOINT)
+      .reply(200, userResponse)
+      .onGet(GROUP_ENDPOINT)
       .reply(422, { msg: 'Not enough segments' });
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 
@@ -80,9 +110,24 @@ describe('Your details tests', () => {
     });
   });
 
-  it('should redirect to sign in if getting the declarations returns a 401 token expired', async () => {
+  it('should redirect to sign in if getting the user declarations returns a 401 token expired', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
+      .reply(401, { msg: TOKEN_EXPIRED })
+      .onGet(GROUP_ENDPOINT)
+      .reply(200, groupResponse);
+    render(<MemoryRouter><YourDetails /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_DETAILS_PAGE_URL } });
+    });
+  });
+
+  it('should redirect to sign in if getting the group declarations returns a 401 token expired', async () => {
+    mockAxios
+      .onGet(USER_ENDPOINT)
+      .reply(200, userResponse)
+      .onGet(GROUP_ENDPOINT)
       .reply(401, { msg: TOKEN_EXPIRED });
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 
@@ -91,9 +136,24 @@ describe('Your details tests', () => {
     });
   });
 
-  it('should redirect to message page on other errors', async () => {
+  it('should redirect to message page on other user endpoint errors', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
+      .reply(500)
+      .onGet(GROUP_ENDPOINT)
+      .reply(200, groupResponse);
+    render(<MemoryRouter><YourDetails /></MemoryRouter>);
+
+    await waitFor(() => {
+      expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', undefined, redirectURL: YOUR_DETAILS_PAGE_URL } });
+    });
+  });
+
+  it('should redirect to message page on group endpoint other errors', async () => {
+    mockAxios
+      .onGet(USER_ENDPOINT)
+      .reply(200, userResponse)
+      .onGet(GROUP_ENDPOINT)
       .reply(500);
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -31,18 +31,14 @@ const userResponse = {
     userTypeId: '321',
     name: 'Admin',
   },
-  groupId: '456',
-};
-const groupResponse = {
-  groupId: 'abc',
-  groupName: 'Company Name',
-  website: null,
-  dateCreated: '2023-02-06T16:21:09.633696',
-  typeOfCompany: null,
-  lastUpdated: '2023-02-07T08:21:09.667603',
-  groupType: {
-    groupTypeId: 'type123',
-    name: 'Shipping Agency',
+  group: {
+    dateCreated: '2023-01-05T11:45:40.485831',
+    groupId: 'abc',
+    groupName: 'something here',
+    groupType: null,
+    lastUpdated: '2023-04-27T07:32:17.186731',
+    typeOfCompany: null,
+    website: null,
   },
 };
 
@@ -59,7 +55,7 @@ describe('Your details tests', () => {
     expect(screen.getByRole('heading', { name: 'Your details' })).toBeInTheDocument();
     expect(screen.getByText('Email address')).toBeInTheDocument();
     expect(screen.getByText('Full name')).toBeInTheDocument();
-    expect(screen.getByText('Your company name')).toBeInTheDocument();
+    // expect(screen.getByText('Your company name')).toBeInTheDocument();
     expect(screen.getByText('Phone number')).toBeInTheDocument();
     expect(screen.getByText('Country')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Account details' })).toBeInTheDocument();
@@ -72,9 +68,7 @@ describe('Your details tests', () => {
   it('should render user & group details if success response', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
-      .reply(200, userResponse)
-      .onGet(GROUP_ENDPOINT)
-      .reply(200, groupResponse);
+      .reply(200, userResponse);
 
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
@@ -83,28 +77,77 @@ describe('Your details tests', () => {
     expect(screen.getByText('(44)123456789')).toBeInTheDocument();
     expect(screen.getByText('GBR')).toBeInTheDocument();
     expect(screen.getByText('Admin')).toBeInTheDocument();
-    expect(screen.getByText('Company Name')).toBeInTheDocument();
-    expect(screen.getByText('Shipping Agency')).toBeInTheDocument();
+    // expect(screen.getByText('Company Name')).toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+  });
+
+  it('should translate ShippingAgent to Shipping agent if type is ShippingAgent', async () => {
+    mockAxios
+      .onGet(USER_ENDPOINT)
+      .reply(200, {
+        userId: '123',
+        email: 'useremail@test.com',
+        fullName: 'Bob Doe',
+        phoneNumber: '(44)123456789',
+        countryCode: 'GBR',
+        verified: true,
+        dateCreated: '2023-02-06T16:21:09.958032',
+        lastUpdated: '2023-04-18T09:09:54.759977',
+        userType: {
+          userTypeId: '321',
+          name: 'Admin',
+        },
+        group: {
+          dateCreated: '2023-01-05T11:45:40.485831',
+          groupId: 'abc',
+          groupName: 'ShippingAgent',
+          groupType: null,
+          lastUpdated: '2023-04-27T07:32:17.186731',
+          typeOfCompany: null,
+          website: null,
+        },
+      });
+
+    render(<MemoryRouter><YourDetails /></MemoryRouter>);
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Shipping agent')).toBeInTheDocument();
+  });
+
+  it('should translate OtherEmail to Other if type is OtherEmail', async () => {
+    mockAxios
+      .onGet(USER_ENDPOINT)
+      .reply(200, {
+        userId: '123',
+        email: 'useremail@test.com',
+        fullName: 'Bob Doe',
+        phoneNumber: '(44)123456789',
+        countryCode: 'GBR',
+        verified: true,
+        dateCreated: '2023-02-06T16:21:09.958032',
+        lastUpdated: '2023-04-18T09:09:54.759977',
+        userType: {
+          userTypeId: '321',
+          name: 'Admin',
+        },
+        group: {
+          dateCreated: '2023-01-05T11:45:40.485831',
+          groupId: 'abc',
+          groupName: 'OtherEmail',
+          groupType: null,
+          lastUpdated: '2023-04-27T07:32:17.186731',
+          typeOfCompany: null,
+          website: null,
+        },
+      });
+
+    render(<MemoryRouter><YourDetails /></MemoryRouter>);
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Other')).toBeInTheDocument();
   });
 
   it('should redirect to sign in if getting the user declarations returns a 422', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
-      .reply(422, { msg: 'Not enough segments' })
-      .onGet(GROUP_ENDPOINT)
-      .reply(200, groupResponse);
-    render(<MemoryRouter><YourDetails /></MemoryRouter>);
-
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_DETAILS_PAGE_URL } });
-    });
-  });
-
-  it('should redirect to sign in if getting the group declarations returns a 422', async () => {
-    mockAxios
-      .onGet(USER_ENDPOINT)
-      .reply(200, userResponse)
-      .onGet(GROUP_ENDPOINT)
       .reply(422, { msg: 'Not enough segments' });
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 
@@ -116,21 +159,6 @@ describe('Your details tests', () => {
   it('should redirect to sign in if getting the user declarations returns a 401 token expired', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
-      .reply(401, { msg: TOKEN_EXPIRED })
-      .onGet(GROUP_ENDPOINT)
-      .reply(200, groupResponse);
-    render(<MemoryRouter><YourDetails /></MemoryRouter>);
-
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, { state: { redirectURL: YOUR_DETAILS_PAGE_URL } });
-    });
-  });
-
-  it('should redirect to sign in if getting the group declarations returns a 401 token expired', async () => {
-    mockAxios
-      .onGet(USER_ENDPOINT)
-      .reply(200, userResponse)
-      .onGet(GROUP_ENDPOINT)
       .reply(401, { msg: TOKEN_EXPIRED });
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 
@@ -142,21 +170,6 @@ describe('Your details tests', () => {
   it('should redirect to message page on other user endpoint errors', async () => {
     mockAxios
       .onGet(USER_ENDPOINT)
-      .reply(500)
-      .onGet(GROUP_ENDPOINT)
-      .reply(200, groupResponse);
-    render(<MemoryRouter><YourDetails /></MemoryRouter>);
-
-    await waitFor(() => {
-      expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, { state: { title: 'Something has gone wrong', undefined, redirectURL: YOUR_DETAILS_PAGE_URL } });
-    });
-  });
-
-  it('should redirect to message page on group endpoint other errors', async () => {
-    mockAxios
-      .onGet(USER_ENDPOINT)
-      .reply(200, userResponse)
-      .onGet(GROUP_ENDPOINT)
       .reply(500);
     render(<MemoryRouter><YourDetails /></MemoryRouter>);
 

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -38,9 +38,12 @@ const groupResponse = {
   groupName: 'Company Name',
   website: null,
   dateCreated: '2023-02-06T16:21:09.633696',
-  typeOfCompany: 'Shipping Agency',
+  typeOfCompany: null,
   lastUpdated: '2023-02-07T08:21:09.667603',
-  groupType: null,
+  groupType: {
+    groupTypeId: 'type123',
+    name: 'Shipping Agency',
+  },
 };
 
 describe('Your details tests', () => {

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -55,12 +55,12 @@ describe('Your details tests', () => {
     expect(screen.getByRole('heading', { name: 'Your details' })).toBeInTheDocument();
     expect(screen.getByText('Email address')).toBeInTheDocument();
     expect(screen.getByText('Full name')).toBeInTheDocument();
-    // expect(screen.getByText('Your company name')).toBeInTheDocument();
+    expect(screen.getByText('Your company name')).toBeInTheDocument();
     expect(screen.getByText('Phone number')).toBeInTheDocument();
     expect(screen.getByText('Country')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Account details' })).toBeInTheDocument();
     expect(screen.getByText('Type of account')).toBeInTheDocument();
-    expect(screen.getByText('Company type')).toBeInTheDocument();
+    // expect(screen.getByText('Company type')).toBeInTheDocument();
     expect(screen.getByText('Password')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Change your password' })).toBeInTheDocument();
   });
@@ -77,72 +77,8 @@ describe('Your details tests', () => {
     expect(screen.getByText('(44)123456789')).toBeInTheDocument();
     expect(screen.getByText('GBR')).toBeInTheDocument();
     expect(screen.getByText('Admin')).toBeInTheDocument();
-    // expect(screen.getByText('Company Name')).toBeInTheDocument();
-    expect(screen.getByText('Other')).toBeInTheDocument();
-  });
-
-  it('should translate ShippingAgent to Shipping agent if type is ShippingAgent', async () => {
-    mockAxios
-      .onGet(USER_ENDPOINT)
-      .reply(200, {
-        userId: '123',
-        email: 'useremail@test.com',
-        fullName: 'Bob Doe',
-        phoneNumber: '(44)123456789',
-        countryCode: 'GBR',
-        verified: true,
-        dateCreated: '2023-02-06T16:21:09.958032',
-        lastUpdated: '2023-04-18T09:09:54.759977',
-        userType: {
-          userTypeId: '321',
-          name: 'Admin',
-        },
-        group: {
-          dateCreated: '2023-01-05T11:45:40.485831',
-          groupId: 'abc',
-          groupName: 'ShippingAgent',
-          groupType: null,
-          lastUpdated: '2023-04-27T07:32:17.186731',
-          typeOfCompany: null,
-          website: null,
-        },
-      });
-
-    render(<MemoryRouter><YourDetails /></MemoryRouter>);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
-    expect(screen.getByText('Shipping agent')).toBeInTheDocument();
-  });
-
-  it('should translate OtherEmail to Other if type is OtherEmail', async () => {
-    mockAxios
-      .onGet(USER_ENDPOINT)
-      .reply(200, {
-        userId: '123',
-        email: 'useremail@test.com',
-        fullName: 'Bob Doe',
-        phoneNumber: '(44)123456789',
-        countryCode: 'GBR',
-        verified: true,
-        dateCreated: '2023-02-06T16:21:09.958032',
-        lastUpdated: '2023-04-18T09:09:54.759977',
-        userType: {
-          userTypeId: '321',
-          name: 'Admin',
-        },
-        group: {
-          dateCreated: '2023-01-05T11:45:40.485831',
-          groupId: 'abc',
-          groupName: 'OtherEmail',
-          groupType: null,
-          lastUpdated: '2023-04-27T07:32:17.186731',
-          typeOfCompany: null,
-          website: null,
-        },
-      });
-
-    render(<MemoryRouter><YourDetails /></MemoryRouter>);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
-    expect(screen.getByText('Other')).toBeInTheDocument();
+    expect(screen.getByText('something here')).toBeInTheDocument();
+    // expect(screen.getByText('Other')).toBeInTheDocument(); company type not being returned in our dataset right now
   });
 
   it('should redirect to sign in if getting the user declarations returns a 422', async () => {


### PR DESCRIPTION
# Ticket



----

## AC

Given I am a registered & active user
When I go to the your details page
Then I can see my company type

----

## To test

_you may need to register a new user if your user account is old as some models were changed a while back_

- register a user as a Shipping Agent
- go to your details page
- you should see company type as 'Shipping agent'

- register a user as Other
- go to your details page
- you should see company type as 'Other'


----

## Notes
company name is not available in the dataset at the moment so has been hidden from the UI