### PR TITLE
NMSW-337 Set a declaration to PreCancelled

### DIFF
--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -259,10 +259,12 @@ const VoyageCheckYourAnswers = () => {
     } else if (formData.formData.deleteVoyage === 'deleteVoyageYes') {
       setIsPendingSubmit(true);
       try {
-        await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRECANCELLED }, {
+        const response = await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRECANCELLED }, {
           headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
         });
-        navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${declarationData.FAL1.nameOfShip} cancelled.` } } });
+        if (response.status === 200) {
+          navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${declarationData.FAL1.nameOfShip} cancelled.` } } });
+        }
       } catch (err) {
         if (err?.response?.status === 422 || err?.response?.data?.msg === TOKEN_EXPIRED) {
           Auth.removeToken();

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import {
   DECLARATION_STATUS_DRAFT,
+  DECLARATION_STATUS_PRECANCELLED,
   DECLARATION_STATUS_PRESUBMITTED,
   DECLARATION_STATUS_SUBMITTED,
 } from '../../constants/AppConstants';
@@ -28,6 +29,7 @@ import StatusTag from '../../components/StatusTag';
 import GetDeclaration from '../../utils/GetDeclaration';
 import Auth from '../../utils/Auth';
 import { scrollToElementId, scrollToTop } from '../../utils/ScrollToElement';
+import VoyageCancelConfirmation from './VoyageCheckYourAnswers/VoyageCancelConfirmation';
 
 const SubmitConfirmation = () => (
   <>
@@ -48,6 +50,7 @@ const VoyageCheckYourAnswers = () => {
   const [fal5Details, setFal5Details] = useState();
   const [fal6Details, setFal6Details] = useState();
   const [isLoading, setIsLoading] = useState(false);
+  const [isPendingCancel, setIsPendingCancel] = useState(false);
   const [isPendingSubmit, setIsPendingSubmit] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [supportingDocs, setSupportingDocs] = useState([]);
@@ -246,6 +249,34 @@ const VoyageCheckYourAnswers = () => {
     }
   };
 
+  const checkCancelRequest = async () => {
+    setIsPendingCancel(true);
+  };
+
+  const handleCancel = async (formData) => {
+    if (formData.formData.deleteVoyage === 'deleteVoyageNo') {
+      setIsPendingCancel(false);
+    } else if (formData.formData.deleteVoyage === 'deleteVoyageYes') {
+      setIsPendingSubmit(true);
+      try {
+        await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRECANCELLED }, {
+          headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+        });
+        navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${declarationData.FAL1.nameOfShip} cancelled.` } } });
+      } catch (err) {
+        if (err?.response?.status === 422 || err?.response?.data?.msg === TOKEN_EXPIRED) {
+          Auth.removeToken();
+          navigate(SIGN_IN_URL, { state: { redirectURL: `${VOYAGE_CHECK_YOUR_ANSWERS}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}` } });
+        } else {
+          // 500 errors will fall into this bucket
+          navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: `${VOYAGE_CHECK_YOUR_ANSWERS}?${URL_DECLARATIONID_IDENTIFIER}=${declarationId}` } });
+        }
+      } finally {
+        setIsPendingSubmit(false);
+      }
+    }
+  };
+
   useEffect(() => {
     if (declarationId) {
       setIsLoading(true);
@@ -266,6 +297,14 @@ const VoyageCheckYourAnswers = () => {
   }
 
   if (isLoading) { return (<LoadingSpinner />); }
+  if (isPendingCancel) {
+    return (
+      <VoyageCancelConfirmation
+        isLoading={isPendingSubmit}
+        handleSubmit={handleCancel}
+      />
+    );
+  }
   if (showConfirmation) {
     return (
       <ConfirmationMessage
@@ -433,15 +472,14 @@ const VoyageCheckYourAnswers = () => {
             )
           }
           {
-            (declarationStatus?.status === DECLARATION_STATUS_SUBMITTED || declarationStatus?.status === DECLARATION_STATUS_PRESUBMITTED)
+            (declarationStatus?.status === DECLARATION_STATUS_DRAFT || declarationStatus?.status === DECLARATION_STATUS_SUBMITTED || declarationStatus?.status === DECLARATION_STATUS_PRESUBMITTED)
             && (
               <button
                 type="button"
-                // className={isPendingCancel ? 'govuk-button disabled' : 'govuk-button govuk-button--warning'}
-                className="govuk-button govuk-button--warning"
+                className={isPendingSubmit ? 'govuk-button govuk-button--warning disabled' : 'govuk-button govuk-button--warning'}
                 data-module="govuk-button"
-              // disabled={isPendingCancel}
-              // onClick={() => handleCancel()}
+                disabled={isPendingSubmit}
+                onClick={() => checkCancelRequest()}
               >
                 Cancel
               </button>

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -472,7 +472,7 @@ const VoyageCheckYourAnswers = () => {
             )
           }
           {
-            (declarationStatus?.status === DECLARATION_STATUS_DRAFT || declarationStatus?.status === DECLARATION_STATUS_SUBMITTED || declarationStatus?.status === DECLARATION_STATUS_PRESUBMITTED)
+            (declarationStatus?.status === DECLARATION_STATUS_SUBMITTED || declarationStatus?.status === DECLARATION_STATUS_PRESUBMITTED)
             && (
               <button
                 type="button"

--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -348,7 +348,8 @@ const VoyageCheckYourAnswers = () => {
           )}
         </div>
         <div className="govuk-grid-column-full">
-          <h1 className="govuk-heading-xl">Check your answers</h1>
+          {declarationStatus?.status === DECLARATION_STATUS_DRAFT && <h1 className="govuk-heading-xl">Check your answers</h1>}
+          {declarationStatus?.status !== DECLARATION_STATUS_DRAFT && <h1 className="govuk-heading-xl">Review your report</h1>}
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/src/pages/Voyage/VoyageCheckYourAnswers/VoyageCancelConfirmation.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers/VoyageCancelConfirmation.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import DisplayForm from '../../../components/DisplayForm';
+import {
+  DISPLAY_GROUPED,
+  FIELD_RADIO,
+  SINGLE_PAGE_FORM,
+  VALIDATE_REQUIRED,
+} from '../../../constants/AppConstants';
+
+const VoyageCancelConfirmation = ({ isLoading, handleSubmit }) => {
+  const formActions = {
+    submit: {
+      label: 'Confirm',
+    },
+  };
+  const formFields = [
+    {
+      type: FIELD_RADIO,
+      label: 'Are you sure you want to cancel the voyage report?',
+      labelAsH1: true,
+      fieldName: 'deleteVoyage',
+      className: 'govuk-radios--inline',
+      displayType: DISPLAY_GROUPED,
+      radioOptions: [
+        {
+          label: 'Yes',
+          name: 'deleteVoyage',
+          id: 'yes',
+          value: 'deleteVoyageYes',
+        },
+        {
+          label: 'No',
+          name: 'deleteVoyage',
+          id: 'no',
+          value: 'deleteVoyageNo',
+        },
+      ],
+      validation: [
+        {
+          type: VALIDATE_REQUIRED,
+          message: 'Select yes if you want to delete your voyage report',
+        },
+      ],
+    },
+  ];
+
+  return (
+    <DisplayForm
+      formId="voyagePassengers"
+      fields={formFields}
+      formActions={formActions}
+      formType={SINGLE_PAGE_FORM}
+      isLoading={isLoading}
+      handleSubmit={handleSubmit}
+    />
+  );
+};
+
+export default VoyageCancelConfirmation;
+
+VoyageCancelConfirmation.propTypes = {
+  isLoading: PropTypes.bool,
+  handleSubmit: PropTypes.func,
+};

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -768,7 +768,7 @@ describe('Voyage check your answers page', () => {
   // ==========================
   // STATUS TESTS
   // ==========================
-  it('should render no status line and the cta as submit if status is draft', async () => {
+  it('should render no status line and the cta as submit and the h1 as check your answers if status is draft', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -810,6 +810,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Check your answers')).toBeInTheDocument();
     expect(screen.getByText('Now send your application')).toBeInTheDocument();
     expect(screen.getByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save and submit' })).toBeInTheDocument();
@@ -818,7 +819,7 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByText('Status')).not.toBeInTheDocument();
   });
 
-  it('should render the status as submitted, submission date, and a cancel CTA if status is submitted', async () => {
+  it('should render the status as submitted, submission date, h1 of review your report, and a cancel CTA if status is submitted', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -860,6 +861,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Review your report')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Submitted').outerHTML).toEqual('<strong class="govuk-tag govuk-tag--green">Submitted</strong>');
     expect(screen.getByText('10 February 2023')).toBeInTheDocument();
@@ -870,7 +872,7 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).not.toBeInTheDocument();
   });
 
-  it('should render the status as submitted, submission date, and a cancel CTA if status is presubmitted', async () => {
+  it('should render the status as submitted, submission date, h1 of review your report, and a cancel CTA if status is presubmitted', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -912,6 +914,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Review your report')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Submitted').outerHTML).toEqual('<strong class="govuk-tag govuk-tag--green">Submitted</strong>');
     expect(screen.getByText('10 February 2023')).toBeInTheDocument();
@@ -922,7 +925,7 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).not.toBeInTheDocument();
   });
 
-  it('should render the status as cancelled, submission date, and a no CTA if status is canceled', async () => {
+  it('should render the status as cancelled, submission date, h1 of review your report, and a no CTA if status is canceled', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -964,6 +967,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Review your report')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Cancelled').outerHTML).toEqual('<strong class="govuk-tag govuk-tag--orange">Cancelled</strong>');
     expect(screen.getByText('10 February 2023')).toBeInTheDocument();
@@ -973,7 +977,7 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).not.toBeInTheDocument();
   });
 
-  it('should render the status as cancelled, submission date, and a no CTA if status is precanceled', async () => {
+  it('should render the status as cancelled, submission date, h1 of review your report, and a no CTA if status is precanceled', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -1015,6 +1019,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Review your report')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Cancelled').outerHTML).toEqual('<strong class="govuk-tag govuk-tag--orange">Cancelled</strong>');
     expect(screen.getByText('10 February 2023')).toBeInTheDocument();
@@ -1024,7 +1029,7 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).not.toBeInTheDocument();
   });
 
-  it('should render the status as failed, submission date, and a no CTA if status is failed', async () => {
+  it('should render the status as failed, submission date, h1 of review your report, and a no CTA if status is failed', async () => {
     mockAxios
       .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
         headers: {
@@ -1066,6 +1071,7 @@ describe('Voyage check your answers page', () => {
       });
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    expect(screen.getByText('Review your report')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Failed').outerHTML).toEqual('<strong class="govuk-tag govuk-tag--red">Failed</strong>');
     expect(screen.getByText('10 February 2023')).toBeInTheDocument();
@@ -1227,7 +1233,7 @@ describe('Voyage check your answers page', () => {
 
     await user.click(screen.getByRole('radio', { name: 'No' }));
     await user.click(screen.getByRole('button', { name: 'Confirm' }));
-    await screen.findByRole('heading', { name: 'Check your answers' });
+    await screen.findByRole('heading', { name: 'Review your report' });
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -8,7 +8,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { DECLARATION_STATUS_PRESUBMITTED } from '../../../constants/AppConstants';
+import { DECLARATION_STATUS_PRECANCELLED, DECLARATION_STATUS_PRESUBMITTED } from '../../../constants/AppConstants';
 import {
   MESSAGE_URL,
   SIGN_IN_URL,
@@ -1123,5 +1123,360 @@ describe('Voyage check your answers page', () => {
     expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
     expect(screen.queryByText('Now send your application')).not.toBeInTheDocument();
     expect(screen.queryByText('By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.')).not.toBeInTheDocument();
+  });
+
+  // ==========================
+  // CANCEL TESTS
+  // ==========================
+
+  it('should show the are you sure question if cancel button clicked', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+    expect(screen.getByRole('radio', { name: 'Yes' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'No' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+  });
+
+  it('should return to CYA page if no is selected', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+
+    await user.click(screen.getByRole('radio', { name: 'No' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    await screen.findByRole('heading', { name: 'Check your answers' });
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('should send status to PreCancelled and on success go to your voyages if yes is selected', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      })
+      .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRECANCELLED })
+      .reply(200, {
+        id: '123',
+        status: 'PreSubmitted',
+        creationDate: '2023-04-17',
+        submissionDate: '2023-04-17',
+        nameOfShip: 'Test Ship',
+        imoNumber: '1234567',
+        callSign: 'NA',
+        signatory: 'Bob Smith',
+        flagState: 'GBR',
+        departureFromUk: false,
+        departurePortUnlocode: 'AU POR',
+        departureDate: '2023-02-12',
+        departureTime: '09:32:00',
+        arrivalPortUnlocode: 'GB DOV',
+        arrivalDate: '2023-02-15',
+        arrivalTime: '14:00:00',
+        previousPortUnlocode: 'AU POR',
+        nextPortUnlocode: 'NL RTM',
+        cargo: 'No cargo',
+        passengers: false,
+        cbpId: null,
+      });
+
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(mockedUseNavigate).toHaveBeenCalledWith(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: 'Report for Test ship name cancelled.' } } });
+  });
+
+  it('should redirect to message page if Cancel Yes returns a 500 response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      })
+      .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRECANCELLED })
+      .reply(500);
+
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, {
+      state: {
+        title: 'Something has gone wrong',
+        message: undefined,
+        redirectURL: `${VOYAGE_CHECK_YOUR_ANSWERS}?${URL_DECLARATIONID_IDENTIFIER}=123`,
+      },
+    });
+  });
+
+  it('should redirect to signin page if Cancel Yes returns a 422 response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      })
+      .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRECANCELLED })
+      .reply(422, { message: 'Not enough segments' });
+
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, {
+      state: { redirectURL: `${VOYAGE_CHECK_YOUR_ANSWERS}?${URL_DECLARATIONID_IDENTIFIER}=123` },
+    });
+  });
+
+  it('should redirect to signin page if Cancel Yes returns a 401 token expired response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123${ENDPOINT_DECLARATION_ATTACHMENTS_PATH}`, {
+        headers: {
+          Authorization: 'Bearer 123',
+        },
+      })
+      .reply(200, {
+        FAL1: {
+          nameOfShip: 'Test ship name',
+          status: 'Submitted',
+          imoNumber: '1234567',
+          callSign: 'NA',
+          signatory: 'Captain Name',
+          flagState: 'GBR',
+          departureFromUk: false,
+          departurePortUnlocode: 'AUPOR',
+          departureDate: '2023-02-12',
+          departureTime: '09:23:00',
+          arrivalPortUnlocode: 'GBDOV',
+          arrivalDate: '2023-02-15',
+          arrivalTime: '14:00:00',
+          previousPortUnlocode: 'AUPOR',
+          nextPortUnlocode: 'NLRTM',
+          cargo: 'No cargo',
+          passengers: false,
+          creationDate: '2023-02-10',
+          submissionDate: '2023-02-10',
+        },
+        FAL5: [
+          {
+            filename: 'Crew details including supernumeraries FAL 5.xlsx',
+            id: 'FAL5',
+            size: '118385',
+            url: 'https://fal5-report-link.com',
+          },
+        ],
+        FAL6: [],
+        supporting: [],
+      })
+      .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRECANCELLED })
+      .reply(401, { msg: TOKEN_EXPIRED });
+
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Are you sure you want to cancel the voyage report?' });
+    await user.click(screen.getByRole('radio', { name: 'Yes' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(mockedUseNavigate).toHaveBeenCalledWith(SIGN_IN_URL, {
+      state: { redirectURL: `${VOYAGE_CHECK_YOUR_ANSWERS}?${URL_DECLARATIONID_IDENTIFIER}=123` },
+    });
   });
 });


### PR DESCRIPTION
# Ticket



----

## AC

Given I have submitted a declaration previously
When I click cancel
Then I am asked are you sure

When I select no and click confirm
Then I am returned to the CYA page

When I select yes and click confirm
Then a request to PATCH status to `PreCancelled` is sent
Then I am taken to `your voyages` and shown a confirmation of cancellation banner
Then I can no longer see that report in my list

----

## To test

- create and submit a declaration
- return to the declaration (check your answer page)
- click cancel
- select 'no' and click confirm when asked are you sure
- > you should be returned to the CYA page
- > your declaration should still exist
- click cancel
- select 'yes' and click confirm
- > you should be taken to your voyages with a confirmation of deletion banner
- > you should not see that report in your list


----

## Notes
