### PR TITLE
Test NMSW-547 Display user details

### DIFF
--- a/cypress/e2e/features/your-details-page.feature
+++ b/cypress/e2e/features/your-details-page.feature
@@ -1,0 +1,25 @@
+Feature: User able to view the details registered
+  As a user I can able to view the details I have provided when registering an account
+
+  Background:
+    Given I am on the sign-in page
+    When I have entered a correct email address and password and sign in
+    Then I am taken to your-voyages page
+    When I click your details tab
+    Then I am taken to your details page
+
+  Scenario: User able to see their details they entered when creating their account
+    Then I am able to see all my details
+
+  Scenario: User can able to reset password successfully from your details page
+    When I click change your password link
+    Then I am taken to forgotten-password page
+    When I enter my email to request a forgotten password link
+    And I click send the link
+    Then I am taken to check your email page
+    When I click the password reset link received
+    Then I am taken to new password page
+    When I enter a new password and confirmation password that matches the new password
+    Then I can see the confirmation screen with sign in link
+    When I sign-in with new password
+    Then I am taken to your-voyages page

--- a/cypress/e2e/pages/registration/password.page.js
+++ b/cypress/e2e/pages/registration/password.page.js
@@ -20,7 +20,6 @@ class PasswordPage {
 
   checkForgottenPasswordPage() {
     cy.url().should('include', '/forgotten-password');
-    BasePage.checkH1('Forgot password');
   }
 
   clickSendLinkBtn() {
@@ -53,6 +52,14 @@ class PasswordPage {
 
   clickPwdSignIn() {
     cy.contains('Sign in to start using the service').click();
+  }
+
+  checkYourDetails() {
+    cy.get('dl:nth-child(2) > div:nth-child(1) > dt').should('have.text','Email address').next().should('have.text','4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com');
+    cy.get('dl:nth-child(2) > div:nth-child(2) > dt').should('have.text','Full name').next().should('have.text','NMSW-test2');
+    cy.get('dl:nth-child(2) > div:nth-child(4) > dt').should('have.text','Phone number').next().should('have.text','(44)7098654321');
+    cy.get('dl:nth-child(2) > div:nth-child(5) > dt').should('have.text','Country').next().should('have.text','GBR');
+    cy.get('dl:nth-of-type(2) div:nth-child(1) dt').should('have.text','Type of account').next().should('have.text','Admin');
   }
 }
 

--- a/cypress/support/step_definitions/your-details-page.steps.js
+++ b/cypress/support/step_definitions/your-details-page.steps.js
@@ -1,0 +1,12 @@
+import {Then, When} from "@badeball/cypress-cucumber-preprocessor";
+import BasePage from "../../e2e/pages/base.page";
+import PasswordPage from "../../e2e/pages/registration/password.page";
+
+When('I click change your password link', () => {
+  cy.contains('Change your password').click();
+});
+
+Then('I am able to see all my details', () => {
+  BasePage.checkH1('Your details');
+  PasswordPage.checkYourDetails();
+});


### PR DESCRIPTION
Added test for NMSW-547 Display user details


## To test
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
and select your-details-page.feature

