### PR TITLE
Test display supporting document upload with delete feature

### DIFF
--- a/cypress/e2e/features/upload-supporting-documents.feature
+++ b/cypress/e2e/features/upload-supporting-documents.feature
@@ -17,6 +17,7 @@ Feature: Upload supporting documents
 
   @regression
   Scenario: User should be able to upload supporting documents for voyage report
+    #upload mare than maximum allowed files
     When I add more files than limited number of supporting documents
       | fileName                                                                  |
       | ValidMELLINA CREW EFFECTS.xlsx                                            |
@@ -31,7 +32,7 @@ Feature: Upload supporting documents
     Then I am shown corresponding error message
       | Field | multiFileUploadForm-error                                 |
       | Error | Error: You've selected too many files: you can only add 8 |
-
+    #upload valid file
     When I upload a valid files, it gets uploaded
       | fileName                                                                  |
       | ValidNMSW FAL 5 and 6 Supporting Information - Crew Off Signers List.xlsx |
@@ -42,6 +43,15 @@ Feature: Upload supporting documents
       | ValidTest_Data_Text.docm                                                  |
       | ValidTest_data_xltm.xltm                                                  |
     Then I can delete files added to add more files
+    #upload file more than 1MB
+    When I add files more than 1Mb
+      | fileName                |
+      | MBFileTest_Data_XLS.xls |
+    Then I am shown error message file must be smaller than 1MB
+      | fileName                |
+      | MBFileTest_Data_XLS.xls |
+    Then I can delete files added to add more files
+    #upload invalid file types
     When I upload a file type that is not valid
       | fileName                              |
       | InvalidFree_Test_Data_100KB_PDF.pdf   |
@@ -54,27 +64,28 @@ Feature: Upload supporting documents
       | InvalidFree_Test_Data_100KB_PPTX.pptx |
       | InvalidSample-gif-Image.gif           |
       | Invalidstylesheet-css.css             |
-
+    #re-upload correct files
     Then I am able to choose valid number of documents and upload in Files added section
       | fileName                       |
       | ValidMELLINA CREW EFFECTS.xlsx |
       | ValidTest_Data.xml             |
       | ValidTest_Data_500KB_DOCX.docx |
     Then I am able to delete the file
+    #upload same file that is already uploaded
     When I attempt to add a file with the same name that is already added
       | fileName                       |
       | ValidMELLINA CREW EFFECTS.xlsx |
     Then I am shown an error message for 'ValidMELLINA CREW EFFECTS.xlsx'
-
-    When auth token is no longer available
-    When I click upload files
+    When auth token is no longer available to upload file
     Then I am taken to the sign-in page
     When I have entered a correct email address and password and sign in
     Then I am taken to upload supporting documents page
+    #add more files within max limit
     Then I am able to add more limited number files to already added supporting files
       | fileName                     |
       | ValidTest_data_xltm.xltm     |
       | ValidTest_Data_100KB_RTF.rtf |
+    #add more files which will exceed max limit
     When I add some more files than limited number of supporting documents
       | fileName                                                                  |
       | ValidMELLINA CREW EFFECTS.xlsx                                            |
@@ -86,18 +97,16 @@ Feature: Upload supporting documents
       | ValidTest_Data_Text.docm                                                  |
     Then I am shown corresponding error message
       | Field | multiFileUploadForm-error                                             |
-      | Error | Error: You've selected too many files: you can add up to 6 more files |
-
-    Then I can delete files added to add more files
-    When I add files more than 1Mb
-      | fileName                |
-      | MBFileTest_Data_XLS.xls |
-    Then I am shown error message to check file and try again
-      | fileName                |
-      | MBFileTest_Data_XLS.xls |
-
+      | Error | Error: You've selected too many files: you can add up to 3 more files |
     When auth token is no longer available
     When I click save and continue
     Then I am taken to the sign-in page
     When I have entered a correct email address and password and sign in
     Then I am taken to task details page
+    When I click on supporting documents link
+    Then I am taken to upload supporting documents page
+    Then I can see the supporting documents I have uploaded
+      | fileName                       |
+      | ValidMELLINA CREW EFFECTS.xlsx |
+      | ValidTest_Data.xml             |
+      | ValidTest_Data_500KB_DOCX.docx |

--- a/cypress/e2e/pages/file-upload.page.js
+++ b/cypress/e2e/pages/file-upload.page.js
@@ -79,6 +79,16 @@ class FileUploadPage {
     cy.get(':nth-child(2) > .nmsw-grid-column-two-twelfths').contains('Delete').click();
   }
 
+  deleteMoreFiles() {
+    cy.get('.nmsw-grid-column-two-twelfths button').then($ele => {
+      let count = $ele.length
+      for (let i = 0; i < count; i++) {
+        cy.get('.nmsw-grid-column-two-twelfths button').first().click().should('not.exist')
+      }
+      cy.get('.multi-file-upload--filelist').should('have.length', 0);
+    })
+  }
+
   verifyPassengerDetailsPage() {
     cy.url().should('include', 'passenger-details');
   }
@@ -119,7 +129,7 @@ class FileUploadPage {
     const files = table.hashes();
     const fileNames = files.map(item => item.fileName);
     cy.get('.multi-file-upload--filelist-filename').each(($ele, index) => {
-      cy.contains(`${fileNames[index]} There was a problem check file and try again`)
+      cy.contains(`${fileNames[index]} The file must be smaller than 1MB`)
     })
   }
 }

--- a/cypress/support/step_definitions/upload-supporting-documents.steps.js
+++ b/cypress/support/step_definitions/upload-supporting-documents.steps.js
@@ -54,11 +54,12 @@ When('I upload a valid files, it gets uploaded', (table) => {
   fileUploadPage.selectMultipleFalFiles(table);
   const files = table.hashes();
   const fileNames = files.map(item => item.fileName);
-  cy.contains('Upload files').click({timeout: 7000});
-  cy.get('.success .multi-file-upload--filelist-filename').each(($el, index) => {
+  cy.intercept('POST', '**/supporting').as('uploadFile');
+  cy.contains('Upload files').click();
+  cy.get('.nmsw-grid-column-ten-twelfths').each(($el, index) => {
     cy.contains(`${fileNames[index]} has been uploaded`).should('have.css', 'color', 'rgb(0, 112, 60)');
   });
-  cy.wait(5000);
+  cy.wait('@uploadFile');
 });
 
 When('I upload a file type that is not valid', (table) => {
@@ -71,17 +72,33 @@ Then('I am shown error message to upload correct file type for the files uploade
 });
 
 Then('I can delete files added to add more files', () => {
-  cy.get('.nmsw-grid-column-two-twelfths > .govuk-button').each(($el) => {
-    cy.wrap($el).click({force: true});
-  });
+  fileUploadPage.deleteMoreFiles();
 });
 
 When('I add files more than 1Mb', (table) => {
   fileUploadPage.selectMultipleFalFiles(table);
   cy.contains('Upload files').click();
-  cy.wait(5000);
+  cy.wait(1000);
 });
 
-Then('I am shown error message to check file and try again', (table) => {
+Then('I am shown error message file must be smaller than 1MB', (table) => {
   fileUploadPage.checkErrorForFileMaxSize(table);
+});
+
+When('I click on supporting documents link', () => {
+  cy.contains('Supporting documents').click();
+});
+
+Then('I can see the supporting documents I have uploaded', (table) => {
+  const files = table.hashes();
+  const fileNames = files.map(item => item.fileName);
+  cy.get('.success .multi-file-upload--filelist-filename').each(($el, index) => {
+    cy.contains(`${fileNames[index]} has been uploaded`).should('have.css', 'color', 'rgb(0, 112, 60)');
+  });
+});
+
+When('auth token is no longer available to upload file', () => {
+  cy.window().its('sessionStorage').invoke('clear').then(() => {
+    cy.reload();
+  });
 });


### PR DESCRIPTION
- Added test for NMSW-243 Display uploaded supporting documents
- Added test for NMSW-514 Delete uploaded supporting documents

## To test

```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```

and select upload-supporting-documents.feature
