### PR TITLE
Test NMSW-551 -Display your group details

### DIFF
--- a/cypress/e2e/features/sign-in.feature
+++ b/cypress/e2e/features/sign-in.feature
@@ -38,7 +38,7 @@ Feature: User sign-in
     Examples:
       | emailAddress                                       | password |
       | TestEmail@test.com                                 | 12345    |
-      | 4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com | test-12  |
+      | 0c4e8b60-43f2-4255-a712-6984d089782d@mailslurp.com | test-12  |
 
   Scenario: User should not be signed-in without providing email and password
     When I try to access a protected page

--- a/cypress/e2e/pages/registration/password.page.js
+++ b/cypress/e2e/pages/registration/password.page.js
@@ -55,9 +55,10 @@ class PasswordPage {
   }
 
   checkYourDetails() {
-    cy.get('dl:nth-child(2) > div:nth-child(1) > dt').should('have.text','Email address').next().should('have.text','4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com');
-    cy.get('dl:nth-child(2) > div:nth-child(2) > dt').should('have.text','Full name').next().should('have.text','NMSW-test2');
-    cy.get('dl:nth-child(2) > div:nth-child(4) > dt').should('have.text','Phone number').next().should('have.text','(44)7098654321');
+    cy.get('dl:nth-child(2) > div:nth-child(1) > dt').should('have.text','Email address').next().should('have.text','0c4e8b60-43f2-4255-a712-6984d089782d@mailslurp.com');
+    cy.get('dl:nth-child(2) > div:nth-child(2) > dt').should('have.text','Full name').next().should('have.text','Auto-test-sign-in');
+    cy.get('dl:nth-child(2) > div:nth-child(3) > dt').should('have.text','Your company name').next().should('have.text','Test NMSW');
+    cy.get('dl:nth-child(2) > div:nth-child(4) > dt').should('have.text','Phone number').next().should('have.text','(44)0699999999');
     cy.get('dl:nth-child(2) > div:nth-child(5) > dt').should('have.text','Country').next().should('have.text','GBR');
     cy.get('dl:nth-of-type(2) div:nth-child(1) dt').should('have.text','Type of account').next().should('have.text','Admin');
   }

--- a/cypress/fixtures/registration.json
+++ b/cypress/fixtures/registration.json
@@ -1,6 +1,6 @@
 {
   "email": "b6f7c995-d7b0-48e7-a1b6-9264b9598b37@mailslurp.com",
   "password": "Test-NMSW-Dev",
-  "signInEmail": "4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com",
+  "signInEmail": "0c4e8b60-43f2-4255-a712-6984d089782d@mailslurp.com",
   "signInEmail2": "7ee68e7d-c48e-438c-8422-c09bfe264e13@mailslurp.com"
 }


### PR DESCRIPTION

Test added for NMSW-551 -Display your group details
Changed sign-in credentials to work with the changes
## To test
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
select your-details-page.feature


