### PR TITLE
Test NMSW-245 On GET drafts delete any without general declarations

### DIFF
--- a/cypress/e2e/features/fal1-upload-general-declaration.feature
+++ b/cypress/e2e/features/fal1-upload-general-declaration.feature
@@ -9,6 +9,10 @@ Feature: Upload General declaration (FAL1) page
     Then I am taken to upload-general-declaration page
 
   Scenario: General declaration page validation
+    When I navigate back to your-voyage page without adding General Declaration
+    Then the voyage without general declaration is not added to the reported voyage
+    Then I click report a voyage
+    Then I am taken to upload-general-declaration page
     When I click check for errors without uploading any file
     Then I am shown corresponding error message
       | Field | fileUploadInput-error |

--- a/cypress/fixtures/registration.json
+++ b/cypress/fixtures/registration.json
@@ -1,6 +1,6 @@
 {
   "email": "b6f7c995-d7b0-48e7-a1b6-9264b9598b37@mailslurp.com",
   "password": "Test-NMSW-Dev",
-  "signInEmail": "4f3a5d85-99bd-46db-b8ea-80ea8772c9c5@mailslurp.com",
+  "signInEmail": "0c4e8b60-43f2-4255-a712-6984d089782d@mailslurp.com",
   "signInEmail2": "7ee68e7d-c48e-438c-8422-c09bfe264e13@mailslurp.com"
 }

--- a/cypress/support/step_definitions/sign-in.steps.js
+++ b/cypress/support/step_definitions/sign-in.steps.js
@@ -34,6 +34,7 @@ When('I have entered a correct email address and password and sign in', () => {
 
 Then('I am taken to your-voyages page', () => {
   cy.get('h1').should('have.text', 'Your voyages');
+  cy.get('main').find('h2').invoke('text').as('totalReport');
 });
 
 When('I have entered an email address for an unverified email address', () => {


### PR DESCRIPTION
Test added for NMSW-245 On GET drafts delete any without general declarations
----

## To test
```
npm run cypress:open:dev -- --env MAIL_API_KEY=<API_KEY>
```
Select fal1-upload-general-declaration.feature
