### PR TITLE
NMSW-610 Accept all success codes

### DIFF
--- a/src/pages/Voyage/VoyageCheckYourAnswers.jsx
+++ b/src/pages/Voyage/VoyageCheckYourAnswers.jsx
@@ -228,13 +228,11 @@ const VoyageCheckYourAnswers = () => {
     } else {
       try {
         setIsPendingSubmit(true);
-        const response = await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRESUBMITTED }, {
+        await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRESUBMITTED }, {
           headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
         });
-        if (response.status === 200) {
-          setShowConfirmation(true);
-          scrollToTop();
-        }
+        setShowConfirmation(true);
+        scrollToTop();
       } catch (err) {
         if (err?.response?.status === 422 || err?.response?.data?.msg === TOKEN_EXPIRED) {
           Auth.removeToken();
@@ -259,12 +257,10 @@ const VoyageCheckYourAnswers = () => {
     } else if (formData.formData.deleteVoyage === 'deleteVoyageYes') {
       setIsPendingSubmit(true);
       try {
-        const response = await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRECANCELLED }, {
+        await axios.patch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/${declarationId}`, { status: DECLARATION_STATUS_PRECANCELLED }, {
           headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
         });
-        if (response.status === 200) {
-          navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${declarationData.FAL1.nameOfShip} cancelled.` } } });
-        }
+        navigate(YOUR_VOYAGES_URL, { state: { confirmationBanner: { message: `Report for ${declarationData.FAL1.nameOfShip} cancelled.` } } });
       } catch (err) {
         if (err?.response?.status === 422 || err?.response?.data?.msg === TOKEN_EXPIRED) {
           Auth.removeToken();

--- a/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
+++ b/src/pages/Voyage/__tests__/VoyageCheckYourAnswers.test.jsx
@@ -1092,7 +1092,7 @@ describe('Voyage check your answers page', () => {
       })
       .reply(200, mockedFAL1And5Response)
       .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRESUBMITTED })
-      .reply(200, {
+      .reply(202, {
         id: '123',
         status: 'PreSubmitted',
         creationDate: '2023-04-17',
@@ -1643,7 +1643,7 @@ describe('Voyage check your answers page', () => {
         supporting: [],
       })
       .onPatch(`${API_URL}${ENDPOINT_DECLARATION_PATH}/123`, { status: DECLARATION_STATUS_PRECANCELLED })
-      .reply(200, {
+      .reply(202, {
         id: '123',
         status: 'PreSubmitted',
         creationDate: '2023-04-17',


### PR DESCRIPTION
# Ticket

As part of the fix for NMSW-610 (backend) the status codes returned for successful declaration status changes are being updated to 202 as this is more correct

----

## AC

Ensure FE app accepts and handles 202 as a success case

----

## To test

- create a voyage
- delete the draft
- > it should successfully delete
- > it should return user to the voyage list with a confirmation banner
- create a voyage
- submit the voyage
- > it should successfully change to 'PreSubmitted'
- > it should take user to confirmation page
- cancel the voyage
- > it should successfully change to 'PreCancelled'
- > it should return user to the voyage list with a confirmation banner


----

## Notes
The BE hasn't changed yet, however we were planning to move to generic success handling for our API responses so I've done that for the two PATCH scenarios here. I've updated the tests to return 202 in anticipation of BE change