### PR TITLE
NMSW-589 Refactor getting all declarations calls/error handling

### DIFF
--- a/src/pages/NavPages/YourVoyages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/YourVoyages/__tests__/YourVoyages.test.jsx
@@ -463,6 +463,30 @@ describe('Your voyages page tests', () => {
     });
   });
 
+  it('should display a message if getting the declarations returns a 500 error', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(500);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+
+    await screen.findByRole('heading', { name: 'Something has gone wrong' });
+    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Click here to continue' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Click here to continue' })).toHaveAttribute('href', YOUR_VOYAGES_URL);
+  });
+
+  it('should display a message if getting the declarations returns a 404 error', async () => {
+    mockAxios
+      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .reply(404);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+
+    await screen.findByRole('heading', { name: 'Something has gone wrong' });
+    expect(screen.getByRole('heading', { name: 'Something has gone wrong' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Click here to continue' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Click here to continue' })).toHaveAttribute('href', YOUR_VOYAGES_URL);
+  });
+
   it('should delete invalid draft declarations (no FAL 1)', async () => {
     mockAxios
       .onGet(CREATE_VOYAGE_ENDPOINT)

--- a/src/utils/API/handleAuthErrors.js
+++ b/src/utils/API/handleAuthErrors.js
@@ -1,0 +1,21 @@
+import { TOKEN_EXPIRED } from '../../constants/AppAPIConstants';
+import { SIGN_IN_URL } from '../../constants/AppUrlConstants';
+import Auth from '../Auth';
+
+const handleAuthErrors = ({ error, navigate, redirectUrl }) => {
+  let errorResponse;
+
+  if (error?.response?.status === 422) {
+    Auth.removeToken();
+    navigate(SIGN_IN_URL, { state: { redirectURL: redirectUrl } });
+  } else if (error?.response?.data?.msg === TOKEN_EXPIRED) {
+    Auth.removeToken();
+    navigate(SIGN_IN_URL, { state: { redirectURL: redirectUrl } });
+  } else {
+    errorResponse = error;
+  }
+
+  return errorResponse;
+};
+
+export default handleAuthErrors;

--- a/src/utils/API/useGetAllDeclarations.jsx
+++ b/src/utils/API/useGetAllDeclarations.jsx
@@ -1,0 +1,79 @@
+import axios from 'axios';
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  API_URL,
+  CREATE_VOYAGE_ENDPOINT,
+  ENDPOINT_DECLARATION_PATH,
+} from '../../constants/AppAPIConstants';
+import { YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
+import Auth from '../Auth';
+import handleAuthErrors from './handleAuthErrors';
+
+const useGetAllDeclarations = (url) => {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiData, setApiData] = useState(null);
+  const [serverError, setServerError] = useState(null);
+
+  const deleteInvalidDeclarations = async (id) => {
+    try {
+      const response = await axios({
+        method: 'delete',
+        url: `${API_URL}${ENDPOINT_DECLARATION_PATH}/${id}`,
+        headers: {
+          Authorization: `Bearer ${Auth.retrieveToken()}`,
+        },
+      });
+      return response.data;
+    } catch (error) {
+      handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
+      // when deleting we don't ever return an error message to the user, auth errors are handled others are ignored
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    setIsLoading(true);
+    const fetchData = async () => {
+      try {
+        const resp = await axios.get(CREATE_VOYAGE_ENDPOINT, {
+          signal,
+          headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+        });
+        const data = await resp?.data;
+
+        const results = [];
+        data.results.map((declaration) => {
+          if (declaration.departureFromUk !== null) {
+            results.push(declaration);
+          } else {
+            deleteInvalidDeclarations(declaration.id);
+          }
+          return results;
+        });
+
+        const sortByLatestFirst = results.sort((a, b) => dayjs(b.creationDate) - dayjs(a.creationDate));
+        setApiData(sortByLatestFirst);
+
+        setIsLoading(false);
+      } catch (error) {
+        if (error?.code === 'ERR_CANCELED') { return; }
+        const errorResponse = handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
+        setServerError({ status: errorResponse?.response?.status, message: errorResponse?.message }); // returned to user
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+    return () => { controller.abort(); };
+  }, [url]);
+
+  return { isLoading, apiData, serverError };
+};
+
+export default useGetAllDeclarations;


### PR DESCRIPTION
# Ticket

NMSW-589

----

## AC

Refactor api functions to reduce repetition / improve maintenance and readability

 - refactor get all declarations for a user out of the your voyages page
 - create a handler for Auth error responses from an API call so we only have to manage the redirects to sign in etc. in one place in future (will move other functions to using the handler in separate PRs)


----

## To test

- check you see all your voyages when logged in
- check that if you create a declaration but don't upload a general dec form that when you return to your voyages page it is deleted
- check that if you remove your auth token and try to load your voyages page you're redirected to sign in

----

## Notes
