### PR TITLE
NMSW-611 Pagination

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -113,6 +113,14 @@ body {
   text-decoration: none;
 }
 
+.govuk-pagination__next .govuk-button--text,
+.govuk-pagination__prev .govuk-button--text {
+  font-weight: 700;
+}
+.govuk-pagination__item--current .govuk-pagination__link {
+  color: govuk-colour("white");
+}
+
 .govuk-error-summary__list .govuk-button--text {
   color: $govuk-error-colour;
   font-weight: 700;

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -13,7 +13,7 @@ import createPaginationArray from './createPaginationArray';
 const Pagination = ({
   maxPageNumber,
   updatePagination,
-  getContent,
+  setPageNumber,
 }) => {
   const pageOnLoad = parseInt(sessionStorage.getItem(PAGINATION_PAGE_LABEL), 10) || 1;
   const [currentPage, setCurrentPage] = useState();
@@ -29,7 +29,7 @@ const Pagination = ({
     e.preventDefault();
     const calculatedNextPage = await calculatePaginationNextPageNumber({ clickType, clickedOnPageNumber, currentPage });
 
-    getContent({ pageNumber: calculatedNextPage });
+    setPageNumber({ pageNumber: calculatedNextPage });
     setCurrentPage(calculatedNextPage);
     sessionStorage.setItem(PAGINATION_PAGE_LABEL, calculatedNextPage);
 
@@ -107,5 +107,5 @@ export default Pagination;
 Pagination.propTypes = {
   maxPageNumber: PropTypes.number.isRequired,
   updatePagination: PropTypes.string.isRequired,
-  getContent: PropTypes.func.isRequired,
+  setPageNumber: PropTypes.func.isRequired,
 };

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ELLIPSIS,
+  PAGINATION_NEXT_LABEL,
+  PAGINATION_PAGE_LABEL,
+  PAGINATION_PREVIOUS_LABEL,
+} from '../../constants/AppConstants';
+import { scrollToTop } from '../../utils/ScrollToElement';
+import calculatePaginationNextPageNumber from './calculatePaginationNextPageNumber';
+import createPaginationArray from './createPaginationArray';
+
+const Pagination = ({
+  maxPageNumber,
+  updatePagination,
+  getContent,
+}) => {
+  const pageOnLoad = parseInt(sessionStorage.getItem(PAGINATION_PAGE_LABEL), 10) || 1;
+  const [currentPage, setCurrentPage] = useState();
+  const [pages, setPages] = useState();
+
+  const createPagination = async () => {
+    const pageArray = await createPaginationArray({ selectedPage: pageOnLoad, totalPages: maxPageNumber });
+    setCurrentPage(pageOnLoad);
+    setPages(pageArray);
+  };
+
+  const handlePaginationClick = async (e, { clickType, clickedOnPageNumber }) => {
+    e.preventDefault();
+    const calculatedNextPage = await calculatePaginationNextPageNumber({ clickType, clickedOnPageNumber, currentPage });
+
+    getContent({ pageNumber: calculatedNextPage });
+    setCurrentPage(calculatedNextPage);
+    sessionStorage.setItem(PAGINATION_PAGE_LABEL, calculatedNextPage);
+
+    scrollToTop();
+  };
+
+  useEffect(() => {
+    if (updatePagination) {
+      createPagination();
+    }
+  }, [updatePagination]);
+
+  if (!pages) { return null; }
+
+  return (
+    <nav className="govuk-pagination" role="navigation" aria-label="results">
+      {currentPage !== 1
+        && (
+          <div className="govuk-pagination__prev">
+            <button
+              type="button"
+              className="govuk-link govuk-button--text govuk-pagination__link"
+              onClick={(e) => handlePaginationClick(e, { clickType: PAGINATION_PREVIOUS_LABEL })}
+            >
+              <svg className="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z" />
+              </svg>
+              <span className="govuk-pagination__link-title">{PAGINATION_PREVIOUS_LABEL}</span>
+            </button>
+          </div>
+        )}
+      <ul className="govuk-pagination__list">
+        {pages.map((page) => (
+          <React.Fragment key={page.pageNumber}>
+            {!page.ellipses
+              && (
+                <li className={page.isCurrentPage ? 'govuk-pagination__item govuk-pagination__item--current' : 'govuk-pagination__item'}>
+                  <button
+                    type="button"
+                    className="govuk-link govuk-button--text govuk-pagination__link"
+                    onClick={(e) => handlePaginationClick(e, { clickType: PAGINATION_PAGE_LABEL, clickedOnPageNumber: page.pageNumber })}
+                  >
+                    {page.pageNumber}
+                  </button>
+                </li>
+              )}
+            {page.ellipses
+              && (
+                <li className="govuk-pagination__item govuk-pagination__item--ellipses">{ELLIPSIS}</li>
+              )}
+          </React.Fragment>
+        ))}
+      </ul>
+      {currentPage !== maxPageNumber
+        && (
+          <div className="govuk-pagination__next">
+            <button
+              type="button"
+              className="govuk-link govuk-button--text govuk-pagination__link"
+              onClick={(e) => handlePaginationClick(e, { clickType: PAGINATION_NEXT_LABEL })}
+            >
+              <span className="govuk-pagination__link-title">{PAGINATION_NEXT_LABEL}</span>
+              <svg className="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z" />
+              </svg>
+            </button>
+          </div>
+        )}
+    </nav>
+  );
+};
+
+export default Pagination;
+
+Pagination.propTypes = {
+  maxPageNumber: PropTypes.number.isRequired,
+  updatePagination: PropTypes.string.isRequired,
+  getContent: PropTypes.func.isRequired,
+};

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -12,7 +12,7 @@ import createPaginationArray from './createPaginationArray';
 
 const Pagination = ({
   maxPageNumber,
-  updatePagination,
+  updatePaginationPageNumber,
   setPageNumber,
 }) => {
   const pageOnLoad = parseInt(sessionStorage.getItem(PAGINATION_PAGE_LABEL), 10) || 1;
@@ -20,8 +20,10 @@ const Pagination = ({
   const [pages, setPages] = useState();
 
   const createPagination = async () => {
-    const pageArray = await createPaginationArray({ selectedPage: pageOnLoad, totalPages: maxPageNumber });
-    setCurrentPage(pageOnLoad);
+    const nextPageNumber = currentPage || pageOnLoad;
+    const pageArray = await createPaginationArray({ selectedPage: nextPageNumber, totalPages: maxPageNumber });
+
+    setCurrentPage(nextPageNumber);
     setPages(pageArray);
   };
 
@@ -37,13 +39,12 @@ const Pagination = ({
   };
 
   useEffect(() => {
-    if (updatePagination) {
+    if (updatePaginationPageNumber) {
       createPagination();
     }
-  }, [updatePagination]);
+  }, [updatePaginationPageNumber]);
 
   if (!pages) { return null; }
-
   return (
     <nav className="govuk-pagination" role="navigation" aria-label="results">
       {currentPage !== 1
@@ -106,6 +107,6 @@ export default Pagination;
 
 Pagination.propTypes = {
   maxPageNumber: PropTypes.number.isRequired,
-  updatePagination: PropTypes.string.isRequired,
+  updatePaginationPageNumber: PropTypes.number.isRequired,
   setPageNumber: PropTypes.func.isRequired,
 };

--- a/src/components/Pagination/__tests__/PaginationClick.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationClick.test.jsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { ELLIPSIS, PAGINATION_NEXT_LABEL, PAGINATION_PREVIOUS_LABEL } from '../../../constants/AppConstants';
+import { CREATE_VOYAGE_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { YOUR_VOYAGES_PAGE_NAME } from '../../../constants/AppUrlConstants';
+import YourVoyages from '../../../pages/NavPages/YourVoyages/YourVoyages';
+
+// Using YourVoyages to test the pagination rendering after a click as this
+// is the only parent page using pagination
+
+describe('Pagination clicks', () => {
+  const mockedResponse = {
+    results: [
+      {
+        id: 'e759592a-0126-4c3c-8515-cfe6c93f659c',
+        status: 'Draft',
+        creationDate: '2023-05-05T08:44:14.776324',
+        submissionDate: null,
+        nameOfShip: 'NMSW Test Ship',
+        imoNumber: '9999990',
+        callSign: 'C1234',
+        signatory: 'Auto Tester',
+        flagState: 'CAN',
+        departureFromUk: false,
+        departurePortUnlocode: 'USXXX',
+        departureDate: '2023-02-12',
+        departureTime: '13:00:00',
+        arrivalPortUnlocode: 'GBXXX',
+        arrivalDate: '2023-02-15',
+        arrivalTime: '12:00:00',
+        previousPortUnlocode: 'USXXX',
+        nextPortUnlocode: 'JPNXX',
+        cargo: 'No cargo',
+        passengers: true,
+        cbpId: null,
+        cbpResponse: null,
+        userId: '82a35d7f-9533-468f-aed8-34af107dde20',
+      },
+    ],
+    pagination: {
+      count: 639,
+      page: 1,
+      per_page: 100,
+      pages: 7,
+    },
+  };
+
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    mockAxios.reset();
+    window.sessionStorage.clear();
+  });
+
+  it('should render the pagination section of the page', async () => {
+    mockAxios
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
+      .reply(200, mockedResponse);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+  });
+
+  it('should go to the next page on next click', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
+      .reply(200, mockedResponse);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: PAGINATION_NEXT_LABEL }));
+    await screen.findByRole('button', { name: '3' });
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('2');
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent('3');
+  });
+
+  it('should go to the page clicked', async () => {
+    window.sessionStorage.setItem('Page', 5);
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=5`)
+      .reply(200, mockedResponse);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await screen.findByRole('button', { name: '3' });
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent('3');
+    expect(screen.getAllByRole('listitem')[3]).toHaveTextContent('4');
+    expect(screen.getAllByRole('listitem')[3].outerHTML).toEqual('<li class="govuk-pagination__item govuk-pagination__item--current"><button type="button" class="govuk-link govuk-button--text govuk-pagination__link">4</button></li>');
+    expect(screen.getAllByRole('listitem')[4]).toHaveTextContent('5');
+    expect(screen.getAllByRole('listitem')[5]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[6]).toHaveTextContent('7');
+  });
+
+  it('should go to previous page when previous clicked', async () => {
+    window.sessionStorage.setItem('Page', 7);
+    const user = userEvent.setup();
+    mockAxios
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=7`)
+      .reply(200, mockedResponse);
+    render(<MemoryRouter><YourVoyages /></MemoryRouter>);
+    expect(await screen.findByText(YOUR_VOYAGES_PAGE_NAME)).toBeInTheDocument();
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: PAGINATION_PREVIOUS_LABEL }));
+    await screen.findByRole('button', { name: '5' });
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent('5');
+    expect(screen.getAllByRole('listitem')[3]).toHaveTextContent('6');
+    expect(screen.getAllByRole('listitem')[3].outerHTML).toEqual('<li class="govuk-pagination__item govuk-pagination__item--current"><button type="button" class="govuk-link govuk-button--text govuk-pagination__link">6</button></li>');
+    expect(screen.getAllByRole('listitem')[4]).toHaveTextContent('7');
+  });
+});

--- a/src/components/Pagination/__tests__/PaginationSetup.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationSetup.test.jsx
@@ -22,7 +22,7 @@ describe('Pagination setup', () => {
   });
 
   it('should render multiple pages, 1, 2, max page number, and a next link if multiple returned', async () => {
-    const maxPageNumber = 10;
+    const maxPageNumber = 3;
     render(
       <Pagination
         maxPageNumber={maxPageNumber}
@@ -32,9 +32,13 @@ describe('Pagination setup', () => {
     );
 
     await screen.findByRole('button', { name: '1' });
+    expect(screen.getAllByRole('listitem').length).toBe(3);
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('2'); // current page is 1, we always show + & - 1 of current
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent('3');
     expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument(); // current page is 1, + 1 is 2
-    expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
   });
@@ -55,7 +59,35 @@ describe('Pagination setup', () => {
     expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('2'); // current page is 1, we always show + & - 1 of current
     expect(screen.getAllByRole('listitem')[2]).toHaveTextContent(ELLIPSIS);
     expect(screen.getAllByRole('listitem')[3]).toHaveTextContent('10');
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByText(ELLIPSIS)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('should render current page from session if exists on initial render', async () => {
+    window.sessionStorage.setItem('Page', 5);
+    const maxPageNumber = 10;
+    render(
+      <Pagination
+        maxPageNumber={maxPageNumber}
+        updatePagination="update"
+        setPageNumber={setPageNumber}
+      />,
+    );
+
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getAllByRole('listitem').length).toBe(7);
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent('4');
+    expect(screen.getAllByRole('listitem')[3]).toHaveTextContent('5');
+    expect(screen.getAllByRole('listitem')[4]).toHaveTextContent('6');
+    expect(screen.getAllByRole('listitem')[5]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[6]).toHaveTextContent('10');
+    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).toBeInTheDocument();
   });
 });

--- a/src/components/Pagination/__tests__/PaginationSetup.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationSetup.test.jsx
@@ -10,7 +10,7 @@ describe('Pagination setup', () => {
     render(
       <Pagination
         maxPageNumber={maxPageNumber}
-        updatePagination="update"
+        updatePaginationPageNumber="update"
         setPageNumber={setPageNumber}
       />,
     );
@@ -26,7 +26,7 @@ describe('Pagination setup', () => {
     render(
       <Pagination
         maxPageNumber={maxPageNumber}
-        updatePagination="update"
+        updatePaginationPageNumber="update"
         setPageNumber={setPageNumber}
       />,
     );
@@ -48,7 +48,7 @@ describe('Pagination setup', () => {
     render(
       <Pagination
         maxPageNumber={maxPageNumber}
-        updatePagination="update"
+        updatePaginationPageNumber="update"
         setPageNumber={setPageNumber}
       />,
     );
@@ -73,7 +73,7 @@ describe('Pagination setup', () => {
     render(
       <Pagination
         maxPageNumber={maxPageNumber}
-        updatePagination="update"
+        updatePaginationPageNumber="update"
         setPageNumber={setPageNumber}
       />,
     );

--- a/src/components/Pagination/__tests__/PaginationSetup.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationSetup.test.jsx
@@ -39,7 +39,7 @@ describe('Pagination setup', () => {
     expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
   });
 
@@ -63,7 +63,7 @@ describe('Pagination setup', () => {
     expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
     expect(screen.getByText(ELLIPSIS)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
   });
 
@@ -87,7 +87,7 @@ describe('Pagination setup', () => {
     expect(screen.getAllByRole('listitem')[4]).toHaveTextContent('6');
     expect(screen.getAllByRole('listitem')[5]).toHaveTextContent(ELLIPSIS);
     expect(screen.getAllByRole('listitem')[6]).toHaveTextContent('10');
-    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).toBeInTheDocument();
   });
 });

--- a/src/components/Pagination/__tests__/PaginationSetup.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationSetup.test.jsx
@@ -50,10 +50,11 @@ describe('Pagination setup', () => {
     );
 
     await screen.findByRole('button', { name: '1' });
-    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument(); // current page is 1, + 1 is 2
-    expect(screen.getByText(ELLIPSIS)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem').length).toBe(4);
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('1');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('2'); // current page is 1, we always show + & - 1 of current
+    expect(screen.getAllByRole('listitem')[2]).toHaveTextContent(ELLIPSIS);
+    expect(screen.getAllByRole('listitem')[3]).toHaveTextContent('10');
     expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
   });

--- a/src/components/Pagination/__tests__/PaginationSetup.test.jsx
+++ b/src/components/Pagination/__tests__/PaginationSetup.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { ELLIPSIS, PAGINATION_NEXT_LABEL, PAGINATION_PREVIOUS_LABEL } from '../../../constants/AppConstants';
+import Pagination from '../Pagination';
+
+describe('Pagination setup', () => {
+  const setPageNumber = jest.fn();
+
+  it('should render single page if only 1 returned', async () => {
+    const maxPageNumber = 1;
+    render(
+      <Pagination
+        maxPageNumber={maxPageNumber}
+        updatePagination="update"
+        setPageNumber={setPageNumber}
+      />,
+    );
+
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('should render multiple pages, 1, 2, max page number, and a next link if multiple returned', async () => {
+    const maxPageNumber = 10;
+    render(
+      <Pagination
+        maxPageNumber={maxPageNumber}
+        updatePagination="update"
+        setPageNumber={setPageNumber}
+      />,
+    );
+
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument(); // current page is 1, + 1 is 2
+    expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('should render ellipses for skipped pages', async () => {
+    const maxPageNumber = 10;
+    render(
+      <Pagination
+        maxPageNumber={maxPageNumber}
+        updatePagination="update"
+        setPageNumber={setPageNumber}
+      />,
+    );
+
+    await screen.findByRole('button', { name: '1' });
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument(); // current page is 1, + 1 is 2
+    expect(screen.getByText(ELLIPSIS)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '10' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_NEXT_LABEL })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PAGINATION_PREVIOUS_LABEL })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Pagination/calculatePaginationNextPageNumber.jsx
+++ b/src/components/Pagination/calculatePaginationNextPageNumber.jsx
@@ -1,0 +1,20 @@
+import { PAGINATION_NEXT_LABEL, PAGINATION_PAGE_LABEL, PAGINATION_PREVIOUS_LABEL } from '../../constants/AppConstants';
+
+const calculatePaginationNextPageNumber = ({ clickType, clickedOnPageNumber, currentPage }) => {
+  let nextPage;
+
+  switch (clickType) {
+    case PAGINATION_PAGE_LABEL: nextPage = clickedOnPageNumber;
+      break;
+    case PAGINATION_PREVIOUS_LABEL: nextPage = currentPage - 1;
+      break;
+    case PAGINATION_NEXT_LABEL: nextPage = currentPage + 1;
+      break;
+    default: nextPage = 1;
+  }
+
+  sessionStorage.setItem(PAGINATION_PAGE_LABEL, nextPage);
+  return nextPage;
+};
+
+export default calculatePaginationNextPageNumber;

--- a/src/components/Pagination/createPaginationArray.js
+++ b/src/components/Pagination/createPaginationArray.js
@@ -1,0 +1,32 @@
+const createPaginationArray = ({ selectedPage, totalPages }) => {
+  let ellipsesSet = false;
+  const pageArray = [];
+
+  for (let i = 1; i <= totalPages; i++) {
+    if (i === 1 || i === totalPages) {
+      pageArray.push({
+        pageNumber: i,
+        isCurrentPage: selectedPage === i,
+      });
+    } else if (i !== 1 && i !== totalPages) {
+      if (i === selectedPage || i === (selectedPage - 1) || i === (selectedPage + 1)) {
+        pageArray.push({
+          pageNumber: i,
+          isCurrentPage: selectedPage === i,
+        });
+        ellipsesSet = false;
+      } else if (!ellipsesSet) {
+        pageArray.push({
+          pageNumber: i,
+          ellipses: true,
+          isCurrentPage: selectedPage === i,
+        });
+        ellipsesSet = true;
+      }
+    }
+  }
+
+  return pageArray;
+};
+
+export default createPaginationArray;

--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -49,12 +49,17 @@ export const VALIDATE_MIN_LENGTH = 'minLength';
 export const VALIDATE_PHONE_NUMBER = 'phoneNumber';
 export const VALIDATE_REQUIRED = 'required';
 export const VALIDATE_NO_SPACES = 'noSpaces';
+
+// Pagination
+export const ELLIPSIS = '...';
+export const PAGINATION_PAGE_LABEL = 'Page';
+export const PAGINATION_PREVIOUS_LABEL = 'Previous';
+export const PAGINATION_NEXT_LABEL = 'Next';
+
 // Templates
 export const GENERAL_DECLARATION_TEMPLATE_NAME = 'General Declaration (FAL 1)';
 export const CREW_DETAILS_TEMPLATE_NAME = 'Crew details including supernumeraries (FAL 5)';
 export const PASSENGER_DETAILS_TEMPLATE_NAME = 'Passenger details (FAL 6)';
-
-// Templates
 export const GENERAL_DECLARATION_LABEL = 'General Declaration (FAL 1)';
 export const CREW_DETAILS_LABEL = 'Crew details including supernumeraries (FAL 5)';
 export const PASSENGER_DETAILS_LABEL = 'Any passenger details (FAL 6)';

--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -94,6 +94,8 @@ const Nav = () => {
     } catch (err) {
       Auth.logout();
       navigate(SIGN_IN_URL);
+    } finally {
+      sessionStorage.removeItem('page'); // removes the page stored so when user signs in it reverts to page 1
     }
   };
 

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -28,6 +28,9 @@ const YourVoyages = () => {
   const [notification, setNotification] = useState({});
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [maxPageNumber, setMaxPageNumber] = useState();
+  const [updatePagination, setUpdatePagination] = useState();
+  const [totalNumberVoyages, setTotalNumberVoyages] = useState();
   const [voyageData, setVoyageData] = useState();
   const apiResponse = useGetAllDeclarations();
 
@@ -71,6 +74,9 @@ const YourVoyages = () => {
     setIsLoading(true);
     if (apiResponse?.apiData) {
       setVoyageData(apiResponse.apiData);
+      setMaxPageNumber(apiResponse.paginationData?.pages);
+      setTotalNumberVoyages(apiResponse.paginationData?.count);
+      setUpdatePagination('update');
       setIsLoading(apiResponse.isLoading);
     } else if (apiResponse?.error) {
       setIsError(true);
@@ -85,7 +91,7 @@ const YourVoyages = () => {
   }
 
   if (isLoading) { return (<LoadingSpinner />); }
-
+  console.log('p', maxPageNumber, updatePagination, totalNumberVoyages);
   return (
     <>
       <div className="govuk-grid-row">

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -15,6 +15,7 @@ import Message from '../../../components/Message';
 import Auth from '../../../utils/Auth';
 import useGetAllDeclarations from '../../../utils/API/useGetAllDeclarations';
 import YourVoyagesDisplay from './YourVoyagesDisplay';
+import Pagination from '../../../components/Pagination/Pagination';
 
 // NOTES:
 // - The filter buttons do nothing
@@ -29,10 +30,11 @@ const YourVoyages = () => {
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [maxPageNumber, setMaxPageNumber] = useState();
+  const [pageNumber, setPageNumber] = useState();
   const [updatePagination, setUpdatePagination] = useState();
   const [totalNumberVoyages, setTotalNumberVoyages] = useState();
   const [voyageData, setVoyageData] = useState();
-  const apiResponse = useGetAllDeclarations({ pageNumber: 1 });
+  const apiResponse = useGetAllDeclarations({ pageNumber });
 
   document.title = SERVICE_NAME;
 
@@ -134,10 +136,19 @@ const YourVoyages = () => {
       </div>
 
       {voyageData?.length > 0 && (
-        <YourVoyagesDisplay
-          voyageData={voyageData}
-          totalVoyages={totalNumberVoyages}
-        />
+        <>
+          <YourVoyagesDisplay
+            voyageData={voyageData}
+            totalVoyages={totalNumberVoyages}
+          />
+
+          <Pagination
+            maxPageNumber={maxPageNumber}
+            updatePagination={updatePagination}
+            // getContent={useGetAllDeclarations}
+            setPageNumber={setPageNumber}
+          />
+        </>
       )}
     </>
   );

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -72,7 +72,7 @@ const YourVoyages = () => {
     if (apiResponse?.apiData) {
       setVoyageData(apiResponse.apiData);
       setIsLoading(apiResponse.isLoading);
-    } else if (apiResponse?.serverError) {
+    } else if (apiResponse?.error) {
       setIsError(true);
       setIsLoading(apiResponse.isLoading);
     }

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -91,7 +91,7 @@ const YourVoyages = () => {
   }
 
   if (isLoading) { return (<LoadingSpinner />); }
-  console.log('p', maxPageNumber, updatePagination, totalNumberVoyages);
+
   return (
     <>
       <div className="govuk-grid-row">
@@ -116,7 +116,7 @@ const YourVoyages = () => {
             </div>
           )}
           <h1 className="govuk-heading-xl govuk-!-margin-bottom-4">Your voyages</h1>
-          {voyageData?.length === 0 && (
+          {!totalNumberVoyages && (
             <div className="govuk-inset-text">
               <p className="govuk-body">You have not reported any voyages yet</p>
             </div>
@@ -136,6 +136,7 @@ const YourVoyages = () => {
       {voyageData?.length > 0 && (
         <YourVoyagesDisplay
           voyageData={voyageData}
+          totalVoyages={totalNumberVoyages}
         />
       )}
     </>

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -32,7 +32,7 @@ const YourVoyages = () => {
   const [updatePagination, setUpdatePagination] = useState();
   const [totalNumberVoyages, setTotalNumberVoyages] = useState();
   const [voyageData, setVoyageData] = useState();
-  const apiResponse = useGetAllDeclarations();
+  const apiResponse = useGetAllDeclarations({ pageNumber: 1 });
 
   document.title = SERVICE_NAME;
 

--- a/src/pages/NavPages/YourVoyages/YourVoyages.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyages.jsx
@@ -31,7 +31,6 @@ const YourVoyages = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [maxPageNumber, setMaxPageNumber] = useState();
   const [pageNumber, setPageNumber] = useState();
-  const [updatePagination, setUpdatePagination] = useState();
   const [totalNumberVoyages, setTotalNumberVoyages] = useState();
   const [voyageData, setVoyageData] = useState();
   const apiResponse = useGetAllDeclarations({ pageNumber });
@@ -78,7 +77,6 @@ const YourVoyages = () => {
       setVoyageData(apiResponse.apiData);
       setMaxPageNumber(apiResponse.paginationData?.pages);
       setTotalNumberVoyages(apiResponse.paginationData?.count);
-      setUpdatePagination('update');
       setIsLoading(apiResponse.isLoading);
     } else if (apiResponse?.error) {
       setIsError(true);
@@ -144,8 +142,7 @@ const YourVoyages = () => {
 
           <Pagination
             maxPageNumber={maxPageNumber}
-            updatePagination={updatePagination}
-            // getContent={useGetAllDeclarations}
+            updatePaginationPageNumber={pageNumber || 1}
             setPageNumber={setPageNumber}
           />
         </>

--- a/src/pages/NavPages/YourVoyages/YourVoyagesDisplay.jsx
+++ b/src/pages/NavPages/YourVoyages/YourVoyagesDisplay.jsx
@@ -7,7 +7,7 @@ import {
   DECLARATION_STATUS_CANCELLED, DECLARATION_STATUS_DRAFT, DECLARATION_STATUS_FAILED, DECLARATION_STATUS_PRECANCELLED, DECLARATION_STATUS_PRESUBMITTED, DECLARATION_STATUS_SUBMITTED,
 } from '../../../constants/AppConstants';
 
-const YourVoyagesDisplay = ({ voyageData }) => {
+const YourVoyagesDisplay = ({ totalVoyages, voyageData }) => {
   const getActionButtontext = (status) => {
     let actionText;
     switch (status) {
@@ -108,7 +108,7 @@ const YourVoyagesDisplay = ({ voyageData }) => {
         <div className="govuk-grid-column-full">
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-full">
-              <h2 className="govuk-heading-s govuk-!-margin-bottom-1 reported-voyages-margin--top">{`${voyageData.length} reported voyages`}</h2>
+              <h2 className="govuk-heading-s govuk-!-margin-bottom-1 reported-voyages-margin--top">{`${totalVoyages} reported voyages`}</h2>
               <div className="facet-tags__container dark-grey__border">
                 <div className="facet-tags__group">
                   <div className="facet-tags__wrapper">
@@ -203,5 +203,6 @@ const YourVoyagesDisplay = ({ voyageData }) => {
 export default YourVoyagesDisplay;
 
 YourVoyagesDisplay.propTypes = {
+  totalVoyages: PropTypes.number,
   voyageData: PropTypes.array,
 };

--- a/src/pages/NavPages/YourVoyages/__tests__/YourVoyages.test.jsx
+++ b/src/pages/NavPages/YourVoyages/__tests__/YourVoyages.test.jsx
@@ -36,7 +36,7 @@ describe('Your voyages page tests', () => {
 
   it('should render the page with the Your Voyages as a H1', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       });
@@ -46,7 +46,7 @@ describe('Your voyages page tests', () => {
 
   it('should display a "Report a voyage" button', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       });
@@ -56,7 +56,7 @@ describe('Your voyages page tests', () => {
 
   it('should show a no voyages message if no voyages', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       });
@@ -67,7 +67,7 @@ describe('Your voyages page tests', () => {
 
   it('should render a draft voyage with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -106,7 +106,7 @@ describe('Your voyages page tests', () => {
 
   it('should render submitted report with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -144,7 +144,7 @@ describe('Your voyages page tests', () => {
 
   it('should render presubmitted report with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -182,7 +182,7 @@ describe('Your voyages page tests', () => {
 
   it('should render cancelled report with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -220,7 +220,7 @@ describe('Your voyages page tests', () => {
 
   it('should render precancelled report with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -258,7 +258,7 @@ describe('Your voyages page tests', () => {
 
   it('should render failed reports with correct tag and link', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -296,7 +296,7 @@ describe('Your voyages page tests', () => {
 
   it('should default to a review status if no status/unknown is received (should not happen but it is our catchall incase of changes)', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -334,7 +334,7 @@ describe('Your voyages page tests', () => {
 
   it('should render all reports recieved ordered by latest first', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -454,7 +454,7 @@ describe('Your voyages page tests', () => {
 
   it('should redirect to sign in if getting the declarations returns a 422', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(422, { msg: 'Not enough segments' });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
 
@@ -465,7 +465,7 @@ describe('Your voyages page tests', () => {
 
   it('should display a message if getting the declarations returns a 500 error', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(500);
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
 
@@ -477,7 +477,7 @@ describe('Your voyages page tests', () => {
 
   it('should display a message if getting the declarations returns a 404 error', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(404);
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
 
@@ -489,7 +489,7 @@ describe('Your voyages page tests', () => {
 
   it('should delete invalid draft declarations (no FAL 1)', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -553,7 +553,7 @@ describe('Your voyages page tests', () => {
 
   it('should still only show valid reports if delete call fails', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -616,7 +616,7 @@ describe('Your voyages page tests', () => {
 
   it('should redirect to sign in if getting the declarations returns a 401 token expired', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(401, { msg: TOKEN_EXPIRED });
     render(<MemoryRouter><YourVoyages /></MemoryRouter>);
 
@@ -628,7 +628,7 @@ describe('Your voyages page tests', () => {
   it('should continue to General Declaration page if Report a voyage button click successful', async () => {
     const user = userEvent.setup();
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       })
@@ -664,7 +664,7 @@ describe('Your voyages page tests', () => {
   it('should redirect to sign in if Report a voyage button click returns a 422', async () => {
     const user = userEvent.setup();
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       })
@@ -680,7 +680,7 @@ describe('Your voyages page tests', () => {
   it('should redirect to sign in if Report a voyage button click returns a 401 token expired', async () => {
     const user = userEvent.setup();
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       })
@@ -696,7 +696,7 @@ describe('Your voyages page tests', () => {
 
   it('should sign user out if delete request returns a 422', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -758,7 +758,7 @@ describe('Your voyages page tests', () => {
 
   it('should still only show valid reports if delete call returns token expired', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [
           {
@@ -821,7 +821,7 @@ describe('Your voyages page tests', () => {
   it('should show error message is 500 response received', async () => {
     const user = userEvent.setup();
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       })
@@ -846,7 +846,7 @@ describe('Your voyages page tests', () => {
       },
     };
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       });
@@ -860,7 +860,7 @@ describe('Your voyages page tests', () => {
 
   it('should NOT show a notification banner if state does NOT contain confirmationBanner and a message', async () => {
     mockAxios
-      .onGet(CREATE_VOYAGE_ENDPOINT)
+      .onGet(`${CREATE_VOYAGE_ENDPOINT}?page=1`)
       .reply(200, {
         results: [],
       });

--- a/src/utils/API/useGetAllDeclarations.jsx
+++ b/src/utils/API/useGetAllDeclarations.jsx
@@ -32,7 +32,7 @@ const useGetAlLDeclarations = ({ pageNumber }) => {
       return response.data;
     } catch (err) {
       handleAuthErrors({ error: err, navigate, redirectUrl: YOUR_VOYAGES_URL });
-      // when deleting we don't
+      // when deleting here we don't show the user an error as it's unnecessary
     }
     return null;
   };

--- a/src/utils/API/useGetAllDeclarations.jsx
+++ b/src/utils/API/useGetAllDeclarations.jsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { PAGINATION_PAGE_LABEL } from '../../constants/AppConstants';
 import {
   API_URL,
   CREATE_VOYAGE_ENDPOINT,
@@ -11,8 +12,9 @@ import { YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
 import Auth from '../Auth';
 import handleAuthErrors from './handleAuthErrors';
 
-const useGetAlLDeclarations = (pageNumber) => {
+const useGetAlLDeclarations = ({ pageNumber }) => {
   const navigate = useNavigate();
+  const pageOnLoad = parseInt(sessionStorage.getItem(PAGINATION_PAGE_LABEL), 10) || 1;
   const [isLoading, setIsLoading] = useState(false);
   const [apiData, setApiData] = useState();
   const [paginationData, setPaginationData] = useState();
@@ -38,11 +40,12 @@ const useGetAlLDeclarations = (pageNumber) => {
   useEffect(() => {
     const controller = new AbortController();
     const { signal } = controller;
+    const pageToUse = pageNumber || pageOnLoad;
 
     setIsLoading(true);
     const fetchData = async () => {
       try {
-        const resp = await axios.get(CREATE_VOYAGE_ENDPOINT, {
+        const resp = await axios.get(`${CREATE_VOYAGE_ENDPOINT}?page=${pageToUse}`, {
           signal,
           headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
         });

--- a/src/utils/API/useGetAllDeclarations.jsx
+++ b/src/utils/API/useGetAllDeclarations.jsx
@@ -6,16 +6,18 @@ import {
   API_URL,
   CREATE_VOYAGE_ENDPOINT,
   ENDPOINT_DECLARATION_PATH,
+  TOKEN_EXPIRED,
 } from '../../constants/AppAPIConstants';
-import { YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
+import { SIGN_IN_URL, YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
 import Auth from '../Auth';
 import handleAuthErrors from './handleAuthErrors';
 
-const useGetAllDeclarations = (url) => {
+const useGetAlLDeclarations = (url) => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
-  const [apiData, setApiData] = useState(null);
-  const [serverError, setServerError] = useState(null);
+  const [apiData, setApiData] = useState();
+  const [paginationData, setPaginationData] = useState();
+  const [error, setError] = useState();
 
   const deleteInvalidDeclarations = async (id) => {
     try {
@@ -29,7 +31,7 @@ const useGetAllDeclarations = (url) => {
       return response.data;
     } catch (error) {
       handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
-      // when deleting we don't ever return an error message to the user, auth errors are handled others are ignored
+      // when deleting we don't
     }
     return null;
   };
@@ -64,7 +66,7 @@ const useGetAllDeclarations = (url) => {
       } catch (error) {
         if (error?.code === 'ERR_CANCELED') { return; }
         const errorResponse = handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
-        setServerError({ status: errorResponse?.response?.status, message: errorResponse?.message }); // returned to user
+        setError({ status: errorResponse?.response?.status, message: errorResponse?.message });
         setIsLoading(false);
       }
     };
@@ -73,7 +75,7 @@ const useGetAllDeclarations = (url) => {
     return () => { controller.abort(); };
   }, [url]);
 
-  return { isLoading, apiData, serverError };
+  return { apiData, error, isLoading, paginationData };
 };
 
-export default useGetAllDeclarations;
+export default useGetAlLDeclarations;

--- a/src/utils/API/useGetAllDeclarations.jsx
+++ b/src/utils/API/useGetAllDeclarations.jsx
@@ -6,13 +6,12 @@ import {
   API_URL,
   CREATE_VOYAGE_ENDPOINT,
   ENDPOINT_DECLARATION_PATH,
-  TOKEN_EXPIRED,
 } from '../../constants/AppAPIConstants';
-import { SIGN_IN_URL, YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
+import { YOUR_VOYAGES_URL } from '../../constants/AppUrlConstants';
 import Auth from '../Auth';
 import handleAuthErrors from './handleAuthErrors';
 
-const useGetAlLDeclarations = (url) => {
+const useGetAlLDeclarations = (pageNumber) => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [apiData, setApiData] = useState();
@@ -29,8 +28,8 @@ const useGetAlLDeclarations = (url) => {
         },
       });
       return response.data;
-    } catch (error) {
-      handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
+    } catch (err) {
+      handleAuthErrors({ error: err, navigate, redirectUrl: YOUR_VOYAGES_URL });
       // when deleting we don't
     }
     return null;
@@ -61,11 +60,12 @@ const useGetAlLDeclarations = (url) => {
 
         const sortByLatestFirst = results.sort((a, b) => dayjs(b.creationDate) - dayjs(a.creationDate));
         setApiData(sortByLatestFirst);
+        setPaginationData(resp.data.pagination);
 
         setIsLoading(false);
-      } catch (error) {
-        if (error?.code === 'ERR_CANCELED') { return; }
-        const errorResponse = handleAuthErrors({ error, navigate, redirectUrl: YOUR_VOYAGES_URL });
+      } catch (err) {
+        if (err?.code === 'ERR_CANCELED') { return; }
+        const errorResponse = handleAuthErrors({ error: err, navigate, redirectUrl: YOUR_VOYAGES_URL });
         setError({ status: errorResponse?.response?.status, message: errorResponse?.message });
         setIsLoading(false);
       }
@@ -73,9 +73,11 @@ const useGetAlLDeclarations = (url) => {
 
     fetchData();
     return () => { controller.abort(); };
-  }, [url]);
+  }, [pageNumber]);
 
-  return { apiData, error, isLoading, paginationData };
+  return {
+    apiData, error, isLoading, paginationData,
+  };
 };
 
 export default useGetAlLDeclarations;


### PR DESCRIPTION
# Ticket
NMSW-618 (FE) of NMSW-611


----

## AC

GIVEN there are less than 100 records for the user
WHEN they view the pagination section
THEN only page 1 is shown
 
GIVEN there are more than 100 records for the user
WHEN the result displayed
THEN there 100 records per page
AND a page link for each 100 records

GIVEN there is at least one voyage (of any status)
WHEN you are viewing page 1
THEN the 'Previous' link is hidden
GIVEN you are viewing the last page
THEN the 'next' link is hidden

GIVEN the voyages are displayed as paginated pages
WHEN there are more than 3 pages
THEN page 1 is always shown
AND the last page number is always shown
AND the page number I am on is shown
AND the page numbers to the left and right of the page I am on are shown
AND ellipses replace in any missing page numbers

GIVEN I am viewing on a small screen
THEN the 'show numbers either side of current page' rule does not apply
AND I see only Previous (if not page 1), Next (if not last page), and the page number I am on

----

## To test

For an account with 0 voyages
- > there should be no pagination

For an account with <= 100 voyages
- > there should only be a `1` link

For an account with up to > 100 voyages and < 400
- > there should be a `1`, `2`, `3`, `Next` link
- click on `3`
- > there should now be `Previous`, `1`, `2`, `3` and no next link

For accounts with > 600 voyages (speak to Jen to borrow her login if you need)
- > there should be `1`, `2`, `...`, `10`, `Next`
- click on next until you reach page 5
- there should be `Previous`, `1`, `...`, `4`, `5`, `6`, `...`, `10`, `Next`

----

## Notes
