### PR TITLE
NMSW-856 Remove link to create account, enable direct URL to create account

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -102,13 +102,14 @@ describe('App tests', () => {
     expect(screen.queryByText('Back')).not.toBeInTheDocument();
   });
 
-  it('should render a back button on /email-address page', async () => {
-    const user = userEvent.setup();
-    render(<MemoryRouter><App /></MemoryRouter>);
+  // We are not linking to this page from the UI in closed beta
+  // it('should render a back button on /email-address page', async () => {
+  //   const user = userEvent.setup();
+  //   render(<MemoryRouter><App /></MemoryRouter>);
 
-    await user.click(screen.getByRole('link', { name: 'create an account' }));
-    expect(screen.queryByText('Back')).toBeInTheDocument();
-  });
+  //   await user.click(screen.getByRole('link', { name: 'create an account' }));
+  //   expect(screen.queryByText('Back')).toBeInTheDocument();
+  // });
 
   it('should clear formData when a footer item is clicked', async () => {
     const user = userEvent.setup();

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { SERVICE_CONTACT_EMAIL, SERVICE_NAME } from '../../constants/AppConstants';
 import {
   YOUR_VOYAGES_URL,
-  REGISTER_ACCOUNT_URL,
+  // REGISTER_ACCOUNT_URL,
   SIGN_IN_URL,
 } from '../../constants/AppUrlConstants';
 import useUserIsPermitted from '../../hooks/useUserIsPermitted';
@@ -27,7 +27,7 @@ const Landing = () => {
             You do not need to submit any FAL forms that you send to other UK authorities, such as the Consolidated European Reporting System, CERS.
           </p>
         </div>
-        <p className="govuk-body" data-testid="createAccountParagraph">You&apos;ll also need to sign in or <Link to={REGISTER_ACCOUNT_URL}>create an account</Link> to use this service</p>
+        {/* <p className="govuk-body" data-testid="createAccountParagraph">You&apos;ll also need to sign in or <Link to={REGISTER_ACCOUNT_URL}>create an account</Link> to use this service</p> */}
         <Link
           to={isAuthenticated ? YOUR_VOYAGES_URL : SIGN_IN_URL}
           role="button"

--- a/src/pages/Landing/Landing.test.jsx
+++ b/src/pages/Landing/Landing.test.jsx
@@ -68,11 +68,12 @@ describe('Landing page tests', () => {
     expect(DownloadFile).toHaveBeenCalledWith('assets/files/Passenger details FAL 6.xlsx', 'Passenger details FAL 6.xlsx');
   });
 
-  it('should include a link to create an account', async () => {
-    render(<MemoryRouter><Landing /></MemoryRouter>);
-    // eslint-disable-next-line max-len
-    expect(screen.getByTestId('createAccountParagraph').outerHTML).toEqual('<p class="govuk-body" data-testid="createAccountParagraph">You\'ll also need to sign in or <a href="/create-account/email-address">create an account</a> to use this service</p>');
-  });
+  // We will not show the link during closed beta testing
+  // it('should include a link to create an account', async () => {
+  //   render(<MemoryRouter><Landing /></MemoryRouter>);
+  //   // eslint-disable-next-line max-len
+  //   expect(screen.getByTestId('createAccountParagraph').outerHTML).toEqual('<p class="govuk-body" data-testid="createAccountParagraph">You\'ll also need to sign in or <a href="/create-account/email-address">create an account</a> to use this service</p>');
+  // });
 
   it('should should have a start now button that includes the > and links to the sign-in page', async () => {
     render(<MemoryRouter><Landing /></MemoryRouter>);

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -17,7 +17,7 @@ import {
 import {
   LOGGED_IN_LANDING,
   MESSAGE_URL,
-  REGISTER_ACCOUNT_URL,
+  // REGISTER_ACCOUNT_URL,
   REGISTER_EMAIL_RESEND_URL,
   REQUEST_PASSWORD_RESET_URL,
   SIGN_IN_URL,
@@ -27,13 +27,13 @@ import Auth from '../../utils/Auth';
 import { scrollToTop } from '../../utils/ScrollToElement';
 import Message from '../../components/Message';
 
-const SupportingText = () => (
-  <div className="govuk-inset-text">
-    <p className="govuk-body">
-      If you do not have an account, you can <Link className="govuk-link" to={REGISTER_ACCOUNT_URL}>create one now</Link>.
-    </p>
-  </div>
-);
+// const SupportingText = () => (
+//   <div className="govuk-inset-text">
+//     <p className="govuk-body">
+//       If you do not have an account, you can <Link className="govuk-link" to={REGISTER_ACCOUNT_URL}>create one now</Link>.
+//     </p>
+//   </div>
+// );
 
 const SignIn = () => {
   const navigate = useNavigate();
@@ -155,9 +155,9 @@ const SignIn = () => {
         keepSessionOnSubmit={state?.redirectURL}
         handleSubmit={handleSubmit}
         removeApiErrors={removeApiErrors}
-      >
-        <SupportingText />
-      </DisplayForm>
+      />
+      {/* <SupportingText />
+      </DisplayForm> */}
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h2 className="govuk-heading-m">Problems signing in</h2>

--- a/src/pages/SignIn/__tests__/SignIn.test.jsx
+++ b/src/pages/SignIn/__tests__/SignIn.test.jsx
@@ -46,11 +46,12 @@ describe('Sign in tests', () => {
     expect(screen.getByRole('textbox', { name: /email/i }).outerHTML).toEqual('<input class="govuk-input" id="email-input" name="email" type="email" autocomplete="email" value="">');
   });
 
-  it('should display a link to create account', () => {
-    render(<MemoryRouter><SignIn /></MemoryRouter>);
-    expect(screen.getByText('create one now')).toBeInTheDocument();
-    expect(screen.getByText('create one now').outerHTML).toEqual('<a class="govuk-link" href="/create-account/email-address">create one now</a>');
-  });
+  // Currently we are not showing any link to create an account
+  // it('should display a link to create account', () => {
+  //   render(<MemoryRouter><SignIn /></MemoryRouter>);
+  //   expect(screen.getByText('create one now')).toBeInTheDocument();
+  //   expect(screen.getByText('create one now').outerHTML).toEqual('<a class="govuk-link" href="/create-account/email-address">create one now</a>');
+  // });
 
   it('should display an input field for password', () => {
     render(<MemoryRouter><SignIn /></MemoryRouter>);


### PR DESCRIPTION
# Ticket



----

## AC

- remove 'create account' link from sign in page
- enable user going directly to `/create-account/email-address`

----

## To test

- go to `/create-account/email-address` you should get the create account page
- > you should be able to sign up
- go to sign in page
- > there should be no create account link

----

## Notes
