### PR TITLE
NMSW-869 Handle password reset to update user account

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -40,3 +40,4 @@ export const USER_AWAITING_VERIFICATION = 'User is awaiting verification';
 export const USER_NOT_REGISTERED = 'User is not registered';
 export const USER_NOT_VERIFIED = 'User not verified, please verify registration';
 export const USER_SIGN_IN_DETAILS_INVALID = 'Email or password invalid';
+export const USER_MUST_UPDATE_PASSWORD = 'To use this service you will need to create a new password';

--- a/src/pages/NavPages/YourDetails/YourDetails.jsx
+++ b/src/pages/NavPages/YourDetails/YourDetails.jsx
@@ -136,7 +136,7 @@ const YourDetails = () => {
               <br />
               <p className="govuk-body">
                 {/* This version not used for MVP: <Link className="govuk-link" to={CHANGE_YOUR_PASSWORD_PAGE_URL}>Change your password</Link> */}
-                <Link to={REQUEST_PASSWORD_RESET_URL} state={{ title: 'Change your password' }}>Change your password</Link>
+                <Link to={REQUEST_PASSWORD_RESET_URL} state={{ resetPasswordTitle: 'Change your password' }}>Change your password</Link>
               </p>
             </dt>
             {/* Not available for MVP */}

--- a/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
+++ b/src/pages/NavPages/YourDetails/__tests__/YourDetails.test.jsx
@@ -181,7 +181,7 @@ describe('Your details tests', () => {
     await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
     await user.click(screen.getByRole('link', { name: 'Change your password' }));
     expect(mockedUseNavigate).toHaveBeenCalledWith('/forgotten-password', {
-      preventScrollReset: undefined, relative: undefined, replace: false, state: { title: 'Change your password' },
+      preventScrollReset: undefined, relative: undefined, replace: false, state: { resetPasswordTitle: 'Change your password' },
     });
   });
 });

--- a/src/pages/SignIn/RequestPasswordReset.jsx
+++ b/src/pages/SignIn/RequestPasswordReset.jsx
@@ -106,7 +106,7 @@ const RequestPasswordReset = () => {
       formActions={formActions}
       formType={SINGLE_PAGE_FORM}
       isLoading={isLoading}
-      pageHeading={state?.title || 'Forgot password'}
+      pageHeading={state?.resetPasswordTitle || 'Forgot password'}
       handleSubmit={handleSubmit}
     >
       <SupportingText />

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -107,6 +107,7 @@ const SignIn = () => {
           {
             title: 'Service update',
             message: "To continue to use the service, please reset your password. Any voyage reports you've saved will not be affected.",
+            linkText: 'Reset password',
             redirectURL: REQUEST_PASSWORD_RESET_URL,
             resetPasswordTitle: 'Reset password',
           },

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../constants/AppConstants';
 import {
   SIGN_IN_ENDPOINT,
+  USER_MUST_UPDATE_PASSWORD,
   USER_NOT_VERIFIED,
   USER_SIGN_IN_DETAILS_INVALID,
 } from '../../constants/AppAPIConstants';
@@ -100,6 +101,16 @@ const SignIn = () => {
       } else if (err?.response?.data?.message === USER_NOT_VERIFIED) {
         setIsNotActivated(true);
         scrollToTop();
+      } else if (err?.response?.data?.message === USER_MUST_UPDATE_PASSWORD) {
+        navigate(MESSAGE_URL, {
+          state:
+          {
+            title: 'Service update',
+            message: "To continue to use the service, please reset your password. Any voyage reports you've saved will not be affected.",
+            redirectURL: REQUEST_PASSWORD_RESET_URL,
+            resetPasswordTitle: 'Reset password',
+          },
+        });
       } else {
         navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: SIGN_IN_URL } });
       }

--- a/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
+++ b/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
@@ -7,10 +7,13 @@ import RequestPasswordReset from '../RequestPasswordReset';
 import { PASSSWORD_RESET_ENDPOINT } from '../../../constants/AppAPIConstants';
 import { MESSAGE_URL, REQUEST_PASSWORD_RESET_CONFIRMATION_URL, REQUEST_PASSWORD_RESET_URL } from '../../../constants/AppUrlConstants';
 
+let mockUseLocationState = {};
+
 const mockedUseNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => mockUseLocationState),
 }));
 
 describe('Request password reset tests', () => {
@@ -20,6 +23,7 @@ describe('Request password reset tests', () => {
   window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
   beforeEach(() => {
+    mockUseLocationState = {};
     mockAxios.reset();
     window.sessionStorage.clear();
   });
@@ -27,6 +31,12 @@ describe('Request password reset tests', () => {
   it('should render h1', async () => {
     render(<MemoryRouter><RequestPasswordReset /></MemoryRouter>);
     expect(screen.getByText('Forgot password')).toBeInTheDocument();
+  });
+
+  it('should render h1 to state if there is a resetPasswordTitle in state', async () => {
+    mockUseLocationState = { state: { resetPasswordTitle: 'Reset password' } };
+    render(<MemoryRouter><RequestPasswordReset /></MemoryRouter>);
+    expect(screen.getByText('Reset password')).toBeInTheDocument();
   });
 
   it('should render an intro inset', async () => {

--- a/src/pages/SignIn/__tests__/SignIn.test.jsx
+++ b/src/pages/SignIn/__tests__/SignIn.test.jsx
@@ -308,6 +308,7 @@ describe('Sign in tests', () => {
       {
         title: 'Service update',
         message: "To continue to use the service, please reset your password. Any voyage reports you've saved will not be affected.",
+        linkText: 'Reset password',
         redirectURL: REQUEST_PASSWORD_RESET_URL,
         resetPasswordTitle: 'Reset password',
       },


### PR DESCRIPTION
# Ticket

NMSW-869

----

## AC

There has been a service update so some users will need to change their password to update their account. This ticket is to make the flow easier to follow to allow users to access their accounts again.

----

## To test

- Run app
- Ask Adèle for details of an account that needs updating
- Try to sign in
- > You should be taken to a message page with a service update
- Click the link 
- > You should be taken to the password reset page with a title of 'Reset password' (don't actually change the password though!)

----

## Notes
