### PR TITLE
NMSW-863 Update sign out

### DIFF
--- a/src/layout/Nav.jsx
+++ b/src/layout/Nav.jsx
@@ -86,7 +86,7 @@ const Nav = () => {
   const handleSignOut = async () => {
     try {
       const response = await axios.post(SIGN_OUT_ENDPOINT, {}, {
-        headers: { Authorization: `Bearer ${Auth.retrieveToken()}` },
+        headers: { Authorization: `Bearer ${Auth.retrieveRefreshToken()}` },
       });
       if (response.status === 200) {
         Auth.logout();

--- a/src/layout/__tests__/Nav.test.jsx
+++ b/src/layout/__tests__/Nav.test.jsx
@@ -134,11 +134,14 @@ describe('Navigation within header tests', () => {
 
   it('should clear token from session and redirect to sign in page on successful sign out', async () => {
     window.sessionStorage.setItem('token', '123');
+    window.sessionStorage.setItem('refreshToken', '321');
     mockedUserIsPermitted = true;
     const user = userEvent.setup();
     mockAxios
-      .onPost(SIGN_OUT_ENDPOINT)
-      .reply(200);
+      .onPost(SIGN_OUT_ENDPOINT, {})
+      .reply(200, {
+        message: 'Sign out successful',
+      });
 
     render(<MemoryRouter><App /></MemoryRouter>);
     await user.click(screen.getByText('Sign out'));
@@ -149,11 +152,14 @@ describe('Navigation within header tests', () => {
   // Error case will usually be when a user clicks sign out but token is already expired
   it('should clear token from session and redirect to sign in page on sign out', async () => {
     window.sessionStorage.setItem('token', '123');
+    window.sessionStorage.setItem('refreshToken', '321');
     mockedUserIsPermitted = true;
     const user = userEvent.setup();
     mockAxios
-      .onPost(SIGN_OUT_ENDPOINT)
-      .reply(401);
+      .onPost(SIGN_OUT_ENDPOINT, {})
+      .reply(401, {
+        message: 'Sign out unsuccessful',
+      });
 
     render(<MemoryRouter><App /></MemoryRouter>);
     await user.click(screen.getByText('Sign out'));

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -88,7 +88,10 @@ const SignIn = () => {
     setIsLoading(true);
     try {
       const response = await axios.post(SIGN_IN_ENDPOINT, formData);
-      if (response.data.token) { Auth.storeToken(response.data.token); }
+      if (response.data.token) {
+        Auth.storeToken(response.data.token);
+        Auth.storeRefreshToken(response.data.refresh_token);
+      }
       if (state?.redirectURL) {
         navigate(state.redirectURL, { state });
       } else {

--- a/src/pages/SignIn/__tests__/SignIn.test.jsx
+++ b/src/pages/SignIn/__tests__/SignIn.test.jsx
@@ -175,13 +175,14 @@ describe('Sign in tests', () => {
     expect(mockedUseNavigate).toHaveBeenCalledWith(LOGGED_IN_LANDING);
   });
 
-  it('should store token in session storage if sign in is successful', async () => {
+  it('should store token and refresh token in session storage if sign in is successful', async () => {
     const user = userEvent.setup();
 
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
       .reply(200, {
         token: '123',
+        refresh_token: '321',
       });
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
@@ -190,6 +191,7 @@ describe('Sign in tests', () => {
     await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
     await user.click(screen.getByTestId('submit-button'));
     expect(window.sessionStorage.getItem('token')).toEqual('123');
+    expect(window.sessionStorage.getItem('refreshToken')).toEqual('321');
   });
 
   it('should not clear session storage if user is being redirected to sign in before completing their action AND the newly signed in user is the same as the previously signed in one', async () => {

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -3,8 +3,16 @@ class Auth {
     sessionStorage.setItem('token', token);
   }
 
+  static storeRefreshToken(refreshToken) {
+    sessionStorage.setItem('refreshToken', refreshToken);
+  }
+
   static retrieveToken() {
     return sessionStorage.getItem('token');
+  }
+
+  static retrieveRefreshToken() {
+    return sessionStorage.getItem('refreshToken');
   }
 
   static logout() {


### PR DESCRIPTION
# Ticket

NMSW-863

----

## AC

Given I am signed in
When I click the sign out link
Then I am signed out
And I see the sign in page

Given a user clicks the sign out link
Then we post/patch to the sign out end point passing the refresh token
And we clear all session data
And we redirect them to the sign in page

----

## To test

- Run app
- Sign in public account
- Open dev tools -> application
- > You should see a refresh token stored
- Open the network tab in dev tools
- Click sign out
- > You should see a successful call to the sign out endpoint
- > You should be redirected to /sign-in
- Open dev tools -> application
- > You should not see anything stored in session
- Sign in again
- Open dev tools -> application
- Delete your refresh token
- Open the network tab in dev tools
- Click sign out
- > You should see an unsuccessful sign out
- > You should still be redirected to /sign-in and session storage should be empty

----

## Notes
