### PR TITLE
NMSW-870

### DIFF
--- a/src/constants/AppConstants.js
+++ b/src/constants/AppConstants.js
@@ -77,3 +77,12 @@ export const MAX_FILE_SIZE = 4194304;
 export const MAX_FILE_SIZE_DISPLAY = (MAX_FILE_SIZE / (1024 * 1024)).toFixed(0);
 export const MAX_SUPPORTING_FILE_SIZE = 1048576;
 export const MAX_SUPPORTING_FILE_SIZE_DISPLAY = (MAX_SUPPORTING_FILE_SIZE / (1024 * 1024)).toFixed(0);
+
+// User types
+export const USER_TYPE_ADMIN = 'Admin';
+export const USER_TYPE_ADMIN_LABEL = 'Administrator';
+export const USER_TYPE_STANDARD = 'User';
+export const USER_TYPE_STANDARD_LABEL = 'Standard user';
+export const USER_GROUP_INTERNAL_LABEL = 'Internal';
+export const USER_GROUP_EXTERNAL_LABEL = 'External';
+export const INTERNAL_TEAMS = ['Border Force Team'];

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -5,12 +5,14 @@ import DisplayForm from '../../components/Forms/DisplayForm';
 import {
   FIELD_EMAIL,
   FIELD_PASSWORD,
+  INTERNAL_TEAMS,
   SIGN_IN_FORM,
   VALIDATE_EMAIL_ADDRESS,
   VALIDATE_REQUIRED,
 } from '../../constants/AppConstants';
 import {
   SIGN_IN_ENDPOINT,
+  USER_ENDPOINT,
   USER_MUST_UPDATE_PASSWORD,
   USER_NOT_VERIFIED,
   USER_SIGN_IN_DETAILS_INVALID,
@@ -23,6 +25,7 @@ import {
   REQUEST_PASSWORD_RESET_URL,
   SIGN_IN_URL,
   HELP_URL,
+  LANDING_URL,
 } from '../../constants/AppUrlConstants';
 import Auth from '../../utils/Auth';
 import { scrollToTop } from '../../utils/ScrollToElement';
@@ -84,19 +87,56 @@ const SignIn = () => {
     setIsLoading(false);
   };
 
+  const getUserData = async (authData) => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    try {
+      const response = await axios.get(USER_ENDPOINT, {
+        signal,
+        headers: { Authorization: `Bearer ${authData.access_token}` },
+      });
+      const data = await response.data;
+      const isInternal = INTERNAL_TEAMS.includes(data.group.groupType.name); // internal users should not be on this app
+console.log('i', isInternal)
+      if (!isInternal) {
+        console.log('store')
+        Auth.storeUserType(data);
+        Auth.storeToken(authData.access_token);
+        Auth.storeRefreshToken(authData.refresh_token);
+
+        if (state?.redirectURL) {
+          navigate(state.redirectURL, { state });
+        } else {
+          navigate(LANDING_URL);
+        }
+      } else {
+        // if it's an internal user we error the standard invalid user error
+        setErrors('Email and password combination is invalid');
+      }
+    } catch (err) {
+      if (err?.code === 'ERR_CANCELED') {
+        return;
+      }
+      setErrors(err?.response?.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleSubmit = async ({ formData }) => {
     setIsLoading(true);
     try {
       const response = await axios.post(SIGN_IN_ENDPOINT, formData);
-      if (response.data.token) {
-        Auth.storeToken(response.data.token);
-        Auth.storeRefreshToken(response.data.refresh_token);
+      if (response.data.access_token) {
+        getUserData(response.data);
       }
-      if (state?.redirectURL) {
-        navigate(state.redirectURL, { state });
-      } else {
-        navigate(LOGGED_IN_LANDING);
-      }
+      // if (response.data.token) { Auth.storeToken(response.data.token); }
+      // if (state?.redirectURL) {
+      //   navigate(state.redirectURL, { state });
+      // } else {
+      //   navigate(LOGGED_IN_LANDING);
+      // }
     } catch (err) {
       if (err?.response?.data?.message === USER_SIGN_IN_DETAILS_INVALID) {
         setErrors('Email and password combination is invalid');

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -25,7 +25,6 @@ import {
   REQUEST_PASSWORD_RESET_URL,
   SIGN_IN_URL,
   HELP_URL,
-  LANDING_URL,
 } from '../../constants/AppUrlConstants';
 import Auth from '../../utils/Auth';
 import { scrollToTop } from '../../utils/ScrollToElement';
@@ -98,9 +97,8 @@ const SignIn = () => {
       });
       const data = await response.data;
       const isInternal = INTERNAL_TEAMS.includes(data.group.groupType.name); // internal users should not be on this app
-console.log('i', isInternal)
+
       if (!isInternal) {
-        console.log('store')
         Auth.storeUserType(data);
         Auth.storeToken(authData.access_token);
         Auth.storeRefreshToken(authData.refresh_token);
@@ -108,7 +106,7 @@ console.log('i', isInternal)
         if (state?.redirectURL) {
           navigate(state.redirectURL, { state });
         } else {
-          navigate(LANDING_URL);
+          navigate(LOGGED_IN_LANDING);
         }
       } else {
         // if it's an internal user we error the standard invalid user error

--- a/src/pages/SignIn/__tests__/SignIn.test.jsx
+++ b/src/pages/SignIn/__tests__/SignIn.test.jsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import SignIn from '../SignIn';
 import {
   SIGN_IN_ENDPOINT,
+  USER_ENDPOINT,
   USER_MUST_UPDATE_PASSWORD,
   USER_NOT_VERIFIED,
   USER_SIGN_IN_DETAILS_INVALID,
@@ -16,6 +16,9 @@ import {
   LOGGED_IN_LANDING,
   REQUEST_PASSWORD_RESET_URL,
 } from '../../../constants/AppUrlConstants';
+import ExternalUser from './__fixtures__/ExternalUser.fixture';
+import SignInUser from './__fixtures__/SignIn.fixture';
+import SignIn from '../SignIn';
 
 const mockUseLocationState = { state: {} };
 const mockedUseNavigate = jest.fn();
@@ -33,6 +36,14 @@ describe('Sign in tests', () => {
   const mockAxios = new MockAdapter(axios);
 
   beforeEach(() => {
+    mockAxios.reset();
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    mockAxios.reset();
+    window.sessionStorage.clear();
+  });
+  afterAll(() => {
     mockAxios.reset();
     window.sessionStorage.clear();
   });
@@ -160,12 +171,11 @@ describe('Sign in tests', () => {
 
   it('should call the login function on sign in button click if there are no errors', async () => {
     const user = userEvent.setup();
-
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(200, {
-        token: '123',
-      });
+      .reply(200, SignInUser)
+      .onGet(USER_ENDPOINT)
+      .reply(200, ExternalUser);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
 
@@ -177,13 +187,11 @@ describe('Sign in tests', () => {
 
   it('should store token and refresh token in session storage if sign in is successful', async () => {
     const user = userEvent.setup();
-
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(200, {
-        token: '123',
-        refresh_token: '321',
-      });
+      .reply(200, SignInUser)
+      .onGet(USER_ENDPOINT)
+      .reply(200, ExternalUser);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
 
@@ -204,9 +212,9 @@ describe('Sign in tests', () => {
     const expectedStoredData = '{"testField":"Hello Test Field","radioButtonSet":"radioOne"}';
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(200, {
-        token: '123',
-      });
+      .reply(200, SignInUser)
+      .onGet(USER_ENDPOINT)
+      .reply(200, ExternalUser);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
 
@@ -262,9 +270,9 @@ describe('Sign in tests', () => {
     };
     mockAxios
       .onPost(SIGN_IN_ENDPOINT)
-      .reply(200, {
-        token: '123',
-      });
+      .reply(200, SignInUser)
+      .onGet(USER_ENDPOINT)
+      .reply(200, ExternalUser);
 
     render(<MemoryRouter><SignIn /></MemoryRouter>);
 

--- a/src/pages/SignIn/__tests__/__fixtures__/ExternalUser.fixture.js
+++ b/src/pages/SignIn/__tests__/__fixtures__/ExternalUser.fixture.js
@@ -1,0 +1,27 @@
+const ExternalUser = {
+  userId: '123user',
+  email: 'externalUser@emailcom',
+  fullName: 'Bob Externalson',
+  phoneNumber: '(44)123123123',
+  countryCode: 'GBR',
+  verified: true,
+  dateCreated: '2023-02-06T16:21:09.958032',
+  lastUpdated: '2023-07-07T13:28:41.394007',
+  userType: {
+    userTypeId: '0b1e75b6-b3d0-4248-9558-cc91af07317c',
+    name: 'Admin',
+  },
+  group: {
+    groupId: 'de5426f1-c301-4afb-9075-fbdefff1df4b',
+    groupName: 'Bobs Company',
+    website: null,
+    dateCreated: '2023-02-06T16:21:09.633696',
+    typeOfCompany: null,
+    lastUpdated: '2023-07-07T13:28:41.384854',
+    groupType: {
+      groupTypeId: '640b4ff5-35fa-4606-a7d4-0ea44f1f3f21',
+      name: 'Operator',
+    },
+  },
+};
+export default ExternalUser;

--- a/src/pages/SignIn/__tests__/__fixtures__/SignIn.fixture.js
+++ b/src/pages/SignIn/__tests__/__fixtures__/SignIn.fixture.js
@@ -1,0 +1,14 @@
+const mockSignInResponse = {
+  access_token: '123',
+  expires_in: 28800,
+  refresh_expires_in: 32400,
+  refresh_token: '321',
+  token_type: 'Bearer',
+  id_token: '567',
+  'not-before-policy': 0,
+  session_state: 'd6c9ecae-977d-47c8-a8a6-52006f300e7b',
+  scope: 'openid email profile',
+  token: '123',
+};
+
+export default mockSignInResponse;

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -1,3 +1,5 @@
+import { INTERNAL_TEAMS, USER_TYPE_ADMIN } from '../constants/AppConstants';
+
 class Auth {
   static storeToken(token) {
     sessionStorage.setItem('token', token);
@@ -7,6 +9,16 @@ class Auth {
     sessionStorage.setItem('refreshToken', refreshToken);
   }
 
+<<<<<<< HEAD
+=======
+  static storeUserType(user) {
+    sessionStorage.setItem('user', JSON.stringify({
+      admin: user.userType.name === USER_TYPE_ADMIN,
+      internal: INTERNAL_TEAMS.includes(user.group.groupType.name),
+    }));
+  }
+
+>>>>>>> d3a2c1d (Add sign in handler for user type)
   static retrieveToken() {
     return sessionStorage.getItem('token');
   }

--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -9,8 +9,6 @@ class Auth {
     sessionStorage.setItem('refreshToken', refreshToken);
   }
 
-<<<<<<< HEAD
-=======
   static storeUserType(user) {
     sessionStorage.setItem('user', JSON.stringify({
       admin: user.userType.name === USER_TYPE_ADMIN,
@@ -18,7 +16,6 @@ class Auth {
     }));
   }
 
->>>>>>> d3a2c1d (Add sign in handler for user type)
   static retrieveToken() {
     return sessionStorage.getItem('token');
   }


### PR DESCRIPTION
# Ticket



----

## AC

Given the user has attempted to sign in to the external app
When the api returns a successful sign in response
Then the FE checks if the user is allowed to view the external app

Given the user is allowed to view the external app
Then they are shown the logged in landing page (dashboard)

Given the user is NOT allowed to view the external app
Then the sign in page normal username/password error is shown

----

## To test

- sign in with external user
- > you should be taken to landing page
- sign in with internal admin
- > you should see username/password error
- sign in with internal standard user
- > you should see username/password error

----

## Notes
