### PR TITLE
Update FE mapping for user not verified error

### DIFF
--- a/src/constants/AppAPIConstants.js
+++ b/src/constants/AppAPIConstants.js
@@ -38,6 +38,7 @@ export const USER_ALREADY_REGISTERED = 'User is already registered';
 export const USER_ALREADY_VERIFIED = 'User already verified, please login';
 export const USER_AWAITING_VERIFICATION = 'User is awaiting verification';
 export const USER_NOT_REGISTERED = 'User is not registered';
+export const USER_HAS_NOT_BEEN_VERIFIED = 'User has not been verified yet';
 export const USER_NOT_VERIFIED = 'User not verified, please verify registration';
 export const USER_SIGN_IN_DETAILS_INVALID = 'Email or password invalid';
 export const USER_MUST_UPDATE_PASSWORD = 'To use this service you will need to create a new password';

--- a/src/pages/SignIn/RequestPasswordReset.jsx
+++ b/src/pages/SignIn/RequestPasswordReset.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { PASSSWORD_RESET_ENDPOINT } from '../../constants/AppAPIConstants';
+import { PASSSWORD_RESET_ENDPOINT, USER_HAS_NOT_BEEN_VERIFIED } from '../../constants/AppAPIConstants';
 import {
   FIELD_EMAIL,
   SINGLE_PAGE_FORM,
@@ -66,8 +66,7 @@ const RequestPasswordReset = () => {
       }
     } catch (err) {
       // This error indicates user registered email address but didn't activate account yet
-      // Ticket in backlog to improve response from API but for now we will use this
-      if (err.response?.data?.message[0]?.message === 'Missing personalisation: user') {
+      if (err.response?.data?.message === USER_HAS_NOT_BEEN_VERIFIED) {
         setIsNotActivated(true);
       } else if (err.response.status === 401) {
         // 401 is invalid email address but we don't message that to the user so we show them the same confirmation page

--- a/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
+++ b/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import RequestPasswordReset from '../RequestPasswordReset';
-import { PASSSWORD_RESET_ENDPOINT } from '../../../constants/AppAPIConstants';
+import { PASSSWORD_RESET_ENDPOINT, USER_HAS_NOT_BEEN_VERIFIED } from '../../../constants/AppAPIConstants';
 import { MESSAGE_URL, REQUEST_PASSWORD_RESET_CONFIRMATION_URL, REQUEST_PASSWORD_RESET_URL } from '../../../constants/AppUrlConstants';
 
 let mockUseLocationState = {};
@@ -142,13 +142,8 @@ describe('Request password reset tests', () => {
     const user = userEvent.setup();
     mockAxios
       .onPost(PASSSWORD_RESET_ENDPOINT, { email: 'test@test.com' })
-      .reply(400, {
-        message: [
-          {
-            error: 'BadRequestError',
-            message: 'Missing personalisation: user',
-          },
-        ],
+      .reply(401, {
+        message: USER_HAS_NOT_BEEN_VERIFIED,
       });
 
     render(<MemoryRouter><RequestPasswordReset /></MemoryRouter>);


### PR DESCRIPTION
# Ticket

NMSW-997

----

## AC

Unlike NMSW-internal when try to click forgotten email link and enter an unverified email address, we are not taking user to email address has not been verified page. Instead we directly redirect them to check your email page.

This is because the BE response for an email that has not been verified as been updated. Therefore we need to update the FE mapping to match what is returned from the BE


----

## To test

- Run app
- Create an account that is registered but not verified (do not complete registration process)
- Click on forgotten your passowrd
- Enter the email of the unverified email
- > You should be taken to the email is not verified page

----

## Notes

- If you click on the send confirmation email click on the email not verified page no invitation will be resent - this is because we direct to the Request a new verification link where the user can change where the email will be sent. This will be looked at in NMSW-995 and flow will be updated for this scenario