### PR TITLE
NMSW-995 Update the user registered but not verified flow for sign in and forgotten password routes

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -26,6 +26,7 @@ import {
   REGISTER_EMAIL_VERIFIED_URL,
   REGISTER_DETAILS_URL,
   REGISTER_PASSWORD_URL,
+  RESEND_EMAIL_USER_NOT_VERIFIED,
   REQUEST_PASSWORD_RESET_URL,
   REQUEST_PASSWORD_RESET_CONFIRMATION_URL,
   REQUEST_PASSWORD_RESET_RESEND_URL,
@@ -66,6 +67,7 @@ const RegisterEmailResend = lazy(() => import('./pages/Register/RegisterEmailRes
 const RegisterEmailVerified = lazy(() => import('./pages/Register/RegisterEmailVerified'));
 const RegisterYourDetails = lazy(() => import('./pages/Register/RegisterYourDetails'));
 const RegisterYourPassword = lazy(() => import('./pages/Register/RegisterYourPassword'));
+const ResendEmailUserNotVerified = lazy(() => import('./pages/Register/ResendEmailUserNotVerified'));
 const RequestPasswordReset = lazy(() => import('./pages/SignIn/RequestPasswordReset'));
 const RequestPasswordResetConfirmation = lazy(() => import('./pages/SignIn/RequestPasswordResetConfirmation'));
 const ResendRequestPasswordReset = lazy(() => import('./pages/SignIn/ResendRequestPasswordReset'));
@@ -116,6 +118,7 @@ const AppRouter = ({ setIsCookieBannerShown }) => {
           <Route path={REGISTER_EMAIL_VERIFIED_URL} element={<RegisterEmailVerified />} />
           <Route path={REGISTER_DETAILS_URL} element={<RegisterYourDetails />} />
           <Route path={REGISTER_PASSWORD_URL} element={<RegisterYourPassword />} />
+          <Route path={RESEND_EMAIL_USER_NOT_VERIFIED} element={<ResendEmailUserNotVerified />} />
           <Route path={REQUEST_PASSWORD_RESET_URL} element={<RequestPasswordReset />} />
           <Route path={REQUEST_PASSWORD_RESET_CONFIRMATION_URL} element={<RequestPasswordResetConfirmation />} />
           <Route path={REQUEST_PASSWORD_RESET_RESEND_URL} element={<ResendRequestPasswordReset />} />

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -13,6 +13,7 @@ export const REGISTER_EMAIL_RESEND_URL = '/create-account/request-new-verificati
 export const REGISTER_EMAIL_VERIFIED_URL = '/activate-account';
 export const REGISTER_DETAILS_URL = '/create-account/your-details';
 export const REGISTER_PASSWORD_URL = '/create-account/your-password';
+export const RESEND_EMAIL_USER_NOT_VERIFIED = '/resend-verfication-email';
 export const REQUEST_PASSWORD_RESET_URL = '/forgotten-password';
 export const REQUEST_PASSWORD_RESET_CONFIRMATION_URL = '/forgotten-password/check-your-email';
 export const REQUEST_PASSWORD_RESET_RESEND_URL = '/forgotten-password/request-new-link';

--- a/src/pages/Register/ResendEmailUserNotVerified.jsx
+++ b/src/pages/Register/ResendEmailUserNotVerified.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT } from '../../constants/AppAPIConstants';
+import {
+  MESSAGE_URL,
+  REGISTER_EMAIL_CHECK_URL,
+  REGISTER_EMAIL_RESEND_URL,
+} from '../../constants/AppUrlConstants';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+const ResendEmailUserNotVerified = () => {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const emailAddress = state?.emailAddress;
+  document.title = 'Resend invitation';
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    try {
+      const controller = new AbortController();
+      const response = await axios.post(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT, {
+        email: emailAddress,
+      }, {
+        signal: controller.signal,
+      });
+
+      if (response.status === 204) {
+        navigate(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress } } });
+      }
+    } catch (err) {
+      if (err?.code === 'ERR_CANCELED') {
+        return;
+      }
+      navigate(MESSAGE_URL, { state: { title: 'Something has gone wrong', message: err.response?.data?.message, redirectURL: state?.redirectURL } });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!emailAddress) {
+      navigate(REGISTER_EMAIL_RESEND_URL);
+    }
+  }, [emailAddress, navigate]);
+
+  if (isLoading) {
+    return (<LoadingSpinner />);
+  }
+
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-full">
+        <h1 className="govuk-heading-xl">Email address not verified</h1>
+        <p className="govuk-body">We can send you a verification link so you can continue creating your account.</p>
+        <button
+          className="govuk-button"
+          type="button"
+          onClick={handleSubmit}
+        >
+          Resend verification email
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ResendEmailUserNotVerified;

--- a/src/pages/Register/ResendEmailUserNotVerified.jsx
+++ b/src/pages/Register/ResendEmailUserNotVerified.jsx
@@ -41,7 +41,7 @@ const ResendEmailUserNotVerified = () => {
 
   useEffect(() => {
     if (!emailAddress) {
-      navigate(REGISTER_EMAIL_RESEND_URL);
+      navigate(REGISTER_EMAIL_RESEND_URL, { replace: true });
     }
   }, [emailAddress, navigate]);
 

--- a/src/pages/Register/__tests__/ResendEmailUserNotVerified.test.jsx
+++ b/src/pages/Register/__tests__/ResendEmailUserNotVerified.test.jsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {
+  REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT,
+} from '../../../constants/AppAPIConstants';
+import {
+  MESSAGE_URL,
+  REGISTER_EMAIL_CHECK_URL,
+  REGISTER_EMAIL_RESEND_URL,
+  SIGN_IN_URL,
+} from '../../../constants/AppUrlConstants';
+import ResendEmailUserNotVerified from '../ResendEmailUserNotVerified';
+
+let mockUseLocationState = { state: {} };
+const mockedUseNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockedUseNavigate,
+  useLocation: jest.fn().mockImplementation(() => mockUseLocationState),
+}));
+
+describe('Resend email when user not verified tests', () => {
+  const mockAxios = new MockAdapter(axios);
+  const scrollIntoViewMock = jest.fn();
+  window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+  beforeEach(() => {
+    mockAxios.reset();
+    mockUseLocationState = { state: { emailAddress: 'test@email.com' } };
+    window.sessionStorage.clear();
+  });
+
+  afterAll(() => {
+    mockAxios.reset();
+    mockUseLocationState = {};
+    window.sessionStorage.clear();
+  });
+
+  it('should redirect to resend verifiecation link page if email is missing from state', async () => {
+    mockUseLocationState = { state: {} };
+    render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
+    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL);
+  });
+
+  it('should NOT redirect to error page if email is in state', async () => {
+    render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
+    await screen.findByRole('heading', { name: 'Email address not verified' });
+    expect(mockedUseNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should render h1, message and resend button', async () => {
+    mockUseLocationState = { state: { email: 'test@email.com', redirectURL: SIGN_IN_URL } };
+    render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
+    expect(screen.getByRole('heading', { name: 'Email address not verified' })).toBeInTheDocument();
+    expect(screen.getByText('We can send you a verification link so you can continue creating your account.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resend verification email' })).toBeInTheDocument();
+  });
+
+  it('should navigate to check your email page if successful POST response', async () => {
+    const user = userEvent.setup();
+    mockAxios
+      .onPost(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT, {
+        email: 'test@email.com',
+      })
+      .reply(204);
+
+    render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Resend verification email' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_CHECK_URL, { state: { dataToSubmit: { emailAddress: 'test@email.com' } } });
+  });
+
+  it('should navigate to message page if API returns a 500', async () => {
+    const user = userEvent.setup();
+    mockUseLocationState = { state: { email: 'test@email.com', redirectURL: SIGN_IN_URL } };
+    mockAxios
+      .onPost(REGISTER_RESEND_VERIFICATION_EMAIL_ENDPOINT, {
+        email: 'test@email.com',
+      })
+      .reply(500);
+
+    render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
+    await user.click(screen.getByRole('button', { name: 'Resend verification email' }));
+    expect(mockedUseNavigate).toHaveBeenCalledWith(MESSAGE_URL, {
+      state: {
+        title: 'Something has gone wrong',
+        redirectURL: SIGN_IN_URL,
+      },
+    });
+  });
+});

--- a/src/pages/Register/__tests__/ResendEmailUserNotVerified.test.jsx
+++ b/src/pages/Register/__tests__/ResendEmailUserNotVerified.test.jsx
@@ -40,10 +40,10 @@ describe('Resend email when user not verified tests', () => {
     window.sessionStorage.clear();
   });
 
-  it('should redirect to resend verifiecation link page if email is missing from state', async () => {
+  it('should redirect to resend verification link page if email is missing from state', async () => {
     mockUseLocationState = { state: {} };
     render(<MemoryRouter><ResendEmailUserNotVerified /></MemoryRouter>);
-    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL);
+    expect(mockedUseNavigate).toHaveBeenCalledWith(REGISTER_EMAIL_RESEND_URL, { replace: true });
   });
 
   it('should NOT redirect to error page if email is in state', async () => {

--- a/src/pages/SignIn/RequestPasswordReset.jsx
+++ b/src/pages/SignIn/RequestPasswordReset.jsx
@@ -10,12 +10,11 @@ import {
 } from '../../constants/AppConstants';
 import {
   MESSAGE_URL,
-  REGISTER_EMAIL_RESEND_URL,
   REQUEST_PASSWORD_RESET_CONFIRMATION_URL,
   REQUEST_PASSWORD_RESET_URL,
+  RESEND_EMAIL_USER_NOT_VERIFIED,
 } from '../../constants/AppUrlConstants';
 import DisplayForm from '../../components/Forms/DisplayForm';
-import Message from '../../components/Message';
 
 const SupportingText = () => (
   <div>
@@ -27,7 +26,6 @@ const RequestPasswordReset = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const [isLoading, setIsLoading] = useState(false);
-  const [isNotActivated, setIsNotActivated] = useState(false);
   document.title = 'Forgot password';
 
   const formActions = {
@@ -67,7 +65,12 @@ const RequestPasswordReset = () => {
     } catch (err) {
       // This error indicates user registered email address but didn't activate account yet
       if (err.response?.data?.message === USER_HAS_NOT_BEEN_VERIFIED) {
-        setIsNotActivated(true);
+        navigate(RESEND_EMAIL_USER_NOT_VERIFIED, {
+          state: {
+            emailAddress: emailToSendTo,
+            redirectURL: REQUEST_PASSWORD_RESET_URL,
+          },
+        });
       } else if (err.response.status === 401) {
         // 401 is invalid email address but we don't message that to the user so we show them the same confirmation page
         navigate(REQUEST_PASSWORD_RESET_CONFIRMATION_URL, { state: { dataToSubmit: { emailAddress: emailToSendTo } } });
@@ -83,20 +86,6 @@ const RequestPasswordReset = () => {
     setIsLoading(true);
     requestPasswordResetEmail({ emailToSendTo: formData.formData.emailAddress });
   };
-
-  if (isNotActivated) {
-    const buttonProps = {
-      buttonLabel: 'Send confirmation email',
-      buttonNavigateTo: REGISTER_EMAIL_RESEND_URL,
-    };
-    return (
-      <Message
-        button={buttonProps}
-        title="Email address not verified"
-        message="We can send you a verification link so you can continue creating your account."
-      />
-    );
-  }
 
   return (
     <DisplayForm

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -23,12 +23,11 @@ import {
   LOGGED_IN_LANDING,
   MESSAGE_URL,
   // REGISTER_ACCOUNT_URL,
-  REGISTER_EMAIL_RESEND_URL,
   REQUEST_PASSWORD_RESET_URL,
   SIGN_IN_URL,
   HELP_URL,
+  RESEND_EMAIL_USER_NOT_VERIFIED,
 } from '../../constants/AppUrlConstants';
-import Message from '../../components/Message';
 import Auth from '../../utils/Auth';
 import ParseJwtForUserType from '../../utils/ParseJwtForUserType';
 import { scrollToTop } from '../../utils/ScrollToElement';
@@ -46,7 +45,6 @@ const SignIn = () => {
   const { state } = useLocation();
   const [errors, setErrors] = useState();
   const [isLoading, setIsLoading] = useState(false);
-  const [isNotActivated, setIsNotActivated] = useState(false);
   document.title = 'Sign in';
 
   // Form fields
@@ -152,7 +150,12 @@ const SignIn = () => {
         setErrors('Email and password combination is invalid');
         scrollToTop();
       } else if (err?.response?.data?.message === USER_NOT_VERIFIED) {
-        setIsNotActivated(true);
+        navigate(RESEND_EMAIL_USER_NOT_VERIFIED, {
+          state: {
+            emailAddress: formData.email,
+            redirectURL: SIGN_IN_URL,
+          },
+        });
         scrollToTop();
       } else if (err?.response?.data?.message === USER_MUST_UPDATE_PASSWORD) {
         navigate(MESSAGE_URL, {
@@ -172,20 +175,6 @@ const SignIn = () => {
       setIsLoading(false);
     }
   };
-
-  if (isNotActivated) {
-    const buttonProps = {
-      buttonLabel: 'Send confirmation email',
-      buttonNavigateTo: REGISTER_EMAIL_RESEND_URL,
-    };
-    return (
-      <Message
-        button={buttonProps}
-        title="Email address not verified"
-        message="We can send you a verification link so you can continue creating your account."
-      />
-    );
-  }
 
   return (
     <>

--- a/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
+++ b/src/pages/SignIn/__tests__/RequestPasswordReset.test.jsx
@@ -5,7 +5,9 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import RequestPasswordReset from '../RequestPasswordReset';
 import { PASSSWORD_RESET_ENDPOINT, USER_HAS_NOT_BEEN_VERIFIED } from '../../../constants/AppAPIConstants';
-import { MESSAGE_URL, REQUEST_PASSWORD_RESET_CONFIRMATION_URL, REQUEST_PASSWORD_RESET_URL } from '../../../constants/AppUrlConstants';
+import {
+  MESSAGE_URL, REQUEST_PASSWORD_RESET_CONFIRMATION_URL, REQUEST_PASSWORD_RESET_URL, RESEND_EMAIL_USER_NOT_VERIFIED,
+} from '../../../constants/AppUrlConstants';
 
 let mockUseLocationState = {};
 
@@ -149,11 +151,12 @@ describe('Request password reset tests', () => {
     render(<MemoryRouter><RequestPasswordReset /></MemoryRouter>);
     await user.type(screen.getByRole('textbox', { name: 'Email address' }), 'test@test.com');
     await user.click(screen.getByTestId('submit-button'));
-    screen.findByRole('heading', { name: 'Email address not verified' });
-    expect(screen.getByRole('heading', { name: 'Email address not verified' })).toBeInTheDocument();
-    expect(screen.getByText('We can send you a verification link so you can continue creating your account.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send confirmation email' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Send confirmation email</button>');
+    expect(mockedUseNavigate).toHaveBeenCalledWith(RESEND_EMAIL_USER_NOT_VERIFIED, {
+      state: {
+        emailAddress: 'test@test.com',
+        redirectURL: REQUEST_PASSWORD_RESET_URL,
+      },
+    });
   });
 
   it('should navigate to message page if other error POST response', async () => {

--- a/src/pages/SignIn/__tests__/SignIn.test.jsx
+++ b/src/pages/SignIn/__tests__/SignIn.test.jsx
@@ -15,6 +15,7 @@ import {
   SIGN_IN_URL,
   LOGGED_IN_LANDING,
   REQUEST_PASSWORD_RESET_URL,
+  RESEND_EMAIL_USER_NOT_VERIFIED,
 } from '../../../constants/AppUrlConstants';
 import mockExternalUser from './__fixtures__/ExternalUser.fixture copy';
 import mockInternalAdminUser from './__fixtures__/InternalAdminUser.fixture';
@@ -450,11 +451,12 @@ describe('Sign in tests', () => {
     await user.type(screen.getByRole('textbox', { name: /email/i }), 'testemail@email.com');
     await user.type(screen.getByTestId('password-passwordField'), 'testpassword');
     await user.click(screen.getByTestId('submit-button'));
-    screen.findByRole('heading', { name: 'Email address not verified' });
-    expect(screen.getByRole('heading', { name: 'Email address not verified' })).toBeInTheDocument();
-    expect(screen.getByText('We can send you a verification link so you can continue creating your account.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send confirmation email' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send confirmation email' }).outerHTML).toEqual('<button class="govuk-button" data-module="govuk-button" type="button">Send confirmation email</button>');
+    expect(mockedUseNavigate).toHaveBeenCalledWith(RESEND_EMAIL_USER_NOT_VERIFIED, {
+      state: {
+        emailAddress: 'testemail@email.com',
+        redirectURL: SIGN_IN_URL,
+      },
+    });
   });
 
   it('should redirect to message page with password reset instructions if user account needs to be updated', async () => {


### PR DESCRIPTION
# Ticket

NMSW-995

----

## AC

Update the flow for when a user is registered but not verified in the sign in and forgotten password routes

Currently the flow goes: click forgot password -> user not verified page -> click 'send confirmation email' -> resend invitation page -> fill in email address -> click request a new link -> resend invite -> check you email page

To be changed to: click forgot password -> user not verified page -> click 'send verification email' -> check your email page

This makes the flow easier to understand and makes for better UX

----

## To test

Scenario 1: Sign in route
- Run app
- Register an email but do not verify it
- Try to sign in with the unverified email
- > You should see a user not verified page
- Click on Send verification email
- > You should receive a new verification email and be taken to the check your answer page

Scenario 2: Forgotten password route
- Run app
- Click in Forgotten your password?
- Enter the unverified email 
- > You should see a user not verified page
- Click on Send verification email
- > You should receive a new verification email and be taken to the check your answer page

Scenario 3: User tries to access /resend-verfication-email when no email in state
- Run app
- Try to go to /resend-verfication-email
- You should be redirected to /create-account/request-new-verification-link

----

## Notes
