### PR TITLE
Change env name for mailslurp Api Key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -407,7 +407,7 @@ steps:
   image: cypress/included:latest
   environment:
     CYPRESS_MAIL_API_KEY:
-      from_secret: DEV_NMSW_MAILSLURP_API_KEY
+      from_secret: CYPRESS_MAIL_API_KEY
   commands:
   - ./extract-env-vars.sh ./helm/dev.yaml cypress-env.sh
   - cat ./cypress-env.sh

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -40,7 +40,7 @@ async function setupNodeEvents(on, config) {
   downloadFile
       }
   );
-  config.env.MAIL_API_KEY = process.env.DEV_NMSW_MAILSLURP_API_KEY;
+  config.env.MAIL_API_KEY = process.env.CYPRESS_MAIL_API_KEY;
   // Make sure to return the config object as it might have been modified by the plugin.
   return config;
 }


### PR DESCRIPTION
Changed env name for mailslurp Api Key


## To test
To Run E2E tests
```
npm run cypress:run:staging
```
