### PR TITLE
NMSW-1372 Update identity documents url and bump version

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for the NMSW UI
 type: application
 version: 0.1.0
 # Use appVersion to set the image tag i.e. nmsw-service:{appVersion}
-appVersion: 1.0.8
+appVersion: 1.0.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nmsw-ui",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nmsw-ui",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nmsw-ui",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "National Maritime Single Window",
   "main": "index.js",
   "scripts": {

--- a/src/constants/AppUrlConstants.js
+++ b/src/constants/AppUrlConstants.js
@@ -1,7 +1,7 @@
 // External links
 export const CROWN_COPYRIGHT_URL = 'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/';
 export const ETA_GUIDANCE_ON_GOVUK_URL = 'https://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta';
-export const EXAMINING_IDENTITY_DOCS_URL = 'https://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta';
+export const EXAMINING_IDENTITY_DOCS_URL = 'https://www.gov.uk/government/publications/recognising-fraudulent-identity-documents/guidance-on-examining-identity-documents-accessible';
 export const FEEDBACK_URL = 'https://www.homeofficesurveys.homeoffice.gov.uk/s/6MBWPJ/';
 export const GOV_URL = 'https://www.gov.uk/';
 export const NATIONALITIES_REQ_CLEARANCE_URL = 'https://www.gov.uk/guidance/immigration-rules/immigration-rules-appendix-visitor-visa-national-list';


### PR DESCRIPTION
# Ticket



----

## AC

Update the URL for examining identity documents

----

## To test

URL should now link to https://www.gov.uk/government/publications/recognising-fraudulent-identity-documents/guidance-on-examining-identity-documents-accessible

----

## Notes
